### PR TITLE
added support for global env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The stack has a `SecretsBucket` parameter which will allow your build agents to 
 The secrets bucket can contain the following files:
 
 * `/private_ssh_key` - An optional private key to use for Git SSH operations when there is no pipeline-specific key present
+* `/env` - An optional bash script to use as a global [agent environment hook](https://buildkite.com/docs/agent/hooks)
 * `/{pipeline-slug}/env` - An optional bash script to use as an [agent environment hook](https://buildkite.com/docs/agent/hooks)
 * `/{pipeline-slug}/private_ssh_key` - An optional pipeline-specific private key to use for Git SSH operations
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ The stack has a `SecretsBucket` parameter which will allow your build agents to 
 
 The secrets bucket can contain the following files:
 
-* `/private_ssh_key` - An optional private key to use for Git SSH operations when there is no pipeline-specific key present
 * `/env` - An optional bash script to use as a global [agent environment hook](https://buildkite.com/docs/agent/hooks)
+* `/private_ssh_key` - An optional private key to use for Git SSH operations when there is no pipeline-specific key present
 * `/{pipeline-slug}/env` - An optional bash script to use as an [agent environment hook](https://buildkite.com/docs/agent/hooks)
 * `/{pipeline-slug}/private_ssh_key` - An optional pipeline-specific private key to use for Git SSH operations
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -60,14 +60,14 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   fi
   echo
 
-  if s3_exists "$env_url" ; then
-    echo "Downloading env from $env_url"
-    eval "$(s3_download $env_url)"
-    echo
-  fi
   if s3_exists "$shared_env_url" ; then
     echo "Downloading shared env from $shared_env_url"
     eval "$(s3_download $shared_env_url)"
+    echo
+  fi
+  if s3_exists "$env_url" ; then
+    echo "Downloading env from $env_url"
+    eval "$(s3_download $env_url)"
     echo
   fi
 fi

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -26,7 +26,7 @@ s3_download() {
 echo "~~~ Setting up the environment"
 
 echo "Sourcing CloudFormation environment..."
-eval "$(cat ~/cfn-env)"
+source ~/cfn-env
 echo
 
 echo "Starting an SSH Agent..."

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -63,8 +63,9 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   if s3_exists "$env_url" ; then
     echo "Downloading env from $env_url"
     eval "$(s3_download $env_url)"
-  elif s3_exists "$shared_env_url" ; then
-    echo "Downloading env from $shared_env_url"
+  fi
+  if s3_exists "$shared_env_url" ; then
+    echo "Downloading shared env from $shared_env_url"
     eval "$(s3_download $shared_env_url)"
   fi
   echo

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -44,6 +44,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   legacy_ssh_key_url="${secrets_url_base}/id_rsa_github"
   shared_ssh_key_url="s3://${BUILDKITE_SECRETS_BUCKET}/${SHARED_SSH_KEY_NAME:-private_ssh_key}"
   env_url="${secrets_url_base}/env"
+  shared_env_url="s3://${BUILDKITE_SECRETS_BUCKET}/env"
 
   if s3_exists "$ssh_key_url" ; then
     echo "Downloading ssh key from $ssh_key_url"
@@ -62,8 +63,11 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   if s3_exists "$env_url" ; then
     echo "Downloading env from $env_url"
     eval "$(s3_download $env_url)"
-    echo
+  elif s3_exists "$shared_env_url" ; then
+    echo "Downloading env from $shared_env_url"
+    eval "$(s3_download $shared_env_url)"
   fi
+  echo
 fi
 
 echo "Waiting for Docker..."

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -62,12 +62,12 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
 
   if s3_exists "$shared_env_url" ; then
     echo "Downloading shared env from $shared_env_url"
-    eval "$(s3_download $shared_env_url)"
+    source "<(s3_download $shared_env_url)"
     echo
   fi
   if s3_exists "$env_url" ; then
     echo "Downloading env from $env_url"
-    eval "$(s3_download $env_url)"
+    source "<(s3_download $env_url)"
     echo
   fi
 fi

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -63,12 +63,13 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   if s3_exists "$env_url" ; then
     echo "Downloading env from $env_url"
     eval "$(s3_download $env_url)"
+    echo
   fi
   if s3_exists "$shared_env_url" ; then
     echo "Downloading shared env from $shared_env_url"
     eval "$(s3_download $shared_env_url)"
+    echo
   fi
-  echo
 fi
 
 echo "Waiting for Docker..."


### PR DESCRIPTION
Docker credentials, for example, are usually the same across all repos.

Same with Nexus credentials and others.

Right now I'm duplicating the file across all pipelines, this is painful, but not as painful as it will be if the credentials change one day for whatever reason...

I think this might be helpful.