### PR TITLE
Don't stop all other Docker containers

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -58,11 +58,6 @@ fi
 echo "~~~ Waiting for :docker:"
 timeout 30 docker ps
 
-if [[ $(docker ps -q | wc -l) -gt 0 ]] ; then
-  echo "~~~ Stopping existing :docker: containers"
-  docker stop $(docker ps -q)
-fi
-
 unset BUILDKITE_SECRETS_BUCKET
 unset BUILDKITE_SECRETS_KEY
 


### PR DESCRIPTION
If you run multiple agents, or you run other daemons on your instance, just stopping all Docker containers is bad. This assumes that people will stop their Docker containers, and that Buildkite's default Docker gear behaves properly.

Closes #121