### PR TITLE
Trigger rolling updates for key params

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -317,6 +317,13 @@ Resources:
         /opt/aws/bin/cfn-init -s $(AWS::StackId) -r AgentLaunchConfiguration --region $(AWS::Region)
         /opt/aws/bin/cfn-signal -e \$? -r 'cfn-init finished' \
           --stack $(AWS::StackName) --resource 'AgentAutoScaleGroup' --region $(AWS::Region)
+        # Here we put any params we want to trigger a restart
+        # $(BuildkiteAgentToken)
+        # $(BuildkiteAgentRelease)
+        # $(BuildkiteQueue)
+        # $(AgentsPerInstance)
+        # $(SecretsBucket)
+        # $(BootstrapScriptUrl)
 
     Metadata:
       # see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html


### PR DESCRIPTION
Updating the agent queue name, and a bunch of other keys, doesn't trigger an update of instances. This outputs those params into UserData so an update is triggered.

> Update requires: Some interruptions for Amazon EBS-backed instances.
> For EBS-backed instances, changing the UserData stops and then starts the instance; however, Amazon EC2 doesn't automatically run the updated UserData. To update configurations on your instance, use the cfn-hup helper script.
> Update requires: Replacement for instance store-backed instances.

Closes #84 

This doesn't fix updating the API key, that'll have to be done in the metrics stack.