### PR TITLE
Implement shared docker layer cache

### DIFF
--- a/packer/conf/buildkite-agent/hooks/post-command
+++ b/packer/conf/buildkite-agent/hooks/post-command
@@ -1,3 +1,27 @@
 #!/bin/bash
 
+set -eux -o pipefail
+
 ssh-agent -k
+
+if [[ -n "${BUILDKITE_DOCKER_COMPOSE_CONTAINER:-}" && -n ${DOCKER_CACHE_IMAGES_PUSH:-} && BUILDKITE_COMMAND_EXIT_STATUS -eq 0 ]] ; then
+    echo "~~~ Pushing cached docker images"
+    (
+        # clear any aws env vars so the machine profile is used
+        unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION
+
+        slug=/tmp/docker-cache/$BUILDKITE_PIPELINE_SLUG.tar.gz
+        images_file=s3://$BUILDKITE_IMAGE_CACHE_BUCKET/$BUILDKITE_PIPELINE_SLUG.images
+        images=$(echo $(docker images -a | grep $(echo $BUILDKITE_JOB_ID | sed 's/-//g') | awk '{print $1}' | xargs -n 1 docker history -q | grep -v '<missing>'))
+
+        if [[ -n $images ]] && ( ! aws s3 ls $images_file || [[ "$images" != $(aws s3 cp $images_file -) ]]) ; then
+            rm -rf /tmp/docker-cache
+            mkdir -p /tmp/docker-cache
+
+            docker save $images | gzip -c > $slug
+
+            aws s3 cp $slug s3://$BUILDKITE_IMAGE_CACHE_BUCKET/$BUILDKITE_PIPELINE_SLUG.tar.gz
+            echo "$images" | aws s3 cp - s3://$BUILDKITE_IMAGE_CACHE_BUCKET/$BUILDKITE_PIPELINE_SLUG.images
+        fi
+    )
+fi

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -41,3 +41,21 @@ if [[ -n "${DOCKER_LOGIN_USER:-}" && -n "${DOCKER_LOGIN_PASSWORD:-}" ]] ; then
   unset DOCKER_LOGIN_PASSWORD
   unset DOCKER_LOGIN_SERVER
 fi
+
+
+# Docker compose layer caching
+
+if [[ -n "${BUILDKITE_DOCKER_COMPOSE_CONTAINER:-}" ]] ; then
+    echo "~~~ Fetching cached docker images"
+
+    (
+        # unset any aws keys so we use the machine policy
+        unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_REGION
+
+        # see if we are missing any of the images locally, and load them if we are
+        images_file=s3://$BUILDKITE_IMAGE_CACHE_BUCKET/$BUILDKITE_PIPELINE_SLUG.images
+        if aws s3 ls $images_file && ! docker inspect $(aws s3 cp $images_file -) > /dev/null ; then
+            aws s3 cp s3://$BUILDKITE_IMAGE_CACHE_BUCKET/$BUILDKITE_PIPELINE_SLUG.tar.gz - | gunzip -c | docker load
+        fi
+    )
+fi

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -250,6 +250,27 @@ Resources:
       Roles:
         - $(IAMRole)
 
+  ImageCacheBucket:
+      Type: AWS::S3::Bucket
+
+  ImageCacheBucketPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ImageCacheBucketPolicy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:Get*
+              - s3:Get
+              - s3:Put*
+              - s3:List*
+            Resource:
+              - "arn:aws:s3:::$(ImageCacheBucket)/*"
+              - "arn:aws:s3:::$(ImageCacheBucket)"
+      Roles:
+        - $(IAMRole)
+
   SecretsBucketPolicies:
     Type: AWS::IAM::Policy
     Condition: UseSecretsBucket
@@ -333,6 +354,7 @@ Resources:
                 cat << EOF > /var/lib/buildkite-agent/cfn-env
                 BUILDKITE_STACK_NAME="$(AWS::StackName)"
                 BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)"
+                BUILDKITE_IMAGE_CACHE_BUCKET="$(ImageCacheBucket)"
                 BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)"
                 EOF
 


### PR DESCRIPTION
@porty and I have been hacking on a fix for https://github.com/buildkite/elastic-ci-stack-for-aws/issues/81

It adds an s3 bucket that contains a tarball for each pipeline that can be `docker load`'ed. Its very much batteries included, all a project should do is nominate a step to save all built layers by setting `DOCKER_CACHE_IMAGES_PUSH=true`. Ideally this is done on master.

pre-commit:
- every step will fetch s3:://cache-bucket/$pipeline.images, which is a list of layer hashes contained in s3://cache-bucket/$pipeline.tar.gz
- if any of the layer hashes are missing, fetch the tarball and `docker load`

post-commit in one step, probably on master only
- work out all the layers used by all docker containers tagged with the buildkite id (should be everything built in this step)
- compare that with the contents of s3://cache-bucket/$pipeline.images
- if the image list is different `docker save` all of the images into s3://cache-bucket/$pipeline.tar.gz and update s3://cache-bucket/$pipeline.images

On both sides if the machine already has fetched all of the required layers both the save and load steps skip, so the fast path is really fast. The slow path, where the cache needs to be fetched is quite a bit faster, fetching from s3 is pretty speedy compared to pulling and building.

_Work in progress_: Still need to do a bunch of testing.
