### PR TITLE
Install zip/unzip

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -20,6 +20,10 @@
     },
     {
       "type": "shell",
+      "script": "scripts/install-utils.sh"
+    },
+    {
+      "type": "shell",
       "script": "scripts/install-awslogs.sh"
     },
     {

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+echo "Installing zip utils..."
+sudo yum update -y -q
+sudo yum install -y zip unzip


### PR DESCRIPTION
These tools are used when integrating with AWS services. These should be
included given the AWS CLI is installed. This is a follow up from #113.