### PR TITLE
Use UnfinishedJobs not BusyAgentCount

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -36,7 +36,7 @@ Resources:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
       Namespace: Buildkite
-      Statistic: Average
+      Statistic: Maximum
       Period: 60
       EvaluationPeriods: 1
       Threshold: 0
@@ -49,12 +49,12 @@ Resources:
   AgentUtilizationAlarmLow:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-down if BusyAgentCount == 0 for the last 6 minutes, every 2 minutes
-      MetricName: BusyAgentCount
+      AlarmDescription: Scale-down if UnfinishedJobs == 0 for 15 minutes
+      MetricName: UnfinishedJobsCount
       Namespace: Buildkite
       Statistic: Maximum
-      Period: 120
-      EvaluationPeriods: 3
+      Period: 900
+      EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:


### PR DESCRIPTION
I've been trying to track down why we were getting scale down events whilst we still had running jobs, and it turns out the `BusyAgentCount` metric lags behind the jobs metrics quite a bit.

<img width="339" alt="metrics" src="https://cloud.githubusercontent.com/assets/153/16758411/a6ec73ba-4854-11e6-9c1b-4913f35018bb.png">

Recent updates the [metrics collector](https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher) and [metrics stack](buildkite/buildkite-metrics#3) means we now have an `UnfinishedJobsCount` metric we can use to represent if there's any jobs being currently worked on.

This PR updates the scaledown so it's based on this new `UnfinishedJobsCount ` metric.