### PR TITLE
Don't use default termination policy

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -503,6 +503,9 @@ Resources:
             - GroupInServiceInstances
             - GroupTerminatingInstances
             - GroupPendingInstances
+      TerminationPolicies:
+        - OldestLaunchConfiguration
+        - ClosestToNextInstanceHour
       Tags:
         - Key: Role
           Value: buildkite-agent


### PR DESCRIPTION
The [default ASG termination policy](http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html) is to keep AZ's with equal number of instances, then oldest launch config, then closest to next instance hour.

For the stack we care more about the last two, and less about AZs.

Closes #108