### PR TITLE
Move runtime installation from Cloudformation metadata to to Packer/AMI

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -21,7 +21,7 @@
     {
       "type": "file",
       "source": "conf/bin",
-      "destination": "/usr/local/bin"
+      "destination": "/usr/local/"
     },
     {
       "type": "shell",

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -19,11 +19,6 @@
       "destination": "/tmp"
     },
     {
-      "type": "file",
-      "source": "conf/bin",
-      "destination": "/usr/local/"
-    },
-    {
       "type": "shell",
       "script": "scripts/install-utils.sh"
     },

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -19,6 +19,11 @@
       "destination": "/tmp"
     },
     {
+      "type": "file",
+      "source": "conf/bin",
+      "destination": "/usr/local/bin"
+    },
+    {
       "type": "shell",
       "script": "scripts/install-utils.sh"
     },

--- a/packer/conf/bin/bk-fetch.sh
+++ b/packer/conf/bin/bk-fetch.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+FROM="$1"
+TO="$2"
+
+case "$FROM" in
+	s3://*)
+		exec aws s3 cp "$FROM" "$TO"
+		;;
+	*)
+		exec curl -Lfs -o "$TO" "$FROM"
+		;;
+esac

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -24,7 +24,7 @@ AWS_DEFAULT_REGION=$AWS_REGION
 AWS_REGION=$AWS_REGION
 EOF
 
-if [[ -n "$BUILDKITE_USE_ECR" ]] ; then
+if [[ "${BUILDKITE_ECR_POLICY:-none}" != "none" ]] ; then
 	printf "AWS_ECR_LOGIN=1\n" >> /var/lib/buildkite-agent/cfn-env
 fi
 

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -45,7 +45,7 @@ fi;
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${AWS_STACK}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
-meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${AWS_STACK}")
+meta-data=$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${AWS_STACK}")
 meta-data-ec2=true
 bootstrap-script="${BOOTSTRAP_SCRIPT}"
 hooks-path=/etc/buildkite-agent/hooks

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -33,7 +33,7 @@ service docker start || ( cat /var/log/docker && false )
 docker ps > /dev/null
 
 # Choose the right agent binary
-ln -s /usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE} /usr/bin/buildkite-agent
+ln -s "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
 
 # Once 3.0 is stable we can just remove this and let the agent do the right thing
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "stable" ]]; then
@@ -55,7 +55,7 @@ EOF
 
 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
-for i in $(seq 1 ${BUILDKITE_AGENTS_PER_INSTANCE}); do
+for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
 	touch "/var/log/buildkite-agent-${i}.log"
 
 	# Setup logging first so we capture everything
@@ -89,10 +89,10 @@ if [[ -n "${BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT}" ]] ; then
 fi
 
 # Start services
