### PR TITLE
Easier ECR integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ rm id_rsa_buildkite*
 
 ## Docker Registry Support
 
-If you want to push or pull from registries such as Docker Hub or Quay you can use the `env` file in your secrets bucket to export the following environment variables:
+If you want to push or pull from registries such as [Docker Hub](https://hub.docker.com/) or [Quay](https://quay.io/) you can use the `env` file in your secrets bucket to export the following environment variables:
 
 * `DOCKER_LOGIN_USER="the-user-name"`
 * `DOCKER_LOGIN_PASSWORD="the-password"`
@@ -177,13 +177,11 @@ If you want to push or pull from registries such as Docker Hub or Quay you can u
 
 Setting these will perform a `docker login` before each pipeline step is run, allowing you to `docker push` to them from within your build scripts.
 
-AWS ECR login can be performed by exporting the following variable from your `env` file or pipeline’s build steps:
+If you are using [Amazon ECR](https://aws.amazon.com/ecr/) you can set the `ECRAccessPolicy` parameter to the stack to either `readonly`, `poweruser`, or `full` depending on [the access level you want](http://docs.aws.amazon.com/AmazonECR/latest/userguide/ecr_managed_policies.html) your builds to have
 
-* `AWS_ECR_LOGIN=true`
+You can disable this in individual pipelines by setting `AWS_ECR_LOGIN=false`.
 
-If you want to login to an ECR server on another AWS account, use the following environment variable instead:
-
-* `AWS_ECR_LOGIN_REGISTRY_IDS="id1,id2,id3"`
+If you want to login to an ECR server on another AWS account, you can set `AWS_ECR_LOGIN_REGISTRY_IDS="id1,id2,id3"`.
 
 ## Updating Your Stack
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -175,6 +175,15 @@ Parameters:
     Description: Optional - The AMI to use, otherwise uses the mapping built in
     Default: ""
 
+  AccessLevelForElasticContainerRegistry:
+    Type: String
+    AllowedValues:
+      - none
+      - readonly
+      - poweruser
+      - full
+    Default: "poweruser"
+
 Conditions:
     UseSpotInstances:
       !Not [ !Equals [ $(SpotPrice), 0 ] ]
@@ -203,6 +212,13 @@ Conditions:
     UseSpecifiedIamPolicies:
       !Not [ !Equals [ !Join [ "", $(ManagedPolicyArns) ], "" ]  ]
 
+Mappings:
+  ECRManagedPolicy:
+    none      : { Policy: '$(AWS::NoValue)' }
+    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess' }
+    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2PowerUserAccess' }
+    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2FullAccess' }
+
 Resources:
   # Allow ec2 instances to assume a role and be granted the IAMPolicies
   IAMInstanceProfile:
@@ -214,7 +230,9 @@ Resources:
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns: !If [ "UseSpecifiedIamPolicies", $(ManagedPolicyArns), '$(AWS::NoValue)' ]
+      ManagedPolicyArns:
+         - !If [ "UseSpecifiedIamPolicies", $(ManagedPolicyArns), '$(AWS::NoValue)' ]
+         - $(ECRManagedPolicy[AccessLevelForElasticContainerRegistry])
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -44,6 +44,11 @@ Metadata:
         - ScaleDownAdjustment
         - AutoscaleStrategy
 
+      - Label:
+          default: Docker Registry Configuration
+        Parameters:
+        - ECRAccessPolicy
+
 Parameters:
   KeyName:
     Description: The ssh keypair used to access the buildkite instances
@@ -175,14 +180,15 @@ Parameters:
     Description: Optional - The AMI to use, otherwise uses the mapping built in
     Default: ""
 
-  ElasticContainerRegistryAccess:
+  ECRAccessPolicy:
     Type: String
+    Description: The ECR access policy to give container instances
     AllowedValues:
       - none
       - readonly
       - poweruser
       - full
-    Default: "poweruser"
+    Default: "none"
 
 Conditions:
     UseSpotInstances:
@@ -213,7 +219,7 @@ Conditions:
       !Not [ !Equals [ !Join [ "", $(ManagedPolicyArns) ], "" ]  ]
 
     UseECR:
-      !Not [ !Equals [ $(ElasticContainerRegistryAccess), "none" ] ]
+      !Not [ !Equals [ $(ECRAccessPolicy), "none" ] ]
 
 Mappings:
   ECRManagedPolicy:
@@ -234,7 +240,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
          - !If [ "UseSpecifiedIamPolicies", $(ManagedPolicyArns), '$(AWS::NoValue)' ]
-         - !If [ "UseECR", "$(ECRManagedPolicy[$(ElasticContainerRegistryAccess)][Policy])", '$(AWS::NoValue)' ]
+         - !If [ "UseECR", "$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])", '$(AWS::NoValue)' ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -223,6 +223,7 @@ Conditions:
 
 Mappings:
   ECRManagedPolicy:
+    none      : { Policy: 'none' }
     readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
     poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
     full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -217,9 +217,9 @@ Conditions:
 
 Mappings:
   ECRManagedPolicy:
-    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess' }
-    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2PowerUserAccess' }
-    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2FullAccess' }
+    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
 
 Resources:
   # Allow ec2 instances to assume a role and be granted the IAMPolicies

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -234,7 +234,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
          - !If [ "UseSpecifiedIamPolicies", $(ManagedPolicyArns), '$(AWS::NoValue)' ]
-         - !If [ "UseECR", "$(ECRManagedPolicy[ElasticContainerRegistryAccess])", '$(AWS::NoValue)' ]
+         - !If [ "UseECR", "$(ECRManagedPolicy[$(ElasticContainerRegistryAccess)][Policy])", '$(AWS::NoValue)' ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -175,7 +175,7 @@ Parameters:
     Description: Optional - The AMI to use, otherwise uses the mapping built in
     Default: ""
 
-  AccessLevelForElasticContainerRegistry:
+  ElasticContainerRegistryAccess:
     Type: String
     AllowedValues:
       - none
@@ -212,6 +212,9 @@ Conditions:
     UseSpecifiedIamPolicies:
       !Not [ !Equals [ !Join [ "", $(ManagedPolicyArns) ], "" ]  ]
 
+    UseECR:
+      !Not [ !Equals [ $(ElasticContainerRegistryAccess), "none" ] ]
+
 Mappings:
   ECRManagedPolicy:
     none      : { Policy: '$(AWS::NoValue)' }
@@ -232,7 +235,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
          - !If [ "UseSpecifiedIamPolicies", $(ManagedPolicyArns), '$(AWS::NoValue)' ]
-         - $(ECRManagedPolicy[AccessLevelForElasticContainerRegistry])
+         - $(ECRManagedPolicy[ElasticContainerRegistryAccess])
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -363,11 +366,18 @@ Resources:
                 BUILDKITE_STACK_NAME="$(AWS::StackName)"
                 BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)"
                 BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)"
-                AWS_DEFAULT_REGION="$(AWS::Region)"
-                AWS_REGION="$(AWS::Region)"
+                AWS_DEFAULT_REGION=$(AWS::Region)
+                AWS_REGION=$(AWS::Region)
                 EOF
 
                 chown buildkite-agent /var/lib/buildkite-agent/cfn-env
+
+
+            01-write-ecr-env:
+              condition: UseECR
+              command: |
+                #!/bin/bash -eu
+                printf "AWS_ECR_LOGIN=1\n" >> /var/lib/buildkite-agent/cfn-env
 
             02-restart-docker:
               command: |

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -217,7 +217,6 @@ Conditions:
 
 Mappings:
   ECRManagedPolicy:
-    none      : { Policy: '$(AWS::NoValue)' }
     readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess' }
     poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2PowerUserAccess' }
     full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2FullAccess' }
@@ -235,7 +234,7 @@ Resources:
     Properties:
       ManagedPolicyArns:
          - !If [ "UseSpecifiedIamPolicies", $(ManagedPolicyArns), '$(AWS::NoValue)' ]
-         - $(ECRManagedPolicy[ElasticContainerRegistryAccess])
+         - !If [ "UseECR", "$(ECRManagedPolicy[ElasticContainerRegistryAccess])", '$(AWS::NoValue)' ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
At the minute it's a little bit tricky to get ECR integration working, this makes it more seamless by adding a parameter called `ElasticContainerRegistryAccess` that is either `none`, `readonly`, `poweruser` or `full`. If this is set, everything else will be setup for ECR to work out of the box. 

Remaining todo:

 * [x] Document the new parameter
