### PR TITLE
Restart awslogs instead of just start for config changes.

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -108,7 +108,7 @@ done
 
 # my kingdom for a decent init system
 start terminationd || true
-service awslogs start || true
+service awslogs restart || true
 
 /opt/aws/bin/cfn-signal \
 	--region "$AWS_REGION" \


### PR DESCRIPTION
I was getting my logs coming through in us-east-1.

After I restarted the process they moved to the right region. I was wondering if its because awslogs may already have been started before this scripts run (perhaps a race condition?), so that starting it is a no op?

Instead I have changed it to restart, so that it will either start if stopped, or restart if started to pickup any config changes.