### PR TITLE
Simplify configuration of fixed size clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ create-stack: config.json build/aws-stack.json extra_tags.json
 	--stack-name $(STACK_NAME) \
 	--disable-rollback \
 	--template-body "file://$(PWD)/build/aws-stack.json" \
-	--capabilities CAPABILITY_IAM \
+	--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
 	--parameters "$$(cat config.json)" \
 	--tags "$$(cat extra_tags.json)"
 
@@ -62,7 +62,7 @@ update-stack: config.json templates/mappings.yml build/aws-stack.json
 	--output text \
 	--stack-name $(STACK_NAME) \
 	--template-body "file://$(PWD)/build/aws-stack.json" \
-	--capabilities CAPABILITY_IAM \
+	--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
 	--parameters "$$(cat config.json)"
 
 toc:

--- a/config.json.example
+++ b/config.json.example
@@ -6,5 +6,13 @@
   {
     "ParameterKey": "BuildkiteAgentToken",
     "ParameterValue": "TokenGoesHere"
+  },
+  {
+    "ParameterKey": "BuildkiteApiAccessToken",
+    "ParameterValue": "ApiTokenGoesHere"
+  },
+  {
+    "ParameterKey": "KeyName",
+    "ParameterValue": "default"
   }
 ]

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -16,6 +16,7 @@ Resources:
 
   AgentScaleUpPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
+    Condition: UseAutoscaling
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
@@ -24,14 +25,16 @@ Resources:
 
   AgentScaleDownPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
+    Condition: UseAutoscaling
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown : 60
+      Cooldown: 60
       ScalingAdjustment: $(ScaleDownAdjustment)
 
   AgentUtilizationAlarmHigh:
    Type: AWS::CloudWatch::Alarm
+   Condition: UseAutoscaling
    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
@@ -48,6 +51,7 @@ Resources:
 
   AgentUtilizationAlarmLow:
    Type: AWS::CloudWatch::Alarm
+   Condition: UseAutoscaling
    Properties:
       AlarmDescription: Scale-down if UnfinishedJobs == 0 for 30 minutes
       MetricName: UnfinishedJobsCount

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -38,11 +38,11 @@ Metadata:
       - Label:
           default: Auto-scaling Configuration
         Parameters:
+        - DesiredSize
         - MinSize
         - MaxSize
         - ScaleUpAdjustment
         - ScaleDownAdjustment
-        - AutoscaleStrategy
 
       - Label:
           default: Docker Registry Configuration
@@ -126,35 +126,35 @@ Parameters:
     Default: ""
 
   InstanceType:
-    Description: The type of instance to use for the agent
+    Description: The type of instance to use for the instances
     Type: String
     Default: t2.nano
     MinLength: 1
 
   SpotPrice:
-    Description: Optional - Spot price to use for the agents. 0 means normal (non-spot) instances are used
+    Description: Optional - Spot price to use for the instances. 0 means normal (non-spot) instances are used
     Type: String
     Default: 0
 
   MaxSize:
-    Description: The maximum number of agents to launch
+    Description: The maximum number of instances to launch
     Type: Number
     Default: 10
     MinValue: 1
 
   MinSize:
-    Description: The minumum number of agents to launch
+    Description: The minumum number of instances to launch
     Type: Number
     Default: 0
 
   ScaleUpAdjustment:
-    Description: The number of agents to adjust by on each scale up event (ScheduledJobsCount > 0 for 1 min)
+    Description: The number of instances to adjust by on each scale up event (ScheduledJobsCount > 0 for 1 min)
     Type: Number
     Default: 5
     MinValue: 0
 
   ScaleDownAdjustment:
-    Description: The number of agents to remove on each scale down event (UnfinishedJobs == 0 for 30 mins)
+    Description: The number of instances to remove on each scale down event (UnfinishedJobs == 0 for 30 mins)
     Type: Number
     Default: -1
     MaxValue: 0
@@ -212,14 +212,17 @@ Conditions:
     UseDefaultAMI:
       !Equals [ $(ImageId), "" ]
 
-    CreateMetricsStack:
-      !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ]
-
     UseManagedPolicyARN:
       !Not [ !Equals [ $(ManagedPolicyARN), "" ] ]
 
     UseECR:
       !Not [ !Equals [ $(ECRAccessPolicy), "none" ] ]
+
+    UseAutoscaling:
+      !Not [ !Equals [ $(MaxSize), $(MinSize) ] ]
+
+    CreateMetricsStack:
+      !And [ Condition: UseAutoscaling, !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ] ]
 
 Mappings:
   ECRManagedPolicy:
@@ -531,6 +534,7 @@ Resources:
         $(Subnets)
       ]
       LaunchConfigurationName: $(AgentLaunchConfiguration)
+      DesiredCapacity: $(MinSize)
       MinSize: $(MinSize)
       MaxSize: $(MaxSize)
       MetricsCollection:


### PR DESCRIPTION
This provides a `DesiredCapacity` parameter and also removes the update policy that prevented `MinSize` == `MaxSize`. 

It changes how autoscaling group updates are made, the ASG is now replaced rather than incrementally updated. 