### PR TITLE
Clean up docker login

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,21 @@ rm id_rsa_buildkite*
 
 ## Docker Registry Support
 
-If you want to push or pull from Docker Hub you can use the `env` file in your secrets bucket to export `DOCKER_HUB_USER`, `DOCKER_HUB_PASSWORD` and `DOCKER_HUB_EMAIL`. This will perform a `docker login` before each pipeline step is run, allowing you to `docker push` to Docker Hub.
+If you want to push or pull from registries such as Docker Hub or Quay you can use the `env` file in your secrets bucket to export the following environment variables:
 
-If you want to use [AWS ECR](https://aws.amazon.com/ecr/) instead of Docker Hub there's no need to worry about credentials, you simply ensure that your agent machines have the necessary IAM roles and permissions.
+* `DOCKER_LOGIN_USER="the-user-name"`
+* `DOCKER_LOGIN_PASSWORD="the-password"`
+* `DOCKER_LOGIN_SERVER=""` - optional. By default it will log into Docker Hub
 
-For all other services you’ll need to perform your own `docker login` commands using the `env` hook.
+Setting these will perform a `docker login` before each pipeline step is run, allowing you to `docker push` to them from within your build scripts.
+
+AWS ECR login can be performed by exporting the following variable from your `env` file or pipeline’s build steps:
+
+* `AWS_ECR_LOGIN=true`
+
+If you want to login to an ECR server on another AWS account, use the following environment variable instead:
+
+* `AWS_ECR_LOGIN_REGISTRY_IDS="id1,id2,id3"`
 
 ## Updating Your Stack
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -21,7 +21,7 @@ s3_download() {
   env -i aws s3 cp --quiet ${aws_s3_args[@]} "$1" /dev/stdout
 }
 
-echo "~~~ :house_with_garden: Setting up the environment"
+echo "~~~ Setting up the environment"
 
 eval "$(cat ~/cfn-env)"
 eval "$(ssh-agent -s)"
@@ -55,7 +55,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   fi
 fi
 
-echo "~~~ Waiting for :docker:"
+echo "~~~ Waiting for Docker"
 timeout 30 docker ps
 
 unset BUILDKITE_SECRETS_BUCKET

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -4,11 +4,13 @@ set -eu -o pipefail
 
 : "${AWS_ECR_LOGIN:-}"
 : "${AWS_ECR_LOGIN_REGISTRY_IDS:-}"
-: "${DOCKER_HUB_USER:-}"
-: "${DOCKER_HUB_PASSWORD:-}"
 : "${DOCKER_LOGIN_USER:-}"
 : "${DOCKER_LOGIN_PASSWORD:-}"
 : "${DOCKER_LOGIN_SERVER:-}"
+
+# Legacy envs
+: "${DOCKER_HUB_USER:-}"
+: "${DOCKER_HUB_PASSWORD:-}"
 
 # AWS ECR login support
 

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -3,7 +3,6 @@
 set -eu -o pipefail
 
 [[ -f ~/.docker/config.json ]] && rm ~/.docker/config.json
-[[ -f ~/.dockercfg ]] && rm ~/.dockercfg
 
 if [[ -n "${DOCKER_HUB_AUTH:-}" ]] ; then
   DOCKER_HUB_USER=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f1)

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -2,27 +2,41 @@
 
 set -eu -o pipefail
 
+: "${AWS_ECR_LOGIN:-}"
+: "${AWS_ECR_LOGIN_REGISTRY_IDS:-}"
+: "${DOCKER_HUB_USER:-}"
+: "${DOCKER_HUB_PASSWORD:-}"
+: "${DOCKER_LOGIN_USER:-}"
+: "${DOCKER_LOGIN_PASSWORD:-}"
+: "${DOCKER_LOGIN_SERVER:-}"
+
 # AWS ECR login support
 
 # For logging into the current AWS account’s registry
-if [[ -n "${AWS_ECR_LOGIN:-}" ]] ; then
+if [[ -n "${AWS_ECR_LOGIN}" ]] ; then
   echo "~~~ Authenticating with AWS ECR"
   eval "$(aws ecr get-login)"
 fi
 
 # For logging into other AWS account’s registries
-if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
+if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS}" ]] ; then
   echo "~~~ Authenticating with AWS ECR"
   eval "$(aws ecr get-login --registry_ids "${AWS_ECR_LOGIN_REGISTRY_IDS}")"
 fi
 
