### PR TITLE
Deprecate BUILDKITE_SECRETS_KEY

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -15,6 +15,9 @@ s3_download() {
   local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
 
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
+    echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
+    echo "AWS KMS is now the supported method for decrypting files from your secrets bucket."
+    echo "See https://github.com/buildkite/elastic-ci-stack-for-aws#secrets-bucket-support"
     aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
   elif [[ -n "${BUILDKITE_USE_KMS:-}" ]] ; then
     aws_s3_args+=("--sse" "aws:kms")


### PR DESCRIPTION
Related to #174, this deprecates the use of `BUILDKITE_SECRETS_KEY`