### PR TITLE
Set a region for Cloudwatch Logs

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -332,7 +332,7 @@ Resources:
                 cwlogs = cwlogs
                 [default]
                 region = $(AWS::Region)
-              mode: 000444
+              mode: "000444"
               owner: root
               group: root
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -327,14 +327,14 @@ Resources:
         config:
           files:
             /etc/awslogs/awscli.conf:
-            content: |
-              [plugins]
-              cwlogs = cwlogs
-              [default]
-              region = $(AWS::Region)
-            mode: 000444
-            owner: root
-            group: root
+              content: |
+                [plugins]
+                cwlogs = cwlogs
+                [default]
+                region = $(AWS::Region)
+              mode: 000444
+              owner: root
+              group: root
 
           commands:
             01-write-buildkite-env:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -325,6 +325,17 @@ Resources:
       # see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html
       AWS::CloudFormation::Init:
         config:
+          files:
+            /etc/awslogs/awscli.conf:
+            content: |
+              [plugins]
+              cwlogs = cwlogs
+              [default]
+              region = $(AWS::Region)
+            mode: 000444
+            owner: root
+            group: root
+
           commands:
             01-write-buildkite-env:
               command: |


### PR DESCRIPTION
Add an awscli.conf that sets the region for cloudwatch logs. Without this, logs are always created in us-east-1