### PR TITLE
Use ECS-Optimized AMI for base image

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,12 +3,12 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-9be6f38c",
+      "source_ami": "ami-b2df2ca4",
       "region": "us-east-1",
       "instance_type": "c4.large",
       "ssh_username": "ec2-user",
-      "ami_name": "buildkite-stack-{{isotime | clean_ami_name}}",
-      "ami_description": "Buildkite CloudFormation Stack base image (Amazon Linux, buildkite-agent, docker, docker-compose, docker-gc, jq)",
+      "ami_name": "buildkite-for-aws-{{isotime | clean_ami_name}}",
+      "ami_description": "buildkite/elastic-ci-stack-for-aws",
       "ami_groups": ["all"]
     }
   ],

--- a/packer/conf/buildkite-agent/terminationd/hook
+++ b/packer/conf/buildkite-agent/terminationd/hook
@@ -2,19 +2,9 @@
 
 set -eu -o pipefail
 
-# Import BUILDKITE_AGENTS_PER_INSTANCE
-eval "$(cat /var/lib/buildkite-agent/cfn-env)"
-
 echo "Stopping buildkite-agent gracefully"
+cd /var/lib/buildkite-agent
 
-for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
-  service "buildkite-agent-${i}" stop &
-done
-
-# Need to ensure it's the buildkite-agent user, so it doesn't match this lifecycld handler script
-while pgrep -u buildkite-agent buildkite-agent > /dev/null; do
-  echo "Waiting for all buildkite-agent processes to have stopped..."
-  sleep 5
-done
+docker-compose down
 
 echo "All buildkite-agent processes have stopped"

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,30 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=1.13.1
 DOCKER_COMPOSE_VERSION=1.11.0
-
-# This performs a manual install of Docker 1.12. The init.d script is from the
-# 1.11 yum package
-
-echo "Installing docker..."
-
-# Only dep to install (found by doing a yum install of 1.11)
-sudo yum install -y xfsprogs
-
-# Add docker group
-sudo groupadd docker
-sudo usermod -a -G docker ec2-user
-
-# Manual install ala https://docs.docker.com/engine/installation/binaries/
-curl -Lsf https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz > docker.tgz
-tar -xvzf docker.tgz
-sudo mv docker/* /usr/bin
-rm docker.tgz
-
-sudo cp /tmp/conf/docker/init.d/docker /etc/init.d/docker
-sudo cp /tmp/conf/docker/docker.conf /etc/sysconfig/docker
-sudo chkconfig docker on
 
 echo "Downloading docker-compose..."
 sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
@@ -34,8 +11,3 @@ docker-compose --version
 echo "Adding docker-gc cron task..."
 sudo cp /tmp/conf/docker/cron.daily/docker-gc /etc/cron.daily/docker-gc
 sudo chmod +x /etc/cron.daily/docker-gc
-
-echo "Downloading jq..."
-sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-sudo chmod +x /usr/bin/jq
-jq --version

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -16,3 +16,8 @@ sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 
 echo "Configuring awscli to use v4 signatures..."
 sudo aws configure set s3.signature_version s3v4
+
+echo "Downloading jq..."
+sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+sudo chmod +x /usr/bin/jq
+jq --version

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -14,8 +14,13 @@ echo "Installing bk elastic stack bin files..."
 sudo chmod +x /tmp/conf/bin/bk-*
 sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 
-echo "Configuring awscli to use v4 signatures..."
+echo "Installing aws-cli tools..."
+sudo yum install -y aws-cli aws-cfn-bootstrap
 sudo aws configure set s3.signature_version s3v4
+
+echo "Installing ec2-metadata script"
+sudo curl -Lsf -o /opt/aws/bin/ec2-metadata http://s3.amazonaws.com/ec2metadata/ec2-metadata
+sudo chmod +x /opt/aws/bin/ec2-metadata
 
 echo "Downloading jq..."
 sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64

--- a/tests/agent.bats
+++ b/tests/agent.bats
@@ -6,6 +6,6 @@
 }
 
 @test "Check terminationd is running" {
-	run status "terminationd"
+	run sudo status "terminationd"
 	[ $status = 0 ]
 }

--- a/tests/agent.bats
+++ b/tests/agent.bats
@@ -4,8 +4,3 @@
 	run service "buildkite-agent-1" status
 	[ $status = 0 ]
 }
-
-@test "Check terminationd is running" {
-	run sudo status "terminationd"
-	[ $status = 0 ]
-}

--- a/tests/docker.bats
+++ b/tests/docker.bats
@@ -5,7 +5,7 @@
 	[ $status = 0 ]
 }
 
-@test "Check docker is version 1.13.1" {
-	run sh -c  "docker --version | grep 'Docker version 1.13.1,'"
+@test "Check docker reports a version" {
+	run docker --version
 	[ $status = 0 ]
 }


### PR DESCRIPTION
Docker considers Amazon Linux an "[unsupported distro](https://github.com/docker/docker/pull/23480)" and it seems like the relationship between the two is becoming increasingly strained. 

Currently we are using the [latest Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/2016.09-release-notes/) and then installing Docker on it. An official Amazon package isn't available for 1.13, and tends to lag behind because kernel changes are often required in the underlying distro. 

This PR moves to the newer [ECS Optimized image](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html) from Amazon, which is basically a supported bundle of Amazon Linux, Docker 1.12.6 (currently) and ECS agent.

My hope is that this will be more stable.