### PR TITLE
Name tags for instances

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -495,6 +495,9 @@ Resources:
         - Key: Role
           Value: buildkite-agent
           PropagateAtLaunch: true
+        - Key: Name
+          Value: buildkite-agent-$(BuildkiteAgentRelease)-$(BuildkiteQueue)
+          PropagateAtLaunch: true
 
     CreationPolicy:
       ResourceSignal:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -496,7 +496,13 @@ Resources:
           Value: buildkite-agent
           PropagateAtLaunch: true
         - Key: Name
-          Value: buildkite-agent-$(BuildkiteAgentRelease)-$(BuildkiteQueue)
+          Value: buildkite-agent
+          PropagateAtLaunch: true
+        - Key: BuildkiteAgentRelease
+          Value: $(BuildkiteAgentRelease)
+          PropagateAtLaunch: true
+        - Key: BuildkiteQueue
+          Value: $(BuildkiteQueue)
           PropagateAtLaunch: true
 
     CreationPolicy:


### PR DESCRIPTION
This PR adds "Name" tags for buildkite agents such that their purpose is clear in the AWS console. It also adds tags for the agent version and queue to assist with managing multiple agent stacks.