+# DOCKER_HUB_* legacy config var support
+if [[ -n "${DOCKER_HUB_USER}" && -n "${DOCKER_HUB_PASSWORD}" ]]; then
+  echo "~~~ :warning: Deprecated DOCKER_HUB_* env variables"
+  echo "The following env hook environments variables need updating:"
+  echo "* DOCKER_HUB_USER is now DOCKER_LOGIN_USER"
+  echo "* DOCKER_HUB_PASSWORD is now DOCKER_LOGIN_PASSWORD"
+  DOCKER_LOGIN_USER="${DOCKER_HUB_USER}"
+  DOCKER_LOGIN_PASSWORD="${DOCKER_HUB_PASSWORD}"
+fi
+
 # Generic docker login support
 
-: "${DOCKER_LOGIN_USER:-}"
-: "${DOCKER_LOGIN_PASSWORD:-}"
-: "${DOCKER_LOGIN_SERVER:-}"
-
-if [[ -n "${DOCKER_LOGIN_USER:-}" && -n "${DOCKER_LOGIN_PASSWORD:-}" ]] ; then
+if [[ -n "${DOCKER_LOGIN_USER}" && -n "${DOCKER_LOGIN_PASSWORD}" ]] ; then
   echo "~~~ Authenticating with Docker server"
 
   docker login --username="${DOCKER_LOGIN_USER}" --password="${DOCKER_LOGIN_PASSWORD}" "${DOCKER_LOGIN_SERVER}"

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -5,8 +5,6 @@ set -eu -o pipefail
 if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
   echo "~~~ Authenticating with Docker Hub as ${DOCKER_HUB_USER}"
 
-  [[ -f ~/.docker/config.json ]] && rm ~/.docker/config.json
-
   docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}"
 
   unset DOCKER_HUB_USER

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -2,8 +2,6 @@
 
 set -eu -o pipefail
 
-[[ -f ~/.docker/config.json ]] && rm ~/.docker/config.json
-
 if [[ -n "${DOCKER_HUB_AUTH:-}" ]] ; then
   DOCKER_HUB_USER=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f1)
   DOCKER_HUB_PASSWORD=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f2)
@@ -12,8 +10,11 @@ fi
 
 if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
   echo "~~~ Authenticating with Docker Hub as ${DOCKER_HUB_USER}"
-  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}"
-fi
 
-unset DOCKER_HUB_USER
-unset DOCKER_HUB_PASSWORD
+  [[ -f ~/.docker/config.json ]] && rm ~/.docker/config.json
+
+  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}"
+
+  unset DOCKER_HUB_USER
+  unset DOCKER_HUB_PASSWORD
+fi

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -2,32 +2,22 @@
 
 set -eu -o pipefail
 
-: "${AWS_ECR_LOGIN:-}"
-: "${AWS_ECR_LOGIN_REGISTRY_IDS:-}"
-: "${DOCKER_LOGIN_USER:-}"
-: "${DOCKER_LOGIN_PASSWORD:-}"
-: "${DOCKER_LOGIN_SERVER:-}"
-
-# Legacy envs
-: "${DOCKER_HUB_USER:-}"
-: "${DOCKER_HUB_PASSWORD:-}"
-
 # AWS ECR login support
 
 # For logging into the current AWS account’s registry
-if [[ -n "${AWS_ECR_LOGIN}" ]] ; then
+if [[ -n "${AWS_ECR_LOGIN:-}" ]] ; then
   echo "~~~ Authenticating with AWS ECR"
   eval "$(aws ecr get-login)"
 fi
 
 # For logging into other AWS account’s registries
-if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS}" ]] ; then
+if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
   echo "~~~ Authenticating with AWS ECR"
   eval "$(aws ecr get-login --registry_ids "${AWS_ECR_LOGIN_REGISTRY_IDS}")"
 fi
 
 # DOCKER_HUB_* legacy config var support
-if [[ -n "${DOCKER_HUB_USER}" && -n "${DOCKER_HUB_PASSWORD}" ]]; then
+if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]]; then
   echo "~~~ :warning: Deprecated DOCKER_HUB_* env variables"
   echo "The following env hook environments variables need updating:"
   echo "* DOCKER_HUB_USER is now DOCKER_LOGIN_USER"
@@ -38,10 +28,10 @@ fi
 
 # Generic docker login support
 
-if [[ -n "${DOCKER_LOGIN_USER}" && -n "${DOCKER_LOGIN_PASSWORD}" ]] ; then
+if [[ -n "${DOCKER_LOGIN_USER:-}" && -n "${DOCKER_LOGIN_PASSWORD:-}" ]] ; then
   echo "~~~ Authenticating with Docker server"
 
