### PR TITLE
Rename BuildkiteAgentsPerInstance to AgentsPerInstance

### DIFF
--- a/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
+++ b/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-# Expose BUILDKITE_AGENTS_PER_INSTANCE
+# Import BUILDKITE_AGENTS_PER_INSTANCE
 eval "$(cat /var/lib/buildkite-agent/cfn-env)"
 
 echo "Stopping buildkite-agent gracefully"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -25,7 +25,7 @@ Metadata:
         Parameters:
         - ImageId
         - InstanceType
-        - BuildkiteAgentsPerInstance
+        - AgentsPerInstance
         - KeyName
         - SpotPrice
         - SecretsBucket
@@ -77,7 +77,7 @@ Parameters:
     Default: elastic
     MinLength: 1
 
-  BuildkiteAgentsPerInstance:
+  AgentsPerInstance:
     Description: Number of Buildkite agents to run on each instance
     Type: Number
     Default: 1
@@ -320,7 +320,7 @@ Resources:
                 cat << EOF > /var/lib/buildkite-agent/cfn-env
                 BUILDKITE_STACK_NAME=$(AWS::StackName)
                 BUILDKITE_SECRETS_BUCKET=$(SecretsBucket)
-                BUILDKITE_AGENTS_PER_INSTANCE=$(BuildkiteAgentsPerInstance)
+                BUILDKITE_AGENTS_PER_INSTANCE=$(AgentsPerInstance)
                 EOF
 
                 chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
@@ -374,7 +374,7 @@ Resources:
 
                 mkdir -p /var/awslogs/etc/config/
 
-                for i in \$(seq 1 $(BuildkiteAgentsPerInstance)); do
+                for i in \$(seq 1 $(AgentsPerInstance)); do
                   touch /var/log/buildkite-agent-\${i}.log
 
                   cat << EOF > /var/awslogs/etc/config/buildkite-agent-\${i}
@@ -390,7 +390,7 @@ Resources:
 
                 # Setup and start services
 
-                for i in \$(seq 1 $(BuildkiteAgentsPerInstance)); do
+                for i in \$(seq 1 $(AgentsPerInstance)); do
                   cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-\${i}
                   service buildkite-agent-\${i} start
                   chkconfig --add buildkite-agent-\${i}


### PR DESCRIPTION
@joffotron when auditing the param descriptions and grouping I realised we named this incorrectly to start with.

This renames it to `AgentsPerInstance` (and it now lives down in the instance config)