### PR TITLE
Increase rolling update PauseTime to 40 minutes

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -521,7 +521,10 @@ Resources:
       AutoScalingRollingUpdate:
         MinInstancesInService: $(MinSize)
         MaxBatchSize: 5
-        PauseTime: PT15M
+        # On rollback this might have to wait for an agent to finish
+        # a job. The agent's init script waits 30 minutes, so we wait
+        # a maximum of 40 minutes to be safe.
+        PauseTime: PT40M
         WaitOnResourceSignals: true
 
   SecurityGroup:


### PR DESCRIPTION
Updating the stack with a large number of instances sometimes fails, and then the rollback itself fails. This increases the `PauseTime` to 40 minutes to help this, with the downside that if an instance fails to come up during a rolling update, it's a long wait before you can do something about it. The upside is updates, and especially rollbacks, should have a better chance of succeeding.

The amount of time that AWS CloudFormation pauses after making a change to a batch of instances to give those instances time to start software applications. For example, you might need to specify PauseTime when scaling up the number of instances in an Auto Scaling group.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html

> If you enable the WaitOnResourceSignals property, PauseTime is the amount of time that AWS CloudFormation should wait for the Auto Scaling group to receive the required number of valid signals from added or replaced instances. If the PauseTime is exceeded before the Auto Scaling group receives the required number of signals, the update fails. For best results, specify a time period that gives your applications sufficient time to get started. If the update needs to be rolled back, a short PauseTime can cause the rollback to fail.

(mentioned in #84)