### PR TITLE
Fix issue with s3 cp command source location in environment hook

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -15,8 +15,7 @@ s3_exists() {
 s3_download() {
   local bucket="$1"
   local key="$2"
-  local bucket_region
-  local aws_s3_args=("--quiet" "--region=$bucket_region")
+  local aws_s3_args="--quiet"
 
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
     echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
@@ -27,7 +26,7 @@ s3_download() {
     aws_s3_args+=("--sse" "aws:kms")
   fi
 
-  if ! env -i aws s3 cp ${aws_s3_args[@]} "$1" /dev/stdout ; then
+  if ! env -i aws s3 cp ${aws_s3_args[@]} "s3://$1/$2" /dev/stdout ; then
     exit 1
   fi
 }


### PR DESCRIPTION
The signature for s3_copy() changed but the aws s3 cp command call didn't change to match. This fixes that issue. It also removes the broken bucket_region local var.