### PR TITLE
Enable S3 v4 Signatures by Default

### DIFF
--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -6,6 +6,9 @@ echo "Installing zip utils..."
 sudo yum update -y -q
 sudo yum install -y zip unzip
 
-echo "Installing bk elastic stack bin files"
+echo "Installing bk elastic stack bin files..."
 sudo chmod +x /tmp/conf/bin/bk-*
 sudo mv /tmp/conf/bin/bk-* /usr/local/bin
+
+echo "Configuring awscli to use v4 signatures..."
+sudo aws configure set s3.signature_version s3v4


### PR DESCRIPTION
Seems like more people are seeing issues with s3 requiring v4 signatures in certain circumstances. This defaults to v4. 

/cc @benschwarz