### PR TITLE
Bumping docker-compose to 1.8.1

### DIFF
--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -31,7 +31,7 @@ sudo cp /tmp/conf/docker/docker.conf /etc/sysconfig/docker
 sudo chkconfig docker on
 
 echo "Downloading docker-compose..."
-sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/1.8.0/docker-compose-Linux-x86_64
+sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/1.8.1/docker-compose-Linux-x86_64
 sudo chmod +x /usr/bin/docker-compose
 docker-compose --version
 


### PR DESCRIPTION
Docker released [docker-compose 1.8.1](https://github.com/docker/compose/releases/tag/1.8.1) a week ago and it has some bug fixes for some issues that we are seeing regularly.  