### PR TITLE
Use queue of "default"

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -75,9 +75,9 @@ Parameters:
     NoEcho: true
 
   BuildkiteQueue:
-    Description: Queue name that agents will use, targetted in pipeline steps using "queue={value}"
+    Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"
     Type: String
-    Default: elastic
+    Default: default
     MinLength: 1
 
   AgentsPerInstance:


### PR DESCRIPTION
For new stack users, having a queue of `elastic` causes much confusion because they think the autoscaling gear is broken, but in fact they have run a build job but there's no matching agents. Also a queue name of `elastic` never fully gelled with me as a good default.

Just like all our other installers, we should probably just stick with `default` and let people do their own queue segregation as they want. It'd definitely help people new to the platform, and experienced users will know about queues anywho.