### PR TITLE
Keep it simple, allow zero instances during update

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -235,9 +235,6 @@ Conditions:
     CreateMetricsStack:
       !And [ Condition: UseAutoscaling, !Not [ !Equals [ $(BuildkiteApiAccessToken), "" ] ] ]
 
-    AllowZeroInstancesDuringScaling:
-      !Equals [ $(MaxSize), "1" ]
-
 Mappings:
   ECRManagedPolicy:
     none      : { Policy: '' }
@@ -456,11 +453,7 @@ Resources:
         Count: $(MinSize)
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MinInstancesInService: !If [
-          "AllowZeroInstancesDuringScaling",
-          0,
-          $(MinSize)
-        ]
+        MinInstancesInService: 0
         MaxBatchSize: 5
         # On rollback this might have to wait for an agent to finish
         # a job. The agent's init script waits 30 minutes, so we wait


### PR DESCRIPTION
This avoids some edge cases on stack update.