### PR TITLE
Remove provisioned IOPS from the template

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -33,7 +33,6 @@ Metadata:
         - ArtifactsBucket
         - AuthorizedUsersUrl
         - RootVolumeSize
-        - RootVolumeIops
 
       - Label:
           default: Auto-scaling Configuration
@@ -154,12 +153,6 @@ Parameters:
     Type: Number
     Default: 250
     MinValue: 10
-
-  RootVolumeIops:
-    Description: Provisioned IOPS for the root volume. You get 3 free for each GB
-    Type: Number
-    Default: 750
-    MinValue: 0
 
   SecurityGroupId:
     Type: String
@@ -312,7 +305,7 @@ Resources:
       ]
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
-          Ebs: { VolumeSize: $(RootVolumeSize), VolumeType: gp2, Iops: $(RootVolumeIops) }
+          Ebs: { VolumeSize: $(RootVolumeSize), VolumeType: gp2 }
       UserData: !Base64 |
         #!/bin/bash -xv
         /opt/aws/bin/cfn-init -s $(AWS::StackId) -r AgentLaunchConfiguration --region $(AWS::Region)


### PR DESCRIPTION
Provisioned IOPS only applies to io1 volumes, not gp2. Fixes #116 