### PR TITLE
Refer to chown by full path

### DIFF
--- a/packer/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
+++ b/packer/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
@@ -48,7 +48,7 @@ AGENT_BUILDS_PATH="${BUILDS_PATH}/${AGENT_BUILDS_NAME}"
 # => "/var/lib/buildkite-agent/builds/my-agent-1"
 
 if [[ -e "${AGENT_BUILDS_PATH}" ]]; then
-	chown -R buildkite-agent:buildkite-agent "${AGENT_BUILDS_PATH}"
+	/usr/local/bin/chown -R buildkite-agent:buildkite-agent "${AGENT_BUILDS_PATH}"
 fi
 
 # Manual tests (anybody know a good way to test this?):


### PR DESCRIPTION
Otherwise a script could alias chown to something that would be executed as root.