### PR TITLE
Remove custom metrics from the default param groups

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -50,12 +50,6 @@ Metadata:
         Parameters:
         - ECRAccessPolicy
 
-      - Label:
-          default: Metrics Configuration
-        Parameters:
-        - MetricsLambdaS3Bucket
-        - MetricsLambdaS3Key
-
 Parameters:
   KeyName:
     Description: The ssh keypair used to access the buildkite instances


### PR DESCRIPTION
These were useful for dev, but are probably just confusing now.