### PR TITLE
Correct scaling up logic 

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -36,7 +36,7 @@ Resources:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
       Namespace: Buildkite
-      Statistic: Maximum
+      Statistic: Minimum
       Period: 60
       EvaluationPeriods: 1
       Threshold: 0


### PR DESCRIPTION
It looks like the scale up logic is incorrect. We currently scale if even if there is an agent that is free but has yet to pick the job off the queue.

We inject metrics every 15 seconds by default into cloudwatch as per:

https://github.com/buildkite/buildkite-cloudwatch-metrics-publisher/blob/master/templates/cloudformation.yml#L45

Having an alarm of maximum over that 60 seconds will always trigger an alarm and a scale up event. 

What this will mean is that agents will spin up to max-agent size quickly even though those agents are in fact idle.

Changing the scale up to minimum will mean that we will only scale up if there is a scheduled job that hasnt been picked up by an agent because the agent is busy doing other builds. 
