### PR TITLE
Start docker manually

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -102,12 +102,10 @@ start terminationd || true
 service awslogs restart || true
 
 # start up docker, wait for it to initialize
-# service docker start
-# chkconfig docker on
-# docker ps
-
-service --status-all
-chkconfig --list
+sleep 5
+service docker start
+chkconfig docker on
+docker ps
 
 for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
 	cp /etc/buildkite-agent/init.d.tmpl "/etc/init.d/buildkite-agent-${i}"

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -102,9 +102,12 @@ start terminationd || true
 service awslogs restart || true
 
 # start up docker, wait for it to initialize
-service docker start
-chkconfig docker on
-docker ps
+# service docker start
+# chkconfig docker on
+# docker ps
+
+service --status-all
+chkconfig --list
 
 for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
 	cp /etc/buildkite-agent/init.d.tmpl "/etc/init.d/buildkite-agent-${i}"

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -102,8 +102,7 @@ start terminationd || true
 service awslogs restart || true
 
 # start up docker, wait for it to initialize
-sleep 5
-service docker start
+service docker start || true
 chkconfig docker on
 docker ps
 

--- a/packer/conf/docker/docker.conf
+++ b/packer/conf/docker/docker.conf
@@ -1,5 +1,7 @@
 # We use the overlay2 storage driver for performance
 OPTIONS="-s overlay2 --debug"
 
+DAEMON_MAXFILES=4096
+
 # Force native resolver to work around https://github.com/docker/docker/issues/22673
 export GODEBUG=netdns=cgo

--- a/packer/conf/docker/docker.conf
+++ b/packer/conf/docker/docker.conf
@@ -1,5 +1,5 @@
 # We use the overlay2 storage driver for performance
-OPTIONS="-s overlay2"
+OPTIONS="-s overlay2 --debug"
 
 # Force native resolver to work around https://github.com/docker/docker/issues/22673
 export GODEBUG=netdns=cgo

--- a/packer/conf/docker/init.d/docker
+++ b/packer/conf/docker/init.d/docker
@@ -66,6 +66,7 @@ start() {
     fi
 
     check_for_cleanup
+    set -x
 
     if ! [ -f $pidfile ]; then
         prestart

--- a/packer/conf/docker/init.d/docker
+++ b/packer/conf/docker/init.d/docker
@@ -66,7 +66,6 @@ start() {
     fi
 
     check_for_cleanup
-    set -x
 
     if ! [ -f $pidfile ]; then
         prestart


### PR DESCRIPTION
Hot fixes for #266 

The docker init script seems to randomly fail to start, although docker is actually starting correctly.

This also enables docker debug by default.