### PR TITLE
Fail if a secret key isn't found but a secrets bucket is set

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -65,7 +65,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
     fi
   done
 
-  if [[ -z $key_found ]] ; then
+  if [[ -z "${key_found:-}" ]] ; then
     echo "~~~ :warning: Failed to find an SSH key in secret bucket"
     exit 1
   fi

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -5,18 +5,32 @@ set -eu -o pipefail
 s3_exists() {
   local bucket="$1"
   local key="$2"
+  local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
 
-  echo -n "Checking if $bucket/$key exists: "
-  if ! env -i aws s3api head-object ${aws_s3_args[@]} --bucket "$bucket" --key "$key" 1>/dev/null ; then
+  if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
+    aws_s3_args+=("--sse-customer-algorithm" "AES256" "--sse-customer-key" "${BUILDKITE_SECRETS_KEY}")
+  fi
+
+  echo -n "Checking if :s3: $bucket/$key exists: "
+  if ! output=$(env -i aws s3api head-object ${aws_s3_args[@]} --bucket "$bucket" --key "$key" 1>/dev/null) ; then
+    echo ":no_good: $output"
     return 1
   fi
+  echo ":thumbsup:"
 }
 
 s3_download() {
   local bucket="$1"
   local key="$2"
+  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
 
-  if ! env -i aws s3 cp --quiet ${aws_s3_args[@]} "s3://$1/$2" /dev/stdout ; then
+  if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
+    aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
+  elif [[ "${BUILDKITE_USE_KMS:-true}" =~ ^(true|1)$ ]] ; then
+    aws_s3_args+=("--sse" "aws:kms")
+  fi
+
+  if ! env -i aws s3 cp ${aws_s3_args[@]} "s3://$1/$2" /dev/stdout ; then
     exit 1
   fi
 }
@@ -35,15 +49,10 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   echo "Downloading secrets from ${BUILDKITE_SECRETS_BUCKET}..."
   echo
 
-  aws_s3_args=("--region=$AWS_DEFAULT_REGION")
-
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
     echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
     echo "AWS KMS is now the supported method for decrypting files from your secrets bucket."
     echo "See https://github.com/buildkite/elastic-ci-stack-for-aws#secrets-bucket-support"
-    aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
-  elif [[ "${BUILDKITE_USE_KMS:-true}" =~ ^(true|1)$ ]] ; then
-    aws_s3_args+=("--sse" "aws:kms")
   fi
 
   # Allow environment vars set in Buildkite to override paths

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -3,11 +3,12 @@
 set -eu -o pipefail
 
 s3_exists() {
-  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
+  local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
   local bucket="$1"
   local key="$2"
 
-  if ! env -i aws s3api head-object --bucket "$bucket" --key "$key" 1>/dev/null ; then
+  echo -n "Checking if $bucket/$key exists: "
+  if ! env -i aws s3api head-object ${aws_s3_args[@]} --bucket "$bucket" --key "$key" 1>/dev/null ; then
     return 1
   fi
 }
