### PR TITLE
Download git-credentials files from secrets bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ The following paths in the bucket are checked.
 
 * `/env` - An [agent environment hook](https://buildkite.com/docs/agent/hooks)
 * `/private_ssh_key` - A private key that is added to ssh-agent for your builds
+* `/git-credentials` - A [git-credentials](https://git-scm.com/docs/git-credential-store#_storage_format) file for git over https
 * `/{pipeline-slug}/env` - An [agent environment hook](https://buildkite.com/docs/agent/hooks), specific to a pipeline
 * `/{pipeline-slug}/private_ssh_key` - A private key that is added to ssh-agent for your builds, specific to the pipeline
+* `/{pipeline-slug}/git-credentials` - A [git-credentials](https://git-scm.com/docs/git-credential-store#_storage_format) file for git over https, specific to a pipeline
 
 These files are encrypted using [Amazon's KMS Service](https://aws.amazon.com/kms/). See the [Security](#security) section for more details.
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -102,6 +102,26 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
       eval "$envvars"
     fi
   done
+
+  git_credentials_paths=(
+    "git-credentials"
+    "${secrets_prefix}/git-credentials"
+  )
+
+  echo "~~~ Downloading git-credentials files"
+
+  for key in ${git_credentials_paths[*]} ; do
+    if s3_exists "${BUILDKITE_SECRETS_BUCKET}" "$key" ; then
+      if ! envvars=$(s3_download "${BUILDKITE_SECRETS_BUCKET}" "$key") ; then
+        echo "~~~ :warning: Failed to download git-credentials from $key"
+        exit 1
+      fi
+      echo "Downloading git-credentials $key"
+      mv "$key" .git-credentials
+      git config credential.helper "store --file=$PWD/.git-credentials"
+    fi
+  done
+
 fi
 
 echo "Waiting for Docker..."


### PR DESCRIPTION
This checks the secrets bucket for a `git-credentials` file to support git over https. 

The format of the file (from https://git-scm.com/docs/git-credential-store#_storage_format) is:

```
https://user:pass@example.com
```