### PR TITLE
Export env vars set in ~/cfn-vars

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -35,8 +35,9 @@ s3_download() {
 echo "~~~ Setting up the environment"
 
 echo "Sourcing CloudFormation environment..."
-eval "$(cat ~/cfn-env)"
-echo
+set -o allexport
+source ~/cfn-env
+set +o allexport
 
 echo "Starting an SSH Agent..."
 eval "$(ssh-agent -s)"


### PR DESCRIPTION
It appears that the vars set to trigger the ECR login in `~/cfn-vars` aren't getting exported. This applies a bash option that exports any defined vars. 