### PR TITLE
Prevent chmod collisions in multi-agent per instance stacks

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -61,4 +61,4 @@ timeout 30 docker ps
 unset BUILDKITE_SECRETS_BUCKET
 unset BUILDKITE_SECRETS_KEY
 
-sudo /usr/bin/fix-buildkite-agent-builds-permissions
+sudo /usr/bin/fix-buildkite-agent-builds-permissions "${BUILDKITE_BUILD_CHECKOUT_PATH}"

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -23,10 +23,17 @@ s3_download() {
 
 echo "~~~ Setting up the environment"
 
+echo "Sourcing CloudFormation environment..."
 eval "$(cat ~/cfn-env)"
+echo
+
+echo "Starting an SSH Agent..."
 eval "$(ssh-agent -s)"
+echo
 
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
+  echo "Downloading secrets..."
+  echo
 
   # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
@@ -48,15 +55,18 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   else
     echo "No SSH keys found in s3://${BUILDKITE_SECRETS_BUCKET}"
   fi
+  echo
 
   if s3_exists "$env_url" ; then
     echo "Downloading env from $env_url"
     eval "$(s3_download $env_url)"
+    echo
   fi
 fi
 
-echo "~~~ Waiting for Docker"
+echo "Waiting for Docker..."
 timeout 30 docker ps
+echo
 
 unset BUILDKITE_SECRETS_BUCKET
 unset BUILDKITE_SECRETS_KEY
@@ -84,4 +94,6 @@ AGENT_BUILD_NAME="${BUILD_PATH_SUFFIX%%/*}"
 # => "my-agent-1"
 
 # Now we can pass this to the sudo script which will validate it before safely chmodding:
+echo "Fixing permissions for '${AGENT_BUILD_NAME}'..."
 sudo /usr/bin/fix-buildkite-agent-builds-permissions "${AGENT_BUILD_NAME}"
+echo

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -76,7 +76,7 @@ unset BUILDKITE_SECRETS_KEY
 #   BUILDKITE_BUILD_PATH="/var/lib/buildkite-agent/builds"
 
 # So we can calculate the suffix as a substring:
-BUILD_PATH_SUFFIX="${BUILDKITE_BUILD_CHECKOUT_PATH:${#BUILDKITE_BUILD_PATH}}"
+BUILD_PATH_SUFFIX="${BUILDKITE_BUILD_CHECKOUT_PATH#${BUILDKITE_BUILD_PATH}/}"
 # => "my-agent-1/my-pipeline-blah"
 
 # Then we can grab just the first path component by removing the longest suffix starting with a slash:

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -75,8 +75,8 @@ unset BUILDKITE_SECRETS_KEY
 #
 #   BUILDKITE_BUILD_PATH="/var/lib/buildkite-agent/builds"
 
-# So we can calculate the suffix (we presume the prefix has no pattern chars):
-BUILD_PATH_SUFFIX="${BUILD_PATH#${BUILDKITE_BUILD_PATH}/}"
+# So we can calculate the suffix as a substring:
+BUILD_PATH_SUFFIX="${BUILDKITE_BUILD_CHECKOUT_PATH:${#BUILDKITE_BUILD_PATH}}"
 # => "my-agent-1/my-pipeline-blah"
 
 # Then we can grab just the first path component by removing the longest suffix starting with a slash:

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -61,4 +61,27 @@ timeout 30 docker ps
 unset BUILDKITE_SECRETS_BUCKET
 unset BUILDKITE_SECRETS_KEY
 
-sudo /usr/bin/fix-buildkite-agent-builds-permissions "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+# We need to scope the next bit to only the currently running agent's builds,
+# but we also need to control security and make sure arbitrary folders can't be
+# chmoded.
+#
+# The agent builds path isn't exposed nicely by itself. The agent name also
+# doesn't quite map to its builds path. We do have a complete checkout path,
+# but we need to chop it up, safely. The path looks like:
+#
+#   BUILDKITE_BUILD_CHECKOUT_PATH="/var/lib/buildkite-agent/builds/my-agent-1/my-pipeline-blah"
+#
+# We know the beginning of this path, it's in BUILDKITE_BUILD_PATH:
+#
+#   BUILDKITE_BUILD_PATH="/var/lib/buildkite-agent/builds"
+
+# So we can calculate the suffix (we presume the prefix has no pattern chars):
+BUILD_PATH_SUFFIX="${BUILD_PATH#${BUILDKITE_BUILD_PATH}/}"
+# => "my-agent-1/my-pipeline-blah"
+
+# Then we can grab just the first path component by removing the longest suffix starting with a slash:
+AGENT_BUILD_NAME="${BUILD_PATH_SUFFIX%%/*}"
+# => "my-agent-1"
+
+# Now we can pass this to the sudo script which will validate it before safely chmodding:
+sudo /usr/bin/fix-buildkite-agent-builds-permissions "${AGENT_BUILD_NAME}"

--- a/packer/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
+++ b/packer/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
@@ -16,80 +16,66 @@ set -eu -o pipefail
 # also need to control security and make sure arbitrary folders can't be
 # chmoded.
 #
-# The agent builds path isn't exposed nicely by itself. The agent name also
-# doesn't quite map to its builds path. We do have a complete checkout path,
-# but we need to chop it up, safely. The path looks like:
-#
-#   BUILDKITE_BUILD_CHECKOUT_PATH="/var/lib/buildkite-agent/builds/my-agent-1/my-pipeline-blah"
-#
-# It should be passed as the first argument to this script.
-BUILD_PATH="$1"
-
-# We know the beginning of this path:
-BUILDS_PATH="/var/lib/buildkite-agent/builds"
-
-# So we can calculate the suffix (we know prefix has no pattern chars):
-BUILD_PATH_SUFFIX="${BUILD_PATH#${BUILDS_PATH}/}"
-# => "my-agent-1/my-pipeline-blah"
-
-# Then we can grab just the first path component by removing the longest suffix starting with a slash:
-AGENT_BUILDS_NAME="${BUILD_PATH_SUFFIX%%/*}"
+# We prepare the agent build directory basename in the environment hook and
+# pass it as the first argument. In here we just need to check that it contains
+# no slashes and isn't a traversal component.
+AGENT_BUILDS_NAME="$1"
 # => "my-agent-1"
 
-# Now we know this component has only non-slash characters
+# Make sure it doesn't contain any slashes by substituting slashes with nothing
+# and making sure it doesn't change
+if [[ "${AGENT_BUILDS_NAME//\//}" != "${AGENT_BUILDS_NAME}" ]]; then
+	exit 1
+fi
+
+# Now we know this name has only non-slash characters.
 #
 # We just need to check that it's not "." or ".." to prevent traversal:
 if [[ "${AGENT_BUILDS_NAME}" == "." || "${AGENT_BUILDS_NAME}" == ".." ]]; then
-	exit 1
+	exit 2
 fi
 
 # We also need to make sure it's not empty so we don't collide with other agents:
 if [[ -z "${AGENT_BUILDS_NAME}" ]]; then
-	exit 2
+	exit 3
 fi
+
+# We know the builds path:
+BUILDS_PATH="/var/lib/buildkite-agent/builds"
 
 # And now we can reconstruct the full agent builds path:
 AGENT_BUILDS_PATH="${BUILDS_PATH}/${AGENT_BUILDS_NAME}"
 # => "/var/lib/buildkite-agent/builds/my-agent-1"
 
-if [[ -e "${AGENT_BUILDS_PATH}" ]] ; then
+if [[ -e "${AGENT_BUILDS_PATH}" ]]; then
 	chown -R buildkite-agent:buildkite-agent "${AGENT_BUILDS_PATH}"
 fi
 
 # Manual tests (anybody know a good way to test this?):
 #
-# ./fix-buildkite-agent-builds-permissions ""
-# => exit 2 (BUILD_PATH_SUFFIX="", AGENT_BUILDS_NAME="")
-#
 # ./fix-buildkite-agent-builds-permissions "/"
-# => exit 2 (BUILD_PATH_SUFFIX="/", AGENT_BUILDS_NAME="")
+# => exit 1
+#
+# ./fix-buildkite-agent-builds-permissions "one/"
+# => exit 1
+#
+# ./fix-buildkite-agent-builds-permissions "/two"
+# => exit 1
+#
+# ./fix-buildkite-agent-builds-permissions "one/two"
+# => exit 1
+#
+# ./fix-buildkite-agent-builds-permissions "one/two/three"
+# => exit 1
+#
+# ./fix-buildkite-agent-builds-permissions "/two/"
+# => exit 1
 #
 # ./fix-buildkite-agent-builds-permissions "."
-# => exit 1 (BUILD_PATH_SUFFIX=".", AGENT_BUILDS_NAME=".")
+# => exit 2
 #
 # ./fix-buildkite-agent-builds-permissions ".."
-# => exit 1 (BUILD_PATH_SUFFIX="..", AGENT_BUILDS_NAME="..")
+# => exit 2
 #
-# ./fix-buildkite-agent-builds-permissions "./"
-# => exit 1 (BUILD_PATH_SUFFIX="./", AGENT_BUILDS_NAME=".")
-#
-# ./fix-buildkite-agent-builds-permissions "../"
-# => exit 1 (BUILD_PATH_SUFFIX="../", AGENT_BUILDS_NAME="..")
-#
-# ./fix-buildkite-agent-builds-permissions "/var/lib/buildkite-agent/./somewhere/else"
-# => exit 1 (BUILD_PATH_SUFFIX="./somewhere/else", AGENT_BUILDS_NAME=".")
-#
-# ./fix-buildkite-agent-builds-permissions "/var/lib/buildkite-agent/../somewhere/else"
-# => exit 1 (BUILD_PATH_SUFFIX="../somewhere/else", AGENT_BUILDS_NAME="..")
-#
-# ./fix-buildkite-agent-builds-permissions "/var/lib/buildkite-agent//somewhere/else"
-# => exit 2 (BUILD_PATH_SUFFIX="/somewhere/else", AGENT_BUILDS_NAME="")
-#
-# ./fix-buildkite-agent-builds-permissions "./somewhere/else"
-# => exit 1 (BUILD_PATH_SUFFIX="./somewhere/else", AGENT_BUILDS_NAME=".")
-#
-# ./fix-buildkite-agent-builds-permissions "../somewhere/else"
-# => exit 1 (BUILD_PATH_SUFFIX="../somewhere/else", AGENT_BUILDS_NAME="..")
-#
-# ./fix-buildkite-agent-builds-permissions "/somewhere/else"
-# => exit 2 (BUILD_PATH_SUFFIX="/somewhere/else", AGENT_BUILDS_NAME="")
+# ./fix-buildkite-agent-builds-permissions ""
+# => exit 3

--- a/packer/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
+++ b/packer/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
@@ -12,6 +12,84 @@
 
 set -eu -o pipefail
 
-if [[ -e /var/lib/buildkite-agent/builds ]] ; then
-	chown -R  buildkite-agent.buildkite-agent /var/lib/buildkite-agent/builds
+# We need to scope this to only the currently running agent's builds, but we
+# also need to control security and make sure arbitrary folders can't be
+# chmoded.
+#
+# The agent builds path isn't exposed nicely by itself. The agent name also
+# doesn't quite map to its builds path. We do have a complete checkout path,
+# but we need to chop it up, safely. The path looks like:
+#
+#   BUILDKITE_BUILD_CHECKOUT_PATH="/var/lib/buildkite-agent/builds/my-agent-1/my-pipeline-blah"
+#
+# It should be passed as the first argument to this script.
+BUILD_PATH="$1"
+
+# We know the beginning of this path:
+BUILDS_PATH="/var/lib/buildkite-agent/builds"
+
+# So we can calculate the suffix (we know prefix has no pattern chars):
+BUILD_PATH_SUFFIX="${BUILD_PATH#${BUILDS_PATH}/}"
+# => "my-agent-1/my-pipeline-blah"
+
+# Then we can grab just the first path component by removing the longest suffix starting with a slash:
+AGENT_BUILDS_NAME="${BUILD_PATH_SUFFIX%%/*}"
+# => "my-agent-1"
+
+# Now we know this component has only non-slash characters
+#
+# We just need to check that it's not "." or ".." to prevent traversal:
+if [[ "${AGENT_BUILDS_NAME}" == "." || "${AGENT_BUILDS_NAME}" == ".." ]]; then
+	exit 1
 fi
+
+# We also need to make sure it's not empty so we don't collide with other agents:
+if [[ -z "${AGENT_BUILDS_NAME}" ]]; then
+	exit 2
+fi
+
+# And now we can reconstruct the full agent builds path:
+AGENT_BUILDS_PATH="${BUILDS_PATH}/${AGENT_BUILDS_NAME}"
+# => "/var/lib/buildkite-agent/builds/my-agent-1"
+
+if [[ -e "${AGENT_BUILDS_PATH}" ]] ; then
+	chown -R buildkite-agent:buildkite-agent "${AGENT_BUILDS_PATH}"
+fi
+
+# Manual tests (anybody know a good way to test this?):
+#
+# ./fix-buildkite-agent-builds-permissions ""
+# => exit 2 (BUILD_PATH_SUFFIX="", AGENT_BUILDS_NAME="")
+#
+# ./fix-buildkite-agent-builds-permissions "/"
+# => exit 2 (BUILD_PATH_SUFFIX="/", AGENT_BUILDS_NAME="")
+#
+# ./fix-buildkite-agent-builds-permissions "."
+# => exit 1 (BUILD_PATH_SUFFIX=".", AGENT_BUILDS_NAME=".")
+#
+# ./fix-buildkite-agent-builds-permissions ".."
+# => exit 1 (BUILD_PATH_SUFFIX="..", AGENT_BUILDS_NAME="..")
+#
+# ./fix-buildkite-agent-builds-permissions "./"
+# => exit 1 (BUILD_PATH_SUFFIX="./", AGENT_BUILDS_NAME=".")
+#
+# ./fix-buildkite-agent-builds-permissions "../"
+# => exit 1 (BUILD_PATH_SUFFIX="../", AGENT_BUILDS_NAME="..")
+#
+# ./fix-buildkite-agent-builds-permissions "/var/lib/buildkite-agent/./somewhere/else"
+# => exit 1 (BUILD_PATH_SUFFIX="./somewhere/else", AGENT_BUILDS_NAME=".")
+#
+# ./fix-buildkite-agent-builds-permissions "/var/lib/buildkite-agent/../somewhere/else"
+# => exit 1 (BUILD_PATH_SUFFIX="../somewhere/else", AGENT_BUILDS_NAME="..")
+#
+# ./fix-buildkite-agent-builds-permissions "/var/lib/buildkite-agent//somewhere/else"
+# => exit 2 (BUILD_PATH_SUFFIX="/somewhere/else", AGENT_BUILDS_NAME="")
+#
+# ./fix-buildkite-agent-builds-permissions "./somewhere/else"
+# => exit 1 (BUILD_PATH_SUFFIX="./somewhere/else", AGENT_BUILDS_NAME=".")
+#
+# ./fix-buildkite-agent-builds-permissions "../somewhere/else"
+# => exit 1 (BUILD_PATH_SUFFIX="../somewhere/else", AGENT_BUILDS_NAME="..")
+#
+# ./fix-buildkite-agent-builds-permissions "/somewhere/else"
+# => exit 2 (BUILD_PATH_SUFFIX="/somewhere/else", AGENT_BUILDS_NAME="")


### PR DESCRIPTION
If we chmod the whole builds directory at the beginning of every build then we might chmod files which are currently in use by another agent's build.

The builds path has a first component which is the agent name. We can safely chmod recursively inside there. But we don't know this path, and don't expose it anywhere. And it's not as simple as `builds-path/agent-name` because the agent name is sanitized, but how it is sanitized depends on the agent version.

So we can grab the checkout path and work backwards. It's kinda hacky, but it works.

Like @tim suggested, it might be nice to extract the munging from the fix script into the environment hook and just pass in a prepared agent directory name and just make sure it has no slashes and isn't a traversal component in the script.