### PR TITLE
Start docker manually to avoid corrupting init

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -102,8 +102,8 @@ start terminationd || true
 service awslogs restart || true
 
 # start up docker, wait for it to initialize
-chkconfig docker on
 service docker start
+chkconfig docker on
 docker ps
 
 for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -97,20 +97,20 @@ if [[ -n "${BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT}" ]] ; then
 	rm /tmp/elastic_bootstrap
 fi
 
+# my kingdom for a decent init system
+start terminationd || true
+service awslogs restart || true
+
+# start up docker, wait for it to initialize
+chkconfig docker on
+service docker start
+docker ps
+
 for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
 	cp /etc/buildkite-agent/init.d.tmpl "/etc/init.d/buildkite-agent-${i}"
 	service "buildkite-agent-${i}" start
 	chkconfig --add "buildkite-agent-${i}"
 done
-
-# my kingdom for a decent init system
-start terminationd || true
-service awslogs restart || true
-
-# restart docker, see buildkite/elastic-ci-stack-for-aws#236
-service docker restart
-sleep 2
-docker ps
 
 /opt/aws/bin/cfn-signal \
 	--region "$AWS_REGION" \

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -24,7 +24,6 @@ rm docker.tgz
 
 sudo cp /tmp/conf/docker/init.d/docker /etc/init.d/docker
 sudo cp /tmp/conf/docker/docker.conf /etc/sysconfig/docker
-sudo chkconfig docker on
 
 echo "Downloading docker-compose..."
 sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 DOCKER_VERSION=17.03.0-ce
 DOCKER_COMPOSE_VERSION=1.11.2
 
-# This performs a manual install of Docker 1.12. The init.d script is from the
+# This performs a manual install of Docker. The init.d script is from the
 # 1.11 yum package
 
 echo "Installing docker..."
@@ -24,6 +24,7 @@ rm docker.tgz
 
 sudo cp /tmp/conf/docker/init.d/docker /etc/init.d/docker
 sudo cp /tmp/conf/docker/docker.conf /etc/sysconfig/docker
+sudo chkconfig docker off
 
 echo "Downloading docker-compose..."
 sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64


### PR DESCRIPTION
A current theory for issue #236 is that the restart is happening during dockers initialization, which causes corruption.

This moves the first docker start from packer to when the instance boots, as well as ensuring it happens before the agents are started.