### PR TITLE
WIP: Move curl or s3 logic into a shared script

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -363,6 +363,18 @@ Resources:
               mode: "000444"
               owner: root
               group: root
+            /usr/local/bin/fetch-s3-or-http:
+              content: |
+                #!/bin/bash
+                case "\$1" in
+                    s3://*)
+                      exec aws s3 cp "\$1" "\$2";;
+                    *)
+                      exec curl -Lfs -o "\$2" "\$1";;
+                esac
+              mode: "000666"
+              owner: root
+              group: root
 
           commands:
             01-write-buildkite-env:
@@ -451,28 +463,21 @@ Resources:
                 #!/bin/bash -eu
 
                 cat << EOF > /etc/cron.hourly/authorized_keys
-                case "$(AuthorizedUsersUrl)" in
-                    s3://*)
-                      aws s3 cp "$(AuthorizedUsersUrl)" /tmp/authorized_keys;;
-                    *)
-                      curl --silent -f "$(AuthorizedUsersUrl)" > /tmp/authorized_keys;;
-                esac
-
+                /usr/local/bin/fetch-s3-or-http "$(AuthorizedUsersUrl)" /tmp/authorized_keys
                 mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
                 chmod 600 /home/ec2-user/.ssh/authorized_keys
                 chown ec2-user: /home/ec2-user/.ssh/authorized_keys
                 EOF
 
                 chmod +x /etc/cron.hourly/authorized_keys
-
                 /etc/cron.hourly/authorized_keys
 
             05-run-bootstrap-script:
               test: test -n "$(BootstrapScriptUrl)"
               command: |
                 #!/bin/bash -eu
-
-                curl -sSL "$(BootstrapScriptUrl)" | bash
+                /usr/local/bin/fetch-s3-or-http "$(BootstrapScriptUrl)" /tmp/bootstrap.sh
+                source /tmp/bootstrap.sh
 
             06-start-the-world:
               command: |


### PR DESCRIPTION
This moves the curl or s3 logic into a dedicated script `/usr/local/bin/curl-or-http`. 

@toolmantim thoughts on whether this should be build into the image and basically replace https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/conf/buildkite-agent/hooks/environment#L19-L33 as well? There are some things in there that aren't covered currently.