### PR TITLE
Have the lifecycled handler script look for just the build agent it is trying to shut down.

### DIFF
--- a/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
+++ b/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
@@ -11,7 +11,7 @@ for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
   service "buildkite-agent-${i}" stop &
 
   # Need to ensure it's the buildkite-agent user, so it doesn't match this lifecycld handler script
-  while pgrep -u buildkite-agent buildkite-agent > /dev/null; do
+  while pgrep -u buildkite-agent buildkite-agent-${i} > /dev/null; do
     echo "Waiting for service buildkite-agent-${i} to have stopped..."
     sleep 5
   done

--- a/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
+++ b/packer/conf/buildkite-agent/scripts/buildkite-agent-lifecycled-handler
@@ -11,7 +11,7 @@ for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
   service "buildkite-agent-${i}" stop &
 
   # Need to ensure it's the buildkite-agent user, so it doesn't match this lifecycld handler script
-  while pgrep -u buildkite-agent buildkite-agent-${i} > /dev/null; do
+  while pgrep -u buildkite-agent "buildkite-agent-${i}" > /dev/null; do
     echo "Waiting for service buildkite-agent-${i} to have stopped..."
     sleep 5
   done


### PR DESCRIPTION
Otherwise, it gets stuck as other agents are still running, and matching
the pgrep

![terminate failing](https://cloud.githubusercontent.com/assets/336405/17090491/60c5100c-5274-11e6-9b66-aa1953c29c55.png)
