### PR TITLE
Grant sudo access to apt-get

### DIFF
--- a/packer/conf/buildkite-agent/sudoers.conf
+++ b/packer/conf/buildkite-agent/sudoers.conf
@@ -1,1 +1,1 @@
-buildkite-agent ALL=NOPASSWD: /usr/bin/fix-buildkite-agent-builds-permissions
+buildkite-agent ALL=NOPASSWD: /usr/bin/fix-buildkite-agent-builds-permissions, /usr/bin/apt-get


### PR DESCRIPTION
I opened this PR because projects for my team need various other software installed (make, zip, unzip, a few other things). Currently the elastic pipeline only includes docker, docker-compose, and the aws CLI. This is enough for 90% of projects but not 100%. Now I can add `apt-get install -y FOO` in to environment hook in the secrets bucket.

However the question is should we just grant sudo access to everything or only a subset.