### PR TITLE
Increase scale in to 30 minutes

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown: 300
+      Cooldown: 120
       ScalingAdjustment : $(ScaleUpAdjustment)
 
   AgentScaleDownPolicy:

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -49,12 +49,12 @@ Resources:
   AgentUtilizationAlarmLow:
    Type: AWS::CloudWatch::Alarm
    Properties:
-      AlarmDescription: Scale-down if UnfinishedJobs == 0 for 15 minutes
+      AlarmDescription: Scale-down if UnfinishedJobs == 0 for 30 minutes
       MetricName: UnfinishedJobsCount
       Namespace: Buildkite
       Statistic: Maximum
-      Period: 900
-      EvaluationPeriods: 1
+      Period: 300
+      EvaluationPeriods: 6
       Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -142,7 +142,7 @@ Parameters:
     MinValue: 0
 
   ScaleDownAdjustment:
-    Description: The number of agents to remove on each scale down event (UnfinishedJobs == 0 for 15 mins)
+    Description: The number of agents to remove on each scale down event (UnfinishedJobs == 0 for 30 mins)
     Type: Number
     Default: -1
     MaxValue: 0


### PR DESCRIPTION
Given instances are min 1 hour billing, and cycling agents during the middle of the day can be a bit of PITA for developers, increasing it to 30 minutes of inactivity is a bit more friendly.

Also there's no need to wait 5 full minutes from the scale in finishing to do the next scale in event, agents should pick up work almost before they're fully marked as in service.