@@ -15,7 +16,7 @@ s3_exists() {
 s3_download() {
   local bucket="$1"
   local key="$2"
-  local aws_s3_args="--quiet"
+  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
 
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
     echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -3,7 +3,6 @@
 set -eu -o pipefail
 
 s3_exists() {
-  local aws_s3_args=("--region=$AWS_DEFAULT_REGION")
   local bucket="$1"
   local key="$2"
 
@@ -16,18 +15,8 @@ s3_exists() {
 s3_download() {
   local bucket="$1"
   local key="$2"
-  local aws_s3_args=("--quiet" "--region=$AWS_DEFAULT_REGION")
 
-  if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
-    echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
-    echo "AWS KMS is now the supported method for decrypting files from your secrets bucket."
-    echo "See https://github.com/buildkite/elastic-ci-stack-for-aws#secrets-bucket-support"
-    aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
-  elif [[ "${BUILDKITE_USE_KMS:-true}" =~ ^(true|1)$ ]] ; then
-    aws_s3_args+=("--sse" "aws:kms")
-  fi
-
-  if ! env -i aws s3 cp ${aws_s3_args[@]} "s3://$1/$2" /dev/stdout ; then
+  if ! env -i aws s3 cp --quiet ${aws_s3_args[@]} "s3://$1/$2" /dev/stdout ; then
     exit 1
   fi
 }
@@ -45,6 +34,17 @@ echo
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   echo "Downloading secrets from ${BUILDKITE_SECRETS_BUCKET}..."
   echo
+
+  aws_s3_args=("--region=$AWS_DEFAULT_REGION")
+
+  if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
+    echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
+    echo "AWS KMS is now the supported method for decrypting files from your secrets bucket."
+    echo "See https://github.com/buildkite/elastic-ci-stack-for-aws#secrets-bucket-support"
+    aws_s3_args+=("--sse-c" "AES256" "--sse-c-key" "${BUILDKITE_SECRETS_KEY}")
+  elif [[ "${BUILDKITE_USE_KMS:-true}" =~ ^(true|1)$ ]] ; then
+    aws_s3_args+=("--sse" "aws:kms")
+  fi
 
   # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -11,12 +11,10 @@ s3_exists() {
     aws_s3_args+=("--sse-customer-algorithm" "AES256" "--sse-customer-key" "${BUILDKITE_SECRETS_KEY}")
   fi
 
-  echo -n "Checking if :s3: $bucket/$key exists: "
-  if ! output=$(env -i aws s3api head-object ${aws_s3_args[@]} --bucket "$bucket" --key "$key" 1>/dev/null) ; then
-    echo ":no_good: $output"
+  if ! env -i aws s3api head-object ${aws_s3_args[@]} --bucket "$bucket" --key "$key" &>/dev/null ; then
+    echo "$bucket/$key in :s3: doesn't exist :no_good:"
     return 1
   fi
-  echo ":thumbsup:"
 }
 
 s3_download() {
@@ -55,6 +53,8 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
     echo "See https://github.com/buildkite/elastic-ci-stack-for-aws#secrets-bucket-support"
   fi
 
+  echo "~~~ Downloading secrets"
+
   # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"
 
@@ -84,6 +84,8 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
     "env"
     "${secrets_prefix}/env"
   )
+
+  echo "~~~ Downloading env files"
 
   for key in ${env_paths[*]} ; do
     if s3_exists "${BUILDKITE_SECRETS_BUCKET}" "$key" ; then

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -60,9 +60,15 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
     if s3_exists "${BUILDKITE_SECRETS_BUCKET}" "$key" ; then
       echo "Downloading ssh-key $key"
       SSH_ASKPASS="/bin/false" ssh-add <(s3_download "${BUILDKITE_SECRETS_BUCKET}" "$key")
+      key_found=1
       break
     fi
   done
+
+  if [[ -z $key_found ]] ; then
+    echo "~~~ :warning: Failed to find an SSH key in secret bucket"
+    exit 1
+  fi
 
   env_paths=(
     "env"

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -12,7 +12,6 @@ s3_exists() {
   fi
 
   if ! env -i aws s3api head-object ${aws_s3_args[@]} --bucket "$bucket" --key "$key" &>/dev/null ; then
-    echo "$bucket/$key in :s3: doesn't exist :no_good:"
     return 1
   fi
 }
@@ -75,7 +74,7 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
     fi
   done
 
-  if [[ -z "${key_found:-}" ]] ; then
+  if [[ -z "${key_found:-}" ]] && [[ "${BUILDKITE_REPO:]}" =~ ^git ]] ; then
     echo "~~~ :warning: Failed to find an SSH key in secret bucket"
     exit 1
   fi

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -43,16 +43,13 @@ eval "$(ssh-agent -s)"
 echo
 
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
-  echo "Downloading secrets from ${BUILDKITE_SECRETS_BUCKET}..."
-  echo
-
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
     echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
     echo "AWS KMS is now the supported method for decrypting files from your secrets bucket."
     echo "See https://github.com/buildkite/elastic-ci-stack-for-aws#secrets-bucket-support"
   fi
 
-  echo "~~~ Downloading secrets"
+  echo "~~~ Downloading secrets from ${BUILDKITE_SECRETS_BUCKET}"
 
   # Allow environment vars set in Buildkite to override paths
   secrets_prefix="${BUILDKITE_SECRETS_PREFIX:-$BUILDKITE_PIPELINE_SLUG}"

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -5,7 +5,7 @@ set -eu -o pipefail
 # AWS ECR login support
 
 # For logging into the current AWS account’s registry
-if [[ "${AWS_ECR_LOGIN:-true}" =~ ^(true|1)$ ]] ; then
+if [[ "${AWS_ECR_LOGIN:-}" =~ ^(true|1)$ ]] ; then
   echo "~~~ Authenticating with AWS ECR"
   eval "$(aws ecr get-login)"
 fi


### PR DESCRIPTION
Currently if all checks for a private ssh key fail, the checkout process kicks off anyway. This changes that so that it fails. 