### PR TITLE
Updated CreationPolicy/ResourceSignal count to 1

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -523,7 +523,7 @@ Resources:
     CreationPolicy:
       ResourceSignal:
         Timeout: PT5M
-        Count: $(MinSize)
+        Count: 1
     UpdatePolicy:
       AutoScalingRollingUpdate:
         MinInstancesInService: $(MinSize)


### PR DESCRIPTION
> The number of success signals AWS CloudFormation must receive before it sets the resource status as CREATE_COMPLETE. If the resource receives a failure signal or doesn't receive the specified number of signals before the timeout period expires, the resource creation fails and AWS CloudFormation rolls the stack back.

After re-reading the docs, we believe the `Count` parameter here is per-instance. The ASG is marked as complete immediately, where it should be waiting for 1 signal from each instance.