### PR TITLE
Replace top level template with latest tagged release

### DIFF
--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -153,8 +153,8 @@ echo "--- Building and publishing stack"
 
 make setup build
 
-# Publish the top-level mappings only on version tagged releases
-if [[ "$BUILDKITE_TAG" =~ ^v ]] ; then
+# Publish the top-level mappings only on when we see the most recent tag on master
+if [[ "$BUILDKITE_TAG" =~ $(git describe origin/master --tags --match="v*") ]] ; then
   aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
   aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
 fi

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -153,14 +153,16 @@ echo "--- Building and publishing stack"
 
 make setup build
 
-if [[ $BUILDKITE_BRANCH == "master" ]] ; then
+# Publish the top-level mappings only on version tagged releases
+if [[ "$BUILDKITE_TAG" =~ ^v ]] ; then
   aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/mappings.yml"
   aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/aws-stack.json"
-
-  # Publish each build to a unique URL, to let people roll back to old versions
-  aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/master/${BUILDKITE_COMMIT}.mappings.yml"
-  aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/master/${BUILDKITE_COMMIT}.aws-stack.json"
 fi
 
+# Publish the most recent commit from each branch
 aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/mappings.yml"
 aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/aws-stack.json"
+
+# Publish each build to a unique URL, to let people roll back to old versions
+aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/${BUILDKITE_COMMIT}.mappings.yml"
+aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${BUILDKITE_BRANCH}/${BUILDKITE_COMMIT}.aws-stack.json"

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Features:
 
 See the [Elastic CI Stack for AWS guide](https://buildkite.com/docs/guides/elastic-ci-stack-aws) for a step-by-step guide, or jump straight in:
 
-[![Launch Buildkite AWS Stack v1.1.1](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/v1.1.1/aws-stack.json)
+[![Launch AWS Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json)
 
-Current version is v1.1.1. See [Releases](https://github.com/buildkite/elastic-ci-stack-for-aws/releases) for older releases, or [Versions](#versions) for development version
+Current release is ![](https://img.shields.io/github/release/buildkite/elastic-ci-stack-for-aws.svg). See [Releases](https://github.com/buildkite/elastic-ci-stack-for-aws/releases) for older releases, or [Versions](#versions) for development version
 
 > Although the stack will create it's own VPC by default, we highly recommend following best practice by setting up a separate development AWS account and using role switching and consolidated billing—see the [Delegate Access Across AWS Accounts tutorial](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more information.
 
@@ -59,7 +59,7 @@ If you'd like to use the [AWS CLI](https://aws.amazon.com/cli/), download [`conf
 aws cloudformation create-stack \
   --output text \
   --stack-name buildkite \
-  --template-url "https://s3.amazonaws.com/buildkite-aws-stack/v1.1.1/aws-stack.json" \
+  --template-url "https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json" \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --parameters $(cat config.json)
 ```
@@ -117,7 +117,7 @@ If you need to different instances sizes and scaling characteristics between pip
 
 Examples:
 
-* A `docker-builders` stack that provides always-on workers with hot docker caches
+* A `docker-builders` stack that provides always-on workers with hot docker caches (see [Optimizing for Slow Docker Builds](#optimizing-for-slow-docker-builds))
 * A `pipeline-uploaders` stack with tiny, always-on instances for lightning fast `buildkite-agent pipeline upload` jobs.
 * A `deploy` stack with added credentials and permissions specifically for deployment.
 
@@ -147,9 +147,9 @@ If you want to login to an ECR server on another AWS account, you can set `AWS_E
 
 ## Versions
 
-We recommend running the latest release, which is a url in the form of `https://s3.amazonaws.com/buildkite-aws-stack/${VERSION}/aws-stack.json` that can be found on the [releases page](https://github.com/buildkite/elastic-ci-stack-for-aws/releases).
+We recommend running the latest release, which is available at `https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json`, or on the [releases page](https://github.com/buildkite/elastic-ci-stack-for-aws/releases).
 
-The latest build of the stack is published to `https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json`, along with a version for each commit in the form of `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.json`. 
+The latest build of the stack is published to `https://s3.amazonaws.com/buildkite-aws-stack/master/aws-stack.json`, along with a version for each commit in the form of `https://s3.amazonaws.com/buildkite-aws-stack/master/${COMMIT}.aws-stack.json`. 
 
 Branches are published in the form of `https://s3.amazonaws.com/buildkite-aws-stack/${BRANCH}/aws-stack.json`. 
 


### PR DESCRIPTION
Currently https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json refers to the latest master, this would change that to be the latest tagged release, which simplifies distribution. 