### PR TITLE
Fix example command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ aws cloudformation create-stack \
   --stack-name buildkite \
   --template-url "https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json" \
   --capabilities CAPABILITY_IAM \
-  --parameters <(cat config.json)
+  --parameters $(cat config.json)
 ```
 
 If you’d prefer to use this repo or build it yourself, clone it and run the following commands:


### PR DESCRIPTION
<( command ) is different and would be used in place of a filename.