### PR TITLE
Basic support for paravirtualized images

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,9 +3,9 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-6869aa05",
+      "source_ami": "ami-2a69aa47",
       "region": "us-east-1",
-      "instance_type": "c4.large",
+      "instance_type": "m1.large",
       "ssh_username": "ec2-user",
       "ami_name": "buildkite-stack-{{isotime | clean_ami_name}}",
       "ami_description": "Buildkite CloudFormation Stack base image (Amazon Linux, buildkite-agent, docker, docker-compose, docker-gc, jq, lifecycled)",

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -311,7 +311,7 @@ Resources:
         $(ImageId)
       ]
       BlockDeviceMappings:
-        - DeviceName: /dev/xvda
+        - DeviceName: /dev/sda1
           Ebs: { VolumeSize: $(RootVolumeSize), VolumeType: gp2, Iops: $(RootVolumeIops) }
       UserData: !Base64 |
         #!/bin/bash -xv


### PR DESCRIPTION
This is by no means complete, but I wanted to see if anyone else is interested using the older paravirtualized instance types?

spot pricing for the c4.large instances is going crazy:
![image](https://cloud.githubusercontent.com/assets/2247982/17613490/4eda2d56-60a1-11e6-97f7-73ac4a753b4c.png)

These huge price spikes cause instance terminations regardless of lifecycled which look like this in a job:
```
$ docker-compose -f .buildkite/docker-compose.yml -p buildkite135479143c984704a4046342d74118a4 kill
ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?
 
If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.
$ docker-compose -f .buildkite/docker-compose.yml -p buildkite135479143c984704a4046342d74118a4 rm --force --all -v
ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?
 
If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.
$ docker-compose -f .buildkite/docker-compose.yml -p buildkite135479143c984704a4046342d74118a4 down
ERROR: Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?
 
If it's at a non-standard location, specify the URL with the DOCKER_HOST environment variable.
```



Older instance types seem to have much more capacity, and lower more stable prices:
![image](https://cloud.githubusercontent.com/assets/2247982/17613500/73116324-60a1-11e6-9647-e71b762a8f95.png)

These are the bare minimum changes required to use the PV instances like m1.large, if there is interest perhaps the mappings should support these instance types automatically?