### PR TITLE
Suspend scheduled action processes on ASG rolling update.

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -461,7 +461,9 @@ Resources:
         PauseTime: PT40M
         WaitOnResourceSignals: true
         # Ignore scaling alarms during update
-        SuspendProcesses: [ AlarmNotification ]
+        SuspendProcesses:
+          - AlarmNotification
+          - ScheduledActions
 
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Although the template does not add any scheduled actions, this allows
people to add a scheduled action outside of the cloudformation and
still be able to update the stack.

My use case is wrapping this stack around terraform to create S3 buckets etc, and hopefully add a scheduled action after the fact.

I believe that this should be a no-op for most people if there are no scheduled actions so it should be safe to include.