### PR TITLE
Only create metrics lambda if required

### DIFF
--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -2,6 +2,7 @@
 Resources:
   LambdaExecutionRole:
     Type: AWS::IAM::Role
+    Condition: CreateMetricsStack
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -17,6 +18,7 @@ Resources:
   LambdaExecutionPolicy:
     DependsOn: LambdaExecutionRole
     Type: AWS::IAM::Policy
+    Condition: CreateMetricsStack
     Properties:
       PolicyName: AccessToCloudwatchForBuildkiteMetrics
       Roles:
@@ -39,6 +41,7 @@ Resources:
     DependsOn:
     - LambdaExecutionRole
     - LambdaExecutionPolicy
+    Condition: CreateMetricsStack
     Properties:
       Code:
         S3Bucket: !If
@@ -65,6 +68,7 @@ Resources:
 
   ScheduledRule:
     Type: "AWS::Events::Rule"
+    Condition: CreateMetricsStack
     Properties:
       Description: "ScheduledRule"
       ScheduleExpression: "rate(1 minute)"
@@ -78,6 +82,7 @@ Resources:
 
   PermissionForEventsToInvokeLambda:
     Type: "AWS::Lambda::Permission"
+    Condition: CreateMetricsStack
     Properties:
       FunctionName: $(BuildkiteMetricsFunction)
       Action: "lambda:InvokeFunction"


### PR DESCRIPTION
The addition of the metrics lambda stack regressed the conditional metrics creation. This re-introduces it.