### PR TITLE
Add a stack version to metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 BUILDKITE_STACK_BUCKET ?= buildkite-aws-stack
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+VERSION ?= $(shell git describe --tags --candidates=1)
 STACK_NAME ?= buildkite
 SHELL=/bin/bash -o pipefail
 TEMPLATES=templates/description.yml \
@@ -18,6 +19,7 @@ build: build/aws-stack.json
 build/aws-stack.json: $(TEMPLATES) templates/mappings.yml
 	-mkdir -p build/
 	bundle exec cfoo $^ > $@
+	sed -i.bak "s/BUILDKITE_STACK_VERSION=dev/BUILDKITE_STACK_VERSION=$(VERSION)/" $@
 
 setup:
 	bundle check || ((which bundle || gem install bundler --no-ri --no-rdoc) && bundle install --path vendor/bundle)

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -60,7 +60,7 @@ fi;
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
-meta-data=$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${BUILDKITE_STACK_NAME}")
+meta-data=$(printf 'queue=%s,docker=%s,stack=%s,buildkite-aws-stack=%s' "${BUILDKITE_QUEUE}" "${DOCKER_VERSION}" "${BUILDKITE_STACK_NAME}" "${BUILDKITE_STACK_VERSION}")
 meta-data-ec2=true
 bootstrap-script="${BOOTSTRAP_SCRIPT}"
 hooks-path=/etc/buildkite-agent/hooks

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -367,6 +367,7 @@ Resources:
       UserData: !Base64 |
         #!/bin/bash -xv
         BUILDKITE_STACK_NAME="$(AWS::StackName)" \
+        BUILDKITE_STACK_VERSION=dev \
         BUILDKITE_SECRETS_BUCKET="$(SecretsBucket)" \
         BUILDKITE_AGENT_TOKEN="$(BuildkiteAgentToken)" \
         BUILDKITE_AGENTS_PER_INSTANCE="$(AgentsPerInstance)" \


### PR DESCRIPTION
Rather than `buildkite-aws-stack=true`, this adds `buildkite-aws-stack=vX.X.X` to the agent metadata. 
