### PR TITLE
Fix buildkite-agent starting before cloud-init has run

### DIFF
--- a/packer/conf/buildkite-agent/init.d/buildkite-agent
+++ b/packer/conf/buildkite-agent/init.d/buildkite-agent
@@ -1,15 +1,18 @@
 #!/bin/sh
 #
+# chkconfig: 345 95 95
+# description:      Buildkite Agent
+
 ### BEGIN INIT INFO
-# Provides:          buildkite-agent
-# Required-Start:    $network $local_fs $remote_fs
+# Provides:          buildkite-agent-%n
+# Required-Start:    $network $local_fs $remote_fs cloud-init docker
 # Required-Stop:     $remote_fs
 # Should-Start:      $named
 # Should-Stop:
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: The Buildkite Build Agent
-# Description:       The Buildkite Build Agent
+# Default-Start:     3 4 5
+# Default-Stop:      0 1 2 6
+# Short-Description: Start/stop the buildkite-agent
+# Description:       Buildkite Agent
 ### END INIT INFO
 
 user="buildkite-agent"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -370,7 +370,7 @@ Resources:
 
                 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
-                # Setup logging first so we capture everything
+                # Setup awslogs
 
                 for i in \$(seq 1 $(AgentsPerInstance)); do
                   touch /var/log/buildkite-agent-\${i}.log
@@ -384,14 +384,12 @@ Resources:
                 EOF
                 done
 
-                service awslogs restart
-
-                # Setup and start services
+                # Setup the agent services
 
                 for i in \$(seq 1 $(AgentsPerInstance)); do
-                  cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-\${i}
-                  service buildkite-agent-\${i} start
+                  cat /etc/buildkite-agent/init.d.tmpl | sed "s/buildkite-agent-%n/buildkite-agent-\${i}/g" > /etc/init.d/buildkite-agent-\${i}
                   chkconfig --add buildkite-agent-\${i}
+                  chkconfig --level 345 buildkite-agent-\${i} on
                 done
 
             03-fetch-authorized-users:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -388,6 +388,7 @@ Resources:
 
                 for i in \$(seq 1 $(AgentsPerInstance)); do
                   cat /etc/buildkite-agent/init.d.tmpl | sed "s/buildkite-agent-%n/buildkite-agent-\${i}/g" > /etc/init.d/buildkite-agent-\${i}
+                  chmod 755 /etc/init.d/buildkite-agent-\${i}
                   chkconfig --add buildkite-agent-\${i}
                   chkconfig --level 345 buildkite-agent-\${i} on
                 done


### PR DESCRIPTION
This updates the cloud-init to not actually start the buildkite agent services, but let the rc change do it, so they don't start accepting jobs before they're ready.