### PR TITLE
Only use two subnets/azs

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -473,7 +473,7 @@ Resources:
     Properties:
       VPCZoneIdentifier: !If [
         "CreateVpcResources",
-        [ $(Subnet0), $(Subnet1), $(Subnet2) ],
+        [ $(Subnet0), $(Subnet1) ],
         $(Subnets)
       ]
       LaunchConfigurationName: $(AgentLaunchConfiguration)

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -18,7 +18,7 @@ Resources:
         ]
         Subnets: !If [
           "CreateVpcResources",
-          "$(Subnet0),$(Subnet1),$(Subnet2)",
+          "$(Subnet0),$(Subnet1)",
           !Join [ ",", $(Subnets) ]
         ]
       Tags:

--- a/templates/vpc.yml
+++ b/templates/vpc.yml
@@ -47,18 +47,6 @@ Resources:
       CidrBlock: 10.0.2.0/24
       VpcId: $(Vpc)
 
-  Subnet2:
-    Type: AWS::EC2::Subnet
-    Condition: CreateVpcResources
-    Properties:
-      AvailabilityZone: !If [
-        "UseSpecifiedAvailabilityZones",
-        !Select [ 2, $(AvailabilityZones) ],
-        !Select [ 2, !GetAZs '$(AWS::Region)' ]
-      ]
-      CidrBlock: 10.0.3.0/24
-      VpcId: $(Vpc)
-
   Routes:
     Type: AWS::EC2::RouteTable
     Condition: CreateVpcResources
@@ -85,11 +73,4 @@ Resources:
     Condition: CreateVpcResources
     Properties:
       SubnetId: $(Subnet1)
-      RouteTableId: $(Routes)
-
-  Subnet2Routes:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Condition: CreateVpcResources
-    Properties:
-      SubnetId: $(Subnet2)
       RouteTableId: $(Routes)


### PR DESCRIPTION
us-west-1 only has two availability zones, so attempting to create a stack there fails. This drops back to two subnets, which should be deployable everywhere.

the exact error is:

```
    Subnet2 Template error: Fn::Select cannot select nonexistent value at index 2
```

I'm probably being really dumb and there is some super obvious solution to this that I'm not seeing.
