### PR TITLE
Change parameter help text

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -112,7 +112,7 @@ Parameters:
 
   AvailabilityZones:
     Type: CommaDelimitedList
-    Description: Optional - Comma-delimited list of VPC availability zones in which to create subnets. Required if not setting Subnets.
+    Description: Optional - defines the AZs that subnets are created in if Subnets parameter is not specified.
     Default: ""
 
   InstanceType:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -112,7 +112,7 @@ Parameters:
 
   AvailabilityZones:
     Type: CommaDelimitedList
-    Description: Optional - Comma-delimited list of VPC availability zones in which to create subnets. Required if setting VpcId.
+    Description: Optional - Comma-delimited list of VPC availability zones in which to create subnets. Required if not setting Subnets.
     Default: ""
 
   InstanceType:


### PR DESCRIPTION
Looking at the generated CloudFormation it seems the AvailabilityZones parameter is only used if creating subnets.
