### PR TITLE
Include outputs template when building stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ TEMPLATES=templates/description.yml \
   templates/buildkite-elastic.yml \
   templates/autoscale.yml \
   templates/vpc.yml \
-  templates/metrics.yml
+  templates/metrics.yml \
+  templates/outputs.yml
 
 all: setup build
 


### PR DESCRIPTION
It seems the outputs from `template/outputs.yml` were never included when generating the aws-stack.json. This addresses the issue.