### PR TITLE
Update docs to point to latest released stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Features:
 
 See the [Elastic CI Stack for AWS guide](https://buildkite.com/docs/guides/elastic-ci-stack-aws) for a step-by-step guide, or jump straight in:
 
-[![Launch Buildkite AWS Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json)
+[![Launch Buildkite AWS Stack v1.1.1](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/v1.1.1/aws-stack.json)
 
-(See [Versions](#versions) for the beta stack, or older versions)
+Current version is v1.1.1. See [Releases](https://github.com/buildkite/elastic-ci-stack-for-aws/releases) for older releases, or [Versions](#versions) for development version
 
-> Although the stack will create it's own VPC by default, we highly recommend following best practice by setting up a separate development AWS account and using role switching and consolidated billing—see the [Delegate Access Across AWS Accounts tutorial](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more information.
+> Although the stack w.ill create it's own VPC by default, we highly recommend following best practice by setting up a separate development AWS account and using role switching and consolidated billing—see the [Delegate Access Across AWS Accounts tutorial](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more information.
 
 If you'd like to use the [AWS CLI](https://aws.amazon.com/cli/), download [`config.json.example`](config.json.example), rename it to `config.json`, and then run the below command:
 
@@ -60,7 +60,7 @@ If you'd like to use the [AWS CLI](https://aws.amazon.com/cli/), download [`conf
 aws cloudformation create-stack \
   --output text \
   --stack-name buildkite \
-  --template-url "https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json" \
+  --template-url "https://s3.amazonaws.com/buildkite-aws-stack/v1.1.1/aws-stack.json" \
   --capabilities CAPABILITY_IAM \
   --parameters $(cat config.json)
 ```
@@ -169,9 +169,11 @@ If you want to login to an ECR server on another AWS account, you can set `AWS_E
 
 ## Versions
 
-The latest stable version of the stack is published to `https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json`, however we also publish a stack for each commit in the `master` branch in the form of `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.json` in case you need to use an older version.
+We recommend running the latest release, which is a url in the form of `https://s3.amazonaws.com/buildkite-aws-stack/${VERSION}/aws-stack.json` that can be found on the [releases page](https://github.com/buildkite/elastic-ci-stack-for-aws/releases).
 
-Branches are published in the form of `https://s3.amazonaws.com/buildkite-aws-stack/${BRANCH}/aws-stack.json`. Prior to merging to master, new features are often available in `https://s3.amazonaws.com/buildkite-aws-stack/beta/aws-stack.json`.
+The latest build of the stack is published to `https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json`, along with a version for each commit in the form of `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.json`. 
+
+Branches are published in the form of `https://s3.amazonaws.com/buildkite-aws-stack/${BRANCH}/aws-stack.json`. 
 
 ## Updating Your Stack
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -2,17 +2,28 @@
 
 set -eu -o pipefail
 
-s3_exists() {
-  env -i aws s3 ls "$1" --summarize --human-readable --region "$AWS_DEFAULT_REGION" | \
-    # `s3 ls` does wildcard matching, so `private_ssh_key` matches `private_ssh_key_old`, e.g.:
-    # 2016-03-01 17:40:53    1.6 KiB private_ssh_key_old
-    #
-    # So we need to grep the output for an exact filename match
-    grep "$(basename "$1")\$"
+s3_download() {
+  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
+  local bucket="$1"
+  local key="$2"
+  local bucket_region
+
+  if ! bucket_region=$(s3_bucket_region "$1") ; then
+    return $?
+  fi
+
+  if ! env -i aws s3api head-object --bucket "$bucket" --key "$key" 1>/dev/null ; then
+    return 1
+  fi
 }
 
 s3_download() {
-  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
+  local bucket="$1"
+  local key="$2"
+  local bucket_region
+  local aws_s3_args=("--quiet" "--region=$bucket_region")
+
+  bucket_region=$(s3_bucket_region "$1") || exit 1
 
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
     aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
@@ -41,31 +52,34 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
 
   # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
-  secrets_url_base="s3://${BUILDKITE_SECRETS_BUCKET}/${secrets_prefix}"
-  ssh_key_url="${secrets_url_base}/${SSH_KEY_NAME:-private_ssh_key}"
-  legacy_ssh_key_url="${secrets_url_base}/id_rsa_github"
-  shared_ssh_key_url="s3://${BUILDKITE_SECRETS_BUCKET}/${SHARED_SSH_KEY_NAME:-private_ssh_key}"
-  env_url="${secrets_url_base}/env"
 
-  if s3_exists "$ssh_key_url" ; then
-    echo "Downloading ssh key from $ssh_key_url"
-    ssh-add <(s3_download "$ssh_key_url")
-  elif s3_exists "$legacy_ssh_key_url" ; then
-    echo "Downloading ssh key from $legacy_ssh_key_url"
-    ssh-add <(s3_download "$legacy_ssh_key_url")
-  elif s3_exists "$shared_ssh_key_url" ; then
-    echo "Downloading ssh key from $shared_ssh_key_url"
-    ssh-add <(s3_download "$shared_ssh_key_url")
-  else
-    echo "No SSH keys found in s3://${BUILDKITE_SECRETS_BUCKET}"
-  fi
-  echo
+  # Locations to check for ssh keys
+  ssh_key_paths=(
+    "$secrets_prefix/${SSH_KEY_NAME:-private_ssh_key}"
+    "$secrets_prefix/id_rsa_github"
+    "${SHARED_SSH_KEY_NAME:-private_ssh_key}"
+    "id_rsa_github"
+  )
 
-  if s3_exists "$env_url" ; then
-    echo "Downloading env from $env_url"
-    eval "$(s3_download $env_url)"
-    echo
-  fi
+  for key in ${ssh_key_paths[*]} ; do
+    if s3_exists "${BUILDKITE_SECRETS_BUCKET}" "$key" ; then
+      echo "Downloading ssh-key $key"
+      ssh-add <(s3_download "${BUILDKITE_SECRETS_BUCKET}" "$key")
+      break
+    fi
+  done
+
+  env_paths=(
+    "env"
+    "${secrets_prefix}/env"
+  )
+
+  for key in ${env_paths[*]} ; do
+    if s3_exists "${BUILDKITE_SECRETS_BUCKET}" "$key" ; then
+      echo "Downloading env $key"
+      eval "$(s3_download "${BUILDKITE_SECRETS_BUCKET}" "$key")"
+    fi
+  done
 fi
 
 echo "Waiting for Docker..."

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -64,7 +64,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   for key in ${ssh_key_paths[*]} ; do
     if s3_exists "${BUILDKITE_SECRETS_BUCKET}" "$key" ; then
       echo "Downloading ssh-key $key"
-      ssh-add <(s3_download "${BUILDKITE_SECRETS_BUCKET}" "$key")
+      SSH_ASKPASS="/bin/false" ssh-add <(s3_download "${BUILDKITE_SECRETS_BUCKET}" "$key")
       break
     fi
   done


### PR DESCRIPTION
Based on discussion in Slack, this updates the README to point to the releases page. This means we can apply some quality control to code that hits master prior to release and public consumption. 