### PR TITLE
Increase polling to 60 seconds

### DIFF
--- a/packer/conf/terminationd/bin/terminationd
+++ b/packer/conf/terminationd/bin/terminationd
@@ -25,7 +25,7 @@ while true; do
   if [[ "${LIFECYCLE_STATE}" == "Terminating:Wait" ]]; then
     break
   else
-    sleep 15 # seconds
+    sleep 60 # seconds
   fi
 done
 


### PR DESCRIPTION
A few people have reported that they're hitting the AWS API rate limit for the `describe-auto-scaling-instances` call. This changes the poll wait from 15 seconds to 60 seconds, which should provide some temporary relief whilst we work on a more scaleable fix.

The downside to this change is that it might take an instance 45 seconds longer to detect whether it should shut down. In a worst-case situation this could mean that the buildkite-agent picks up a new job where it wouldn't have before, and then is delayed even further. But I think this tradeoff is acceptable until we work on terminationd alternative.