-  docker login --username="${DOCKER_LOGIN_USER}" --password="${DOCKER_LOGIN_PASSWORD}" "${DOCKER_LOGIN_SERVER}"
+  docker login --username="${DOCKER_LOGIN_USER}" --password="${DOCKER_LOGIN_PASSWORD}" "${DOCKER_LOGIN_SERVER:-}"
 
   unset DOCKER_LOGIN_USER
   unset DOCKER_LOGIN_PASSWORD

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -2,6 +2,20 @@
 
 set -eu -o pipefail
 
+# AWS ECR login support
+
+# For logging into the current AWS account’s registry
+if [[ -n "${AWS_ECR_LOGIN:-}" ]] ; then
+  echo "~~~ Authenticating with AWS ECR"
+  eval "$(aws ecr get-login)"
+fi
+
+# For logging into other AWS account’s registries
+if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
+  echo "~~~ Authenticating with AWS ECR"
+  eval "$(aws ecr get-login --registry_ids "${AWS_ECR_LOGIN_REGISTRY_IDS}")"
+fi
+
 # Generic docker login support
 
 : "${DOCKER_LOGIN_USER:-}"

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -8,18 +8,13 @@ set -eu -o pipefail
 if [[ -n "${DOCKER_HUB_AUTH:-}" ]] ; then
   DOCKER_HUB_USER=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f1)
   DOCKER_HUB_PASSWORD=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f2)
-  DOCKER_HUB_EMAIL=$(jq -r '."https://index.docker.io/v1/".email' <<< "$DOCKER_HUB_AUTH")
   unset DOCKER_HUB_AUTH
 fi
 
-if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" && -n "${DOCKER_HUB_EMAIL:-}" ]] ; then
-  echo "~~~ Authenticating with :docker: hub as ${DOCKER_HUB_USER}"
-  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}" --email="${DOCKER_HUB_EMAIL}"
-elif [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
-  echo "Missing DOCKER_HUB_EMAIL."
-  exit 1
+if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
+  echo "~~~ Authenticating with Docker Hub as ${DOCKER_HUB_USER}"
+  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}"
 fi
 
 unset DOCKER_HUB_USER
 unset DOCKER_HUB_PASSWORD
-unset DOCKER_HUB_EMAIL

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -2,11 +2,18 @@
 
 set -eu -o pipefail
 
-if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
-  echo "~~~ Authenticating with Docker Hub as ${DOCKER_HUB_USER}"
+# Generic docker login support
 
-  docker login --username="${DOCKER_HUB_USER}" --password="${DOCKER_HUB_PASSWORD}"
+: "${DOCKER_LOGIN_USER:-}"
+: "${DOCKER_LOGIN_PASSWORD:-}"
+: "${DOCKER_LOGIN_SERVER:-}"
 
-  unset DOCKER_HUB_USER
-  unset DOCKER_HUB_PASSWORD
+if [[ -n "${DOCKER_LOGIN_USER:-}" && -n "${DOCKER_LOGIN_PASSWORD:-}" ]] ; then
+  echo "~~~ Authenticating with Docker server"
+
+  docker login --username="${DOCKER_LOGIN_USER}" --password="${DOCKER_LOGIN_PASSWORD}" "${DOCKER_LOGIN_SERVER}"
+
+  unset DOCKER_LOGIN_USER
+  unset DOCKER_LOGIN_PASSWORD
+  unset DOCKER_LOGIN_SERVER
 fi

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -2,12 +2,6 @@
 
 set -eu -o pipefail
 
-if [[ -n "${DOCKER_HUB_AUTH:-}" ]] ; then
-  DOCKER_HUB_USER=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f1)
-  DOCKER_HUB_PASSWORD=$(jq -r '."https://index.docker.io/v1/".auth' <<< "$DOCKER_HUB_AUTH" | base64 --decode | cut -d: -f2)
-  unset DOCKER_HUB_AUTH
-fi
-
 if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]] ; then
   echo "~~~ Authenticating with Docker Hub as ${DOCKER_HUB_USER}"
 


### PR DESCRIPTION
This removes `DOCKER_HUB_*` configs in favour of generic `DOCKER_LOGIN_*` environment variables, and adds support for AWS ECR login.

This also removes the `rm` of the Docker login creds, a file that is readable by all builds. This means that if one step performs a docker login, subsequent steps can read that file. Is this a problem? I'm not sure what the answer is for a world where more than one agent runs on the machine at once. The current implementation isn't much more secure at the moment in this situation anyway.

- [x] First cut for review
- [x] Decide on whether it's okay to leave Docker login creds around between job runs
- [x] Add back support for `DOCKER_HUB_USER` and `DOCKER_HUB_PASSWORD` with a deprecation warning

Closes #111