-for i in $(seq 1 ${BUILDKITE_AGENTS_PER_INSTANCE}); do
-	cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-${i}
-	service buildkite-agent-${i} start
-	chkconfig --add buildkite-agent-${i}
+for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
+	cp /etc/buildkite-agent/init.d.tmpl "/etc/init.d/buildkite-agent-${i}"
+	service "buildkite-agent-${i}" start
+	chkconfig --add "buildkite-agent-${i}"
 done
 
 # Make sure terminationd is started if it isn't

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+set -euo pipefail
+
+## Installs the Buildkite Agent, run from the CloudFormation template
+
+INSTANCE_ID=$(/opt/aws/bin/ec2-metadata --instance-id | cut -d " " -f 2)
+DOCKER_VERSION=$(docker --version | cut -f3 -d' ' | sed 's/,//')
+
+env
+
+# Cloudwatch logs needs a region specifically configured
+cat << EOF > /etc/awslogs/awscli.conf
+[plugins]
+cwlogs = cwlogs
+[default]
+region = $AWS_REGION
+EOF
+
+# cfn-env is sourced by the environment hook in builds
+cat << EOF > /var/lib/buildkite-agent/cfn-env
+BUILDKITE_STACK_NAME=$BUILDKITE_STACK_NAME
+BUILDKITE_SECRETS_BUCKET=$BUILDKITE_SECRETS_BUCKET
+AWS_DEFAULT_REGION=$AWS_REGION
+AWS_REGION=$AWS_REGION
+EOF
+
+if [[ -n "$BUILDKITE_USE_ECR" ]] ; then
+	printf "AWS_ECR_LOGIN=1\n" >> /var/lib/buildkite-agent/cfn-env
+fi
+
+# Start docker up
+service docker start || ( cat /var/log/docker && false )
+docker ps > /dev/null
+
+# Choose the right agent binary
+ln -s /usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE} /usr/bin/buildkite-agent
+
+# Once 3.0 is stable we can just remove this and let the agent do the right thing
+if [[ "${BUILDKITE_AGENT_RELEASE}" == "stable" ]]; then
+	BOOTSTRAP_SCRIPT="/etc/buildkite-agent/bootstrap.sh"
+else
+	BOOTSTRAP_SCRIPT="buildkite-agent bootstrap"
+fi;
+
+cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
+name="${AWS_STACK}-${INSTANCE_ID}-%n"
+token="${BUILDKITE_AGENT_TOKEN}"
+meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${AWS_STACK}")
+meta-data-ec2=true
+bootstrap-script="${BOOTSTRAP_SCRIPT}"
+hooks-path=/etc/buildkite-agent/hooks
+build-path=/var/lib/buildkite-agent/builds
+plugins-path=/var/lib/buildkite-agent/plugins
+EOF
+
+chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
+
+for i in $(seq 1 ${BUILDKITE_AGENTS_PER_INSTANCE}); do
+	touch "/var/log/buildkite-agent-${i}.log"
+
+	# Setup logging first so we capture everything
+	cat <<- EOF > "/etc/awslogs/config/buildkite-agent-${i}.conf"
+	[/var/log/buildkite-agent-${i}.log]
+	file = /var/log/buildkite-agent-${i}.log
+	log_group_name = /var/log/buildkite-agent.log
+	log_stream_name = {instance_id}-${i}
+	datetime_format = %Y-%m-%d %H:%M:%S
+	EOF
+done
+
+service awslogs restart
+
+if [[ -n "${BUILDKITE_AUTHORIZED_USERS_URL}" ]] ; then
+	cat <<- EOF > /etc/cron.hourly/authorized_keys
+	/usr/local/bin/bk-fetch.sh "${BUILDKITE_AUTHORIZED_USERS_URL}" /tmp/authorized_keys
+	mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
+	chmod 600 /home/ec2-user/.ssh/authorized_keys
+	chown ec2-user: /home/ec2-user/.ssh/authorized_keys
+	EOF
+
+	chmod +x /etc/cron.hourly/authorized_keys
+	/etc/cron.hourly/authorized_keys
+fi
+
+if [[ -n "${BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT}" ]] ; then
+	/usr/local/bin/bk-fetch.sh "${BUILDKITE_AUTHORIZED_USERS_URL}" /tmp/elastic_bootstrap
+	bash < /tmp/elastic_bootstrap
+	rm /tmp/elastic_bootstrap
+fi
+
+# Start services
+for i in $(seq 1 ${BUILDKITE_AGENTS_PER_INSTANCE}); do
+	cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-${i}
+	service buildkite-agent-${i} start
+	chkconfig --add buildkite-agent-${i}
+done
+
+# Make sure terminationd is started if it isn't
+start terminationd || true

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -43,9 +43,9 @@ else
 fi;
 
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
-name="${AWS_STACK}-${INSTANCE_ID}-%n"
+name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
-meta-data=$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${AWS_STACK}")
+meta-data=$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${BUILDKITE_STACK_NAME}")
 meta-data-ec2=true
 bootstrap-script="${BOOTSTRAP_SCRIPT}"
 hooks-path=/etc/buildkite-agent/hooks

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -7,5 +7,5 @@ sudo yum update -y -q
 sudo yum install -y zip unzip
 
 echo "Installing bk elastic stack bin files"
