### PR TITLE
Follow bootstrap URL redirects

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -442,7 +442,7 @@ Resources:
               command: |
                 #!/bin/bash -euo pipefail
 
-                curl --silent -f "$(BootstrapScriptUrl)" | bash
+                curl -sSL "$(BootstrapScriptUrl)" | bash
 
   AgentLifecycleQueue:
     Type: AWS::SQS::Queue


### PR DESCRIPTION
This works nicely with S3 urls since they will give redirects if the region is not included. This change is not AWS specific. There is not a reason to skip redirects on these urls.