### PR TITLE
More tags for EC2 instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ templates/mappings.yml
 vendor/
 .bundle/
 *.bak
+extra_tags.json
 

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,18 @@ upload: build/aws-stack.json
 config.json:
 	test -s config.json || $(error Please create a config.json file)
 
-create-stack: config.json build/aws-stack.json
+extra_tags.json:
+	touch extra_tags.json
+
+create-stack: config.json build/aws-stack.json extra_tags.json
 	aws cloudformation create-stack \
 	--output text \
 	--stack-name $(STACK_NAME) \
 	--disable-rollback \
 	--template-body "file://$(PWD)/build/aws-stack.json" \
 	--capabilities CAPABILITY_IAM \
-	--parameters "$$(cat config.json)"
+	--parameters "$$(cat config.json)" \
+	--tags "$$(cat extra_tags.json)"
 
 validate: build/aws-stack.json
 	aws cloudformation validate-template \

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ AWS_PROFILE="some-profile" make create-stack
 aws-vault exec some-profile -- make create-stack
 ```
 
+Adding extra tags to the stack (including the EC2 instances) can be done via `extra_tags.json` (see [`extra_tags.json.example`](extra_tags.json.example) for usage).
+
 ## What’s On Each Machine?
 
 * [Amazon Linux](https://aws.amazon.com/amazon-linux-ami/)

--- a/extra_tags.json.example
+++ b/extra_tags.json.example
@@ -1,0 +1,10 @@
+[
+  {
+    "Key": "Owner",
+    "Value": "ops-team"
+  },
+  {
+    "Key": "Other",
+    "Value": "something else"
+  }
+]

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -21,3 +21,10 @@ Resources:
           "$(Subnet0),$(Subnet1),$(Subnet2)",
           !Join [ ",", $(Subnets) ]
         ]
+      Tags:
+        - Key: Role
+          Value: buildkite-metrics
+          PropagateAtLaunch: true
+        - Key: Name
+          Value: buildkite-metrics
+          PropagateAtLaunch: true

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -24,7 +24,5 @@ Resources:
       Tags:
         - Key: Role
           Value: buildkite-metrics
-          PropagateAtLaunch: true
         - Key: Name
           Value: buildkite-metrics
-          PropagateAtLaunch: true


### PR DESCRIPTION
We have a company directive to add standardised tags to EC2 instances, including the Buildkite agent/metrics boxes. The existing `Role` and `Name` tags for the agent stack is 👌  but is missing for the metrics stack, plus we also require a few more for both boxes.

1. Tags the _metrics_ stack with appropriate Name/Role tag (follow on from https://github.com/buildkite/elastic-ci-stack-for-aws/pull/104 which only named the _agent_ boxes)
2. Adds ability for user-specified tags via `extra_tags.json`, with provided example.

## Questions

Is `extra_tags.json` overkill? The other option is to have organisations document the incantation to create the new stack (`aws cloudformation create-stack ...`) and add the tags directive there. You'd lose the Makefile goodness, but then again you could just document `make config.json build/aws-stack.json` as well.