-chmod +x /tmp/conf/bin/bk-*
-mv /tmp/conf/bin/bk-* /usr/local/bin
+sudo chmod +x /tmp/conf/bin/bk-*
+sudo mv /tmp/conf/bin/bk-* /usr/local/bin

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -7,5 +7,6 @@ sudo yum update -y -q
 sudo yum install -y zip unzip
 
 echo "Installing bk elastic stack bin files"
+ls -alR /tmp
 chmod +x /tmp/bin/bk-*
 mv /tmp/bin/bk-* /usr/local/bin

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -7,6 +7,5 @@ sudo yum update -y -q
 sudo yum install -y zip unzip
 
 echo "Installing bk elastic stack bin files"
-ls -alR /tmp
-chmod +x /tmp/bin/bk-*
-mv /tmp/bin/bk-* /usr/local/bin
+chmod +x /tmp/conf/bin/bk-*
+mv /tmp/conf/bin/bk-* /usr/local/bin

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -5,3 +5,7 @@ set -eu -o pipefail
 echo "Installing zip utils..."
 sudo yum update -y -q
 sudo yum install -y zip unzip
+
+echo "Installing bk elastic stack bin files"
+chod +x /tmp/bin/bk-*
+mv /tmp/bin/bk-* /usr/local/bin

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -7,5 +7,5 @@ sudo yum update -y -q
 sudo yum install -y zip unzip
 
 echo "Installing bk elastic stack bin files"
-chod +x /tmp/bin/bk-*
+chmod +x /tmp/bin/bk-*
 mv /tmp/bin/bk-* /usr/local/bin

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -360,8 +360,7 @@ Resources:
         BUILDKITE_ECR_POLICY=$(ECRAccessPolicy) \
         AWS_DEFAULT_REGION=$(AWS::Region) \
         AWS_REGION=$(AWS::Region) \
-        AWS_STACK=$(AWS::StackId) \
-        /usr/local/bin/bk-install-elastic-stack.sh
+          /usr/local/bin/bk-install-elastic-stack.sh
 
         /opt/aws/bin/cfn-signal \
           --region "$(AWS::Region)" \

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -349,167 +349,25 @@ Resources:
           Ebs: { VolumeSize: $(RootVolumeSize), VolumeType: gp2 }
       UserData: !Base64 |
         #!/bin/bash -xv
-        /opt/aws/bin/cfn-init \
-          --region "$(AWS::Region)" \
-          --stack "$(AWS::StackId)" \
-          --resource "AgentLaunchConfiguration"
+        export BUILDKITE_STACK_NAME="$(AWS::StackName)"
+        export BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)"
+        export BUILDKITE_AGENT_TOKEN="$(BuildkiteAgentToken)"
+        export BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)"
+        export BUILDKITE_AGENT_RELEASE="$(BuildkiteAgentRelease)"
+        export BUILDKITE_QUEUE="$(BuildkiteQueue)"
+        export BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="$(BootstrapScriptUrl)"
+        export BUILDKITE_AUTHORIZED_USERS_URL="$(AuthorizedUsersUrl)"
+        export BUILDKITE_USE_ECR=$(UseECR)
+        export AWS_DEFAULT_REGION=$(AWS::Region)
+        export AWS_REGION=$(AWS::Region)
+        export AWS_STACK=$(AWS::StackId)
+        /usr/local/bin/bk-install-elastic-stack.sh
         /opt/aws/bin/cfn-signal \
           --region "$(AWS::Region)" \
           --stack "$(AWS::StackName)" \
           --resource "AgentAutoScaleGroup" \
           --exit-code \$?
-        # Here we put any params we want to trigger a restart
-        # $(BuildkiteAgentToken)
-        # $(BuildkiteAgentRelease)
-        # $(BuildkiteQueue)
-        # $(AgentsPerInstance)
-        # $(SecretsBucket)
-        # $(BootstrapScriptUrl)
 
-    Metadata:
-      # see http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-init.html
-      AWS::CloudFormation::Init:
-        config:
-          files:
-            /etc/awslogs/awscli.conf:
-              content: |
-                [plugins]
-                cwlogs = cwlogs
-                [default]
-                region = $(AWS::Region)
-              mode: "000444"
-              owner: root
-              group: root
-
-          commands:
-            01-write-buildkite-env:
-              command: |
-                #!/bin/bash -eu
-
-                cat << EOF > /var/lib/buildkite-agent/cfn-env
-                BUILDKITE_STACK_NAME="$(AWS::StackName)"
-                BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)"
-                BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)"
-                AWS_DEFAULT_REGION=$(AWS::Region)
-                AWS_REGION=$(AWS::Region)
-                EOF
-
-                chown buildkite-agent /var/lib/buildkite-agent/cfn-env
-
-
-            01-write-ecr-env:
-              condition: UseECR
-              command: |
-                #!/bin/bash -eu
-                printf "AWS_ECR_LOGIN=1\n" >> /var/lib/buildkite-agent/cfn-env
-
-            02-restart-docker:
-              command: |
-                #!/bin/bash -eu
-
-                # Sometimes Docker can be unreponsive:
-                # https://github.com/docker/docker/issues/23131
-                # https://github.com/buildkite/elastic-ci-stack-for-aws/issues/86
-                #
-                # As a workaround we start the docker daemon, wait 10 seconds, and verify
-                service docker start || ( cat /var/log/docker && false )
-                sleep 10 && docker info
-
-            03-install-buildkite:
-              command: |
-                #!/bin/bash -eu
-
-                # Choose the right binary
-                ln -s /usr/bin/buildkite-agent-$(BuildkiteAgentRelease) /usr/bin/buildkite-agent
-
-                # Setup the buildkite-agent config
-                INSTANCE_ID=\$(/opt/aws/bin/ec2-metadata --instance-id | cut -d " " -f 2)
-                DOCKER_VERSION=\$(docker --version | cut -f3 -d' ' | sed 's/,//')
-
-                # Once 3.0 is stable we can just remove this and let the agent do the right thing
-                if [[ "$(BuildkiteAgentRelease)" == "stable" ]]; then
-                  BOOTSTRAP_SCRIPT="/etc/buildkite-agent/bootstrap.sh"
-                else
-                  BOOTSTRAP_SCRIPT="buildkite-agent bootstrap"
-                fi;
-
-                cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
-                name="$(AWS::StackName)-\$INSTANCE_ID-%n"
-                token="$(BuildkiteAgentToken)"
-                meta-data=\$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "$(BuildkiteQueue)" "\$DOCKER_VERSION" "$(AWS::StackName)")
-                meta-data-ec2=true
-                bootstrap-script="\$BOOTSTRAP_SCRIPT"
-                hooks-path=/etc/buildkite-agent/hooks
-                build-path=/var/lib/buildkite-agent/builds
-                plugins-path=/var/lib/buildkite-agent/plugins
-                EOF
-
-                chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
-
-                # Setup logging first so we capture everything
-                for i in \$(seq 1 $(AgentsPerInstance)); do
-                  touch /var/log/buildkite-agent-\${i}.log
-
-                  cat << EOF > /etc/awslogs/config/buildkite-agent-\${i}.conf
-                [/var/log/buildkite-agent-\${i}.log]
-                file = /var/log/buildkite-agent-\${i}.log
-                log_group_name = /var/log/buildkite-agent.log
-                log_stream_name = {instance_id}-\${i}
-                datetime_format = %Y-%m-%d %H:%M:%S
-                EOF
-                done
-
-                service awslogs restart
-
-
-            04-fetch-authorized-users:
-              test: test -n "$(AuthorizedUsersUrl)"
-              command: |
-                #!/bin/bash -eu
-
-                cat << EOF > /etc/cron.hourly/authorized_keys
-                case "$(AuthorizedUsersUrl)" in
-                    s3://*)
-                      aws s3 cp "$(AuthorizedUsersUrl)" /tmp/authorized_keys;;
-                    *)
-                      curl --silent -f "$(AuthorizedUsersUrl)" > /tmp/authorized_keys;;
-                esac
-
-                mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
-                chmod 600 /home/ec2-user/.ssh/authorized_keys
-                chown ec2-user: /home/ec2-user/.ssh/authorized_keys
-                EOF
-
-                chmod +x /etc/cron.hourly/authorized_keys
-
-                /etc/cron.hourly/authorized_keys
-
-            05-run-bootstrap-script:
-              test: test -n "$(BootstrapScriptUrl)"
-              command: |
-                #!/bin/bash -eu
-
-                case "$(BootstrapScriptUrl)" in
-                    s3://*)
-                      aws s3 cp "$(BootstrapScriptUrl)" - | bash
-                    *)
-                      curl -sSL "$(BootstrapScriptUrl)" | bash
-                esac
-
-            06-start-the-world:
-              command: |
-                #!/bin/bash -eu
-
-                # Start services
-
-                for i in \$(seq 1 $(AgentsPerInstance)); do
-                  cp /etc/buildkite-agent/init.d.tmpl /etc/init.d/buildkite-agent-\${i}
-                  service buildkite-agent-\${i} start
-                  chkconfig --add buildkite-agent-\${i}
-                done
-
-                # Make sure terminationd is started if it isn't
-                start terminationd || true
 
   # XXX: We don't even want a topic or role, but CloudFormation requires them
   # to create a lifecycle hook.

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -109,7 +109,7 @@ Parameters:
     Default: ""
 
   BootstrapScriptUrl:
-    Description: Optional - S3 url to run on each instance during boot
+    Description: Optional - http(s) url or S3 url to run on each instance during boot
     Type: String
     Default: ""
 
@@ -349,19 +349,20 @@ Resources:
           Ebs: { VolumeSize: $(RootVolumeSize), VolumeType: gp2 }
       UserData: !Base64 |
         #!/bin/bash -xv
-        export BUILDKITE_STACK_NAME="$(AWS::StackName)"
-        export BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)"
-        export BUILDKITE_AGENT_TOKEN="$(BuildkiteAgentToken)"
-        export BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)"
-        export BUILDKITE_AGENT_RELEASE="$(BuildkiteAgentRelease)"
-        export BUILDKITE_QUEUE="$(BuildkiteQueue)"
-        export BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="$(BootstrapScriptUrl)"
-        export BUILDKITE_AUTHORIZED_USERS_URL="$(AuthorizedUsersUrl)"
-        export BUILDKITE_USE_ECR=$(UseECR)
-        export AWS_DEFAULT_REGION=$(AWS::Region)
-        export AWS_REGION=$(AWS::Region)
-        export AWS_STACK=$(AWS::StackId)
+        BUILDKITE_STACK_NAME="$(AWS::StackName)" \
+        BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)" \
+        BUILDKITE_AGENT_TOKEN="$(BuildkiteAgentToken)" \
+        BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)" \
+        BUILDKITE_AGENT_RELEASE="$(BuildkiteAgentRelease)" \
+        BUILDKITE_QUEUE="$(BuildkiteQueue)" \
+        BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="$(BootstrapScriptUrl)" \
+        BUILDKITE_AUTHORIZED_USERS_URL="$(AuthorizedUsersUrl)" \
+        BUILDKITE_ECR_POLICY=$(ECRAccessPolicy) \
+        AWS_DEFAULT_REGION=$(AWS::Region) \
+        AWS_REGION=$(AWS::Region) \
+        AWS_STACK=$(AWS::StackId) \
         /usr/local/bin/bk-install-elastic-stack.sh
+
         /opt/aws/bin/cfn-signal \
           --region "$(AWS::Region)" \
           --stack "$(AWS::StackName)" \


### PR DESCRIPTION
As part of the move towards multiple ASG's in one stack, this moves configuration from the `LaunchConfiguration` into a script on the AMI. 

This should have effectively no impact on functionality, it's just moving code from cfn-init into a shell script.