### PR TITLE
Added feature to copy authorized_users from specified s3 bucket path

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -32,6 +32,7 @@ Metadata:
         - SecretsBucket
         - ArtifactsBucket
         - AuthorizedUsersUrl
+        - AuthorizedUsersS3Path
         - BootstrapScriptUrl
         - RootVolumeSize
 
@@ -96,7 +97,12 @@ Parameters:
     Default: ""
 
   AuthorizedUsersUrl:
-    Description: Optional - S3 url to periodically download ssh authorized_keys from
+    Description: Optional - http(s) url to periodically download ssh authorized_keys from
+    Type: String
+    Default: ""
+
+  AuthorizedUsersS3Path:
+    Description: Optional - S3 path to periodically copy ssh authorized_keys from
     Type: String
     Default: ""
 
@@ -405,6 +411,26 @@ Resources:
                 cat << EOF > /etc/cron.hourly/authorized_keys
                 curl --silent -f "$(AuthorizedUsersUrl)" > /tmp/authorized_keys
                 mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
+                chmod 600 /home/ec2-user/.ssh/authorized_keys
+                chown ec2-user: /home/ec2-user/.ssh/authorized_keys
+                EOF
+
+                chmod +x /etc/cron.hourly/authorized_keys
+
+                /etc/cron.hourly/authorized_keys
+
+            04-fetch-and-merge-authorized-users-s3:
+              test: test -n "$(AuthorizedUsersS3Path)"
+              command: |
+                #!/bin/bash -eu
+
+                cat << EOF > /etc/cron.hourly/authorized_keys
+                aws s3 cp "$(AuthorizedUsersS3Path)" /tmp/authorized_keys
+
+                touch /home/ec2-user/.ssh/authorized_keys
+                cp /home/ec2-user/.ssh/authorized_keys /tmp/original_keys
+                (cat /tmp/original_keys; echo; cat /tmp/authorized_keys; echo) | sort | uniq > /home/ec2-user/.ssh/authorized_keys
+
                 chmod 600 /home/ec2-user/.ssh/authorized_keys
                 chown ec2-user: /home/ec2-user/.ssh/authorized_keys
                 EOF

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -411,7 +411,6 @@ Resources:
                 esac
 
                 mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
-                
                 chmod 600 /home/ec2-user/.ssh/authorized_keys
                 chown ec2-user: /home/ec2-user/.ssh/authorized_keys
                 EOF

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -32,7 +32,6 @@ Metadata:
         - SecretsBucket
         - ArtifactsBucket
         - AuthorizedUsersUrl
-        - AuthorizedUsersS3Path
         - BootstrapScriptUrl
         - RootVolumeSize
 
@@ -97,12 +96,7 @@ Parameters:
     Default: ""
 
   AuthorizedUsersUrl:
-    Description: Optional - http(s) url to periodically download ssh authorized_keys from
-    Type: String
-    Default: ""
-
-  AuthorizedUsersS3Path:
-    Description: Optional - S3 path to periodically copy ssh authorized_keys from
+    Description: Optional - http(s) url or S3 path to periodically download ssh authorized_keys from
     Type: String
     Default: ""
 
@@ -409,23 +403,12 @@ Resources:
                 #!/bin/bash -eu
 
                 cat << EOF > /etc/cron.hourly/authorized_keys
-                curl --silent -f "$(AuthorizedUsersUrl)" > /tmp/authorized_keys
-                mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
-                chmod 600 /home/ec2-user/.ssh/authorized_keys
-                chown ec2-user: /home/ec2-user/.ssh/authorized_keys
-                EOF
-
-                chmod +x /etc/cron.hourly/authorized_keys
-
-                /etc/cron.hourly/authorized_keys
-
-            04-fetch-and-merge-authorized-users-s3:
-              test: test -n "$(AuthorizedUsersS3Path)"
-              command: |
-                #!/bin/bash -eu
-
-                cat << EOF > /etc/cron.hourly/authorized_keys
-                aws s3 cp "$(AuthorizedUsersS3Path)" /tmp/authorized_keys
+                case "$(AuthorizedUsersUrl)" in
+                    s3://*)
+                      aws s3 cp "$(AuthorizedUsersUrl)" /tmp/authorized_keys;;
+                    *)
+                      curl --silent -f "$(AuthorizedUsersUrl)" > /tmp/authorized_keys;;
+                esac
 
                 if [ ! -f /home/ec2-user/.ssh/original_authorized_keys ]; then
                    cp /home/ec2-user/.ssh/authorized_keys /home/ec2-user/.ssh/original_authorized_keys

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -427,9 +427,11 @@ Resources:
                 cat << EOF > /etc/cron.hourly/authorized_keys
                 aws s3 cp "$(AuthorizedUsersS3Path)" /tmp/authorized_keys
 
-                touch /home/ec2-user/.ssh/authorized_keys
-                cp /home/ec2-user/.ssh/authorized_keys /tmp/original_keys
-                (cat /tmp/original_keys; echo; cat /tmp/authorized_keys; echo) | sort | uniq > /home/ec2-user/.ssh/authorized_keys
+                if [ ! -f /home/ec2-user/.ssh/original_authorized_keys ]; then
+                   cp /home/ec2-user/.ssh/authorized_keys /home/ec2-user/.ssh/original_authorized_keys
+                fi
+
+                (cat /tmp/authorized_keys; echo; cat /home/ec2-user/.ssh/original_authorized_keys; echo) | sort | uniq > /home/ec2-user/.ssh/authorized_keys
 
                 chmod 600 /home/ec2-user/.ssh/authorized_keys
                 chown ec2-user: /home/ec2-user/.ssh/authorized_keys

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -410,12 +410,8 @@ Resources:
                       curl --silent -f "$(AuthorizedUsersUrl)" > /tmp/authorized_keys;;
                 esac
 
-                if [ ! -f /home/ec2-user/.ssh/original_authorized_keys ]; then
-                   cp /home/ec2-user/.ssh/authorized_keys /home/ec2-user/.ssh/original_authorized_keys
-                fi
-
-                (cat /tmp/authorized_keys; echo; cat /home/ec2-user/.ssh/original_authorized_keys; echo) | sort | uniq > /home/ec2-user/.ssh/authorized_keys
-
+                mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
+                
                 chmod 600 /home/ec2-user/.ssh/authorized_keys
                 chown ec2-user: /home/ec2-user/.ssh/authorized_keys
                 EOF


### PR DESCRIPTION
Solved 2 problems:
1. Instead of using http(s), I can use the existing bucket to store authorized_users, e.g. use the secrets bucket
2. Merge with the local authorized_users instead of override, to allow login with the private key which used to create the EC2 instance.
