### PR TITLE
Make sure that docker starts before launching the buildkite-agent

### DIFF
--- a/packer/conf/buildkite-agent/init.d/buildkite-agent
+++ b/packer/conf/buildkite-agent/init.d/buildkite-agent
@@ -1,8 +1,11 @@
 #!/bin/sh
 #
+# chkconfig:   2345 86 05
+# description: The Buildkite Build Agent
+
 ### BEGIN INIT INFO
 # Provides:          buildkite-agent
-# Required-Start:    $network $local_fs $remote_fs
+# Required-Start:    $network $local_fs $remote_fs docker
 # Required-Stop:     $remote_fs
 # Should-Start:      $named
 # Should-Stop:

--- a/packer/conf/docker/init.d/docker
+++ b/packer/conf/docker/init.d/docker
@@ -4,13 +4,13 @@
 #
 #       Daemon for docker.com
 #
-# chkconfig:   2345 95 05
+# chkconfig:   2345 85 05
 # description: Daemon for docker.com
 
 ### BEGIN INIT INFO
 # Provides:       docker
 # Required-Start: $network cgconfig
-# Required-Stop:
+# Required-Stop: buildkite-agent
 # Should-Start:
 # Should-Stop:
 # Default-Start: 2 3 4 5


### PR DESCRIPTION
This changes order of services to fix issue #256 so that docker starts up before buildkite-agent.