### PR TITLE
Keep each master aws-stack.json

### DIFF
--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -142,6 +142,10 @@ make setup build
 if [[ $BUILDKITE_BRANCH == "master" ]] ; then
   aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
   aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
+
+  # Publish each build to a unique URL, to let people roll back to old versions
+  aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/master/${BUILDKITE_COMMIT}.mappings.yml"
+  aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/master/${BUILDKITE_COMMIT}.aws-stack.json"
 fi
 
 aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/mappings.yml"


### PR DESCRIPTION
This will at least give people a URL to download old releases of the stack.