### PR TITLE
Allow agent to get objects from its artifacts bucket.

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -340,6 +340,7 @@ Resources:
             Action:
               - s3:Put*
               - s3:List*
+              - s3:Get*
             Resource:
               - "arn:aws:s3:::$(ArtifactsBucket)/*"
               - "arn:aws:s3:::$(ArtifactsBucket)"


### PR DESCRIPTION
Not sure if there is a reason not to allow this by default, but sometimes I have pipelines that create an artifact in once stage, and then need it in the next, so it would be good to be able to pull down something from the artifacts bucket during a step.