### PR TITLE
use correct parameter name for ECR login

### DIFF
--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -13,7 +13,7 @@ fi
 # For logging into other AWS account’s registries
 if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
   echo "~~~ Authenticating with AWS ECR"
-  eval "$(aws ecr get-login --registry_ids "${AWS_ECR_LOGIN_REGISTRY_IDS}")"
+  eval "$(aws ecr get-login --registry-ids "${AWS_ECR_LOGIN_REGISTRY_IDS}")"
 fi
 
 # DOCKER_HUB_* legacy config var support


### PR DESCRIPTION
When using AWS_ECR_LOGIN_REGISTRY_IDS variable I'm getting an error
```
Unknown options: --registry_ids,[xxxxxxxxxxxxx]
```
The parameter used by aws-cli is "registry-ids", not "registry_ids"