### PR TITLE
Don't start docker in packer but in cloud init

### DIFF
--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -10,9 +10,6 @@ sudo usermod -a -G docker ec2-user
 sudo rm -rf /var/lib/docker/
 sudo cp /tmp/conf/docker/docker.conf /etc/sysconfig/docker
 
-sudo service docker start || ( cat /var/log/docker && false )
-sudo docker info
-
 echo "Downloading docker-compose..."
 sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/1.7.1/docker-compose-Linux-x86_64
 sudo chmod +x /usr/bin/docker-compose

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -341,16 +341,13 @@ Resources:
               command: |
                 #!/bin/bash -eu
 
-                # Sometimes Docker can be unreponsive
+                # Sometimes Docker can be unreponsive:
                 # https://github.com/docker/docker/issues/23131
                 # https://github.com/buildkite/elastic-ci-stack-for-aws/issues/86
                 #
-                # As a workaround we'll restart the docker daemon before starting the buildkite-agent
-                service docker restart
-
-                # We'll also verify that docker commands work. If this fails, cloud-init will fail and
-                # the machine won't be marked as healthy
-                docker info
+                # As a workaround we start the docker daemon, wait 10 seconds, and verify
+                service docker start || ( cat /var/log/docker && false )
+                sleep 10 && docker info
             03-install-buildkite:
               command: |
                 #!/bin/bash -eu


### PR DESCRIPTION
It appears #94 seems to have just made it worse. This removes the docker start from the packer image, only starts it on cloud init, and waits 10 seconds before trying to use the daemon