### PR TITLE
Fix issue #177

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -120,7 +120,7 @@ aws cloudformation create-stack \
   --stack-name "$stack_name" \
   --disable-rollback \
   --template-body "file://${PWD}/build/aws-stack.json" \
-  --capabilities CAPABILITY_IAM \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --parameters "$(cat config.json)"
 
 echo "--- Waiting for stack to complete"

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -73,7 +73,7 @@ cat << EOF > config.json
   },
   {
     "ParameterKey": "InstanceType",
-    "ParameterValue": "t2.micro"
+    "ParameterValue": "t2.nano"
   },
   {
     "ParameterKey": "SecretsBucket",
@@ -98,6 +98,10 @@ cat << EOF > config.json
   {
     "ParameterKey": "AgentsPerInstance",
     "ParameterValue": "3"
+  },
+  {
+    "ParameterKey": "ECRAccessPolicy",
+    "ParameterValue": "readonly"
   }
 ]
 EOF

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ aws cloudformation create-stack \
   --output text \
   --stack-name buildkite \
   --template-url "https://s3.amazonaws.com/buildkite-aws-stack/v1.1.1/aws-stack.json" \
-  --capabilities CAPABILITY_IAM \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --parameters $(cat config.json)
 ```
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -253,6 +253,13 @@ Resources:
     Condition: UseECR
     Properties:
       ManagedPolicyArns: !If [ UseECR, ['$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])'], '$(AWS::NoValue)' ]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ ec2.amazonaws.com ]
+            Action: sts:AssumeRole
+      Path: /
 
   IAMPolicies:
     Type: AWS::IAM::Policy

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -170,14 +170,14 @@ Parameters:
     Description: Optional - Existing security group to associate the container instances. Creates one by default.
     Default: ""
 
-  ManagedPolicyArns:
-    Type: CommaDelimitedList
-    Description: Optional - ARNs of existing managed IAM policies to associate with the container instances.
-    Default: ""
-
   ImageId:
     Type: String
     Description: Optional - The AMI to use, otherwise uses the mapping built in
+    Default: ""
+
+  ManagedPolicyARN:
+    Type: String
+    Description: Optional - ARN of an existing managed IAM policies to associate with instances
     Default: ""
 
   ECRAccessPolicy:
@@ -215,8 +215,8 @@ Conditions:
     CreateMetricsStack:
       !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ]
 
-    UseSpecifiedIamPolicies:
-      !Not [ !Equals [ !Join [ "", $(ManagedPolicyArns) ], "" ]  ]
+    UseManagedPolicyARN:
+      !Not [ !Equals [ $(ManagedPolicyARN), "" ] ]
 
     UseECR:
       !Not [ !Equals [ $(ECRAccessPolicy), "none" ] ]
@@ -234,25 +234,14 @@ Resources:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
-      Roles: !If [ UseECR, [ $(IAMRole), $(ECRAccessRole) ], [ $(IAMRole) ] ]
+      Roles: [ $(IAMRole) ]
 
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns: !If [ UseSpecifiedIamPolicies, $(ManagedPolicyArns), '$(AWS::NoValue)' ]
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: [ ec2.amazonaws.com ]
-            Action: sts:AssumeRole
-      Path: /
-
-  ECRAccessRole:
-    Type: AWS::IAM::Role
-    Condition: UseECR
-    Properties:
-      ManagedPolicyArns: !If [ UseECR, ['$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])'], '$(AWS::NoValue)' ]
+      ManagedPolicyArns:
+        - !If [ UseManagedPolicyARN, $(ManagedPolicyARN), '$(AWS::NoValue)' ]
+        - !If [ UseECR, '$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])', '$(AWS::NoValue)' ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -177,12 +177,12 @@ Parameters:
 
   ManagedPolicyARN:
     Type: String
-    Description: Optional - ARN of an existing managed IAM policies to associate with instances
+    Description: Optional - ARN of an existing managed IAM policy that will be attached to the instance role
     Default: ""
 
   ECRAccessPolicy:
     Type: String
-    Description: The ECR access policy to give container instances
+    Description: Optional - The ECR access policy to give container instances
     AllowedValues:
       - none
       - readonly

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -239,6 +239,7 @@ Resources:
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: "$(AWS::StackName)-Role"
       ManagedPolicyArns:
         - !If [ UseManagedPolicyARN, $(ManagedPolicyARN), '$(AWS::NoValue)' ]
         - !If [ UseECR, '$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])', '$(AWS::NoValue)' ]

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -221,12 +221,9 @@ Conditions:
     UseECR:
       !Not [ !Equals [ $(ECRAccessPolicy), "none" ] ]
 
-    UseECRAndSpecifiedIamPolicies:
-      !And [ { Condition: "UseSpecifiedIamPolicies" }, { Condition: "UseECR" } ]
-
 Mappings:
   ECRManagedPolicy:
-    none      : { Policy: 'none' }
+    none      : { Policy: '' }
     readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
     poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
     full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
@@ -237,22 +234,12 @@ Resources:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
-      Roles: [ $(IAMRole) ]
+      Roles: !If [ UseECR, [ $(IAMRole), $(ECRAccessRole) ], [ $(IAMRole) ] ]
 
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns:
-        - !If
-          - UseECRAndSpecifiedIamPolicies
-          - [ $(ManagedPolicyArns), "$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])" ]
-          - !If
-            - UseSpecifiedIamPolicies
-            - [ $(ManagedPolicyArns) ]
-            - !If
-              - UseECR
-              - [ "$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])" ]
-              - $(AWS::NoValue)
+      ManagedPolicyArns: !If [ UseSpecifiedIamPolicies, $(ManagedPolicyArns), '$(AWS::NoValue)' ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
@@ -260,6 +247,12 @@ Resources:
               Service: [ ec2.amazonaws.com ]
             Action: sts:AssumeRole
       Path: /
+
+  ECRAccessRole:
+    Type: AWS::IAM::Role
+    Condition: UseECR
+    Properties:
+      ManagedPolicyArns: !If [ UseECR, ['$(ECRManagedPolicy[$(ECRAccessPolicy)][Policy])'], '$(AWS::NoValue)' ]
 
   IAMPolicies:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
Another attempt at fixing #177. This breaks BC by replacing `ManagedPolicyArns` with `ManagedPolicyARN`. This is because there is no mechanism to merge a list with a single item in CloudFormation.

To mitigate this, I've added a predictable RoleName for the IAMRole (as suggested in #161).