### PR TITLE
Fix the lifecycled hook from instantly returning

### DIFF
--- a/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
+++ b/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
@@ -11,9 +11,9 @@ for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
   service "buildkite-agent-${i}" stop &
 done
 
-until pgrep buildkite-agent > /dev/null; do
+while pgrep buildkite-agent > /dev/null; do
   echo "Waiting for buildkite-agent processes to finish..."
-  sleep 0.5
+  sleep 5
 done
 
 echo "buildkite-agent stopped"


### PR DESCRIPTION
In #76 we introduced a bug where the lifecycled hook would instantly return, even if the buildkite-agent process had not finished gracefully shutting down. This caused the scale in event to continue, shutting down the machine mid-build… causing failing build jobs, and strange errors such as `could not connect to Docker host`

This fixes it by changing `until` to `while`.

Our tests unfortunately don't cover the the scale-in lifecycled hook.

Fixes #91