### PR TITLE
Send cfn-signal/init logs to CloudWatch

### DIFF
--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -12,3 +12,21 @@ file = /var/log/docker
 log_group_name = /var/log/docker
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%S.%f
+
+[/var/log/cfn-init-cmd.log]
+file = /var/log/cfn-init-cmd.log
+log_group_name = /var/log/cfn-init-cmd.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%f
+
+[/var/log/cfn-init.log]
+file = /var/log/cfn-init.log
+log_group_name = /var/log/cfn-init.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%f
+
+[/var/log/cfn-wire.log]
+file = /var/log/cfn-wire.log
+log_group_name = /var/log/cfn-wire.log
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%d %H:%M:%S,%f


### PR DESCRIPTION
To make it easier to debug autoscaling/cfn signals (for example, for #130), this adds the cfn logs to CloudWatch