### PR TITLE
Fix release tag publishing race condition

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -43,6 +43,8 @@ steps:
     agents:
       queue: aws-stack
     artifact_paths: "templates/mappings.yml;build/aws-stack.json"
+    concurrency_group: "aws-stack-publish"
+    concurrency: 1
 
   - wait
 

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -21,6 +21,10 @@ DESTINATION_REGIONS=(
 DESTINATION_AMIS=(
 )
 
+is_tag_build() {
+   [[ "$BUILDKITE_TAG" = "$BUILDKITE_BRANCH" ]]
+}
+
 is_latest_tag() {
    [[ "$BUILDKITE_TAG" = $(git describe origin/master --tags --match='v*') ]]
 }
@@ -98,7 +102,7 @@ Mappings:
     us-east-1 : { AMI: $base_image_id }
 EOF
 
-  if [[ $BUILDKITE_BRANCH == "master" ]] || is_latest_tag ; then
+  if [[ $BUILDKITE_BRANCH == "master" ]] || is_tag_build ; then
     for region in ${DESTINATION_REGIONS[*]}; do
       echo "--- Copying $image_id to $region"
 

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -26,7 +26,7 @@ is_tag_build() {
 }
 
 is_latest_tag() {
-   [[ "$BUILDKITE_TAG" = $(git describe origin/master --tags --match='v*') ]]
+   [[ "$BUILDKITE_TAG" = $(git describe --abbrev=0 --tags --match 'v*') ]]
 }
 
 copy_ami_to_region() {


### PR DESCRIPTION
This fixes a race condition where more commits are pushed to master before the publish step has started running. It also prevents multiple publish steps running at the same time, and it makes sure to copy the AMIs to all the regions for all builds of tags (not just the "latest tag").

What was the race condition? If there's two commits on master since the last tag, git describe will append some extra info to the output:

```
$ git describe origin/master --tags
v2.0.1-2-gf121d00
```

Adding --abbrev=0 removes the extra info git adds:

```
git describe origin/master --tags --abbrev=0
v2.0.1
```

So checking `$BUILDKITE_TAG == $(git describe origin/master --tags --abbrev=0)` will work, even if new commits are pushed to master in between the build starting and the publish step running.