### PR TITLE
Support spot fleets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ STACK_NAME ?= buildkite
 SHELL=/bin/bash -o pipefail
 TEMPLATES=templates/description.yml \
   templates/buildkite-elastic.yml \
-  templates/autoscale.yml \
+  templates/asg.yml \
+  templates/spot-fleet.yml \
   templates/vpc.yml \
   templates/metrics.yml \
   templates/outputs.yml

--- a/templates/asg.yml
+++ b/templates/asg.yml
@@ -2,7 +2,7 @@
 Resources:
   AgentScaleUpPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
-    Condition: UseAutoscaling
+    Condition: UseAutoScalingGroup
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: { Ref: AgentAutoScaleGroup }
@@ -11,7 +11,7 @@ Resources:
 
   AgentScaleDownPolicy:
     Type: AWS::AutoScaling::ScalingPolicy
-    Condition: UseAutoscaling
+    Condition: UseAutoScalingGroup
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: { Ref: AgentAutoScaleGroup }
@@ -20,7 +20,7 @@ Resources:
 
   AgentUtilizationAlarmHigh:
    Type: AWS::CloudWatch::Alarm
-   Condition: UseAutoscaling
+   Condition: UseAutoScalingGroup
    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
@@ -37,7 +37,7 @@ Resources:
 
   AgentUtilizationAlarmLow:
    Type: AWS::CloudWatch::Alarm
-   Condition: UseAutoscaling
+   Condition: UseAutoScalingGroup
    Properties:
       AlarmDescription: Scale-down if UnfinishedJobs == 0 for N minutes
       MetricName: UnfinishedJobsCount

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -156,7 +156,7 @@ Parameters:
   SpotPrice:
     Description: Spot bid price per unit in a spot fleet. Use "auto" for automatic pricing or "0" for on-demand instances.
     Type: String
-    Default:
+    Default: "0"
 
   MaxSize:
     Description: Maximum number of instances

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -154,9 +154,9 @@ Parameters:
     MinLength: 1
 
   SpotPrice:
-    Description: Spot bid price to use for the instances. 0 means normal (non-spot) instances
+    Description: Spot bid price per unit in a spot fleet. Use "auto" for automatic pricing or "0" for on-demand instances.
     Type: String
-    Default: 0
+    Default:
 
   MaxSize:
     Description: Maximum number of instances
@@ -292,6 +292,12 @@ Outputs:
 Conditions:
     UseSpotInstances:
       "Fn::Not": [ "Fn::Equals": [ { Ref: SpotPrice }, 0 ] ]
+
+    UseSpotInstancesWithAutoPricing:
+      "Fn::Equals": [ { Ref: SpotPrice }, "auto" ]
+
+    UseOnDemandInstances:
+      "Fn::Not": { Condition: UseAutoscaling }
 
     CreateVpcResources:
       "Fn::Equals": [ { Ref: VpcId }, "" ]
@@ -565,9 +571,11 @@ Resources:
 
   AgentLifecycleTopic:
     Type: AWS::SNS::Topic
+    Condition: UseOnDemandInstances
 
   AgentLifecycleHookRole:
     Type: AWS::IAM::Role
+    Condition: UseOnDemandInstances
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -587,6 +595,7 @@ Resources:
 
   AgentLifecycleHook:
     Type: AWS::AutoScaling::LifecycleHook
+    Condition: UseOnDemandInstances
     Properties:
       AutoScalingGroupName: { Ref: AgentAutoScaleGroup }
       LifecycleTransition: autoscaling:EC2_INSTANCE_TERMINATING
@@ -597,6 +606,7 @@ Resources:
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    Condition: UseOnDemandInstances
     Properties:
       VPCZoneIdentifier:
         { "Fn::If": [ "CreateVpcResources", [ { Ref: Subnet0 }, { Ref: Subnet1 } ], { Ref: Subnets } ] }
@@ -616,7 +626,6 @@ Resources:
       TerminationPolicies:
         - OldestLaunchConfiguration
         - ClosestToNextInstanceHour
-
     CreationPolicy:
       ResourceSignal:
         Timeout: PT5M
@@ -643,3 +652,60 @@ Resources:
       Tags:
       - Key: Name
         Value: { Ref: 'AWS::StackName' }
+
+  SpotFleetIAMRole:
+    Type: AWS::IAM::Role
+    Condition: UseSpotInstances
+    Properties:
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ spotfleet.amazonaws.com ]
+            Action: sts:AssumeRole
+      Path: /
+
+  SpotFleet:
+    Type: AWS::EC2::SpotFleet
+    Condition: UseSpotInstances
+    Properties:
+      SpotFleetRequestConfigData:
+        AllocationStrategy: lowestPrice
+        IamFleetRole: !GetAtt SpotFleetIAMRole.Arn
+        TargetCapacity: !Ref MinSize
+        SpotPrice: !Ref SpotPrice
+        LaunchTemplateConfigs:
+          - LaunchTemplateSpecification:
+            LaunchTemplateId: { Ref: AgentLaunchTemplate }
+            Version: { "Fn::GetAtt" : ["AgentLaunchTemplate", "LatestVersionNumber"] }
+
+  SpotFleetScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Condition: UseSpotInstances
+    Properties:
+      MaxCapacity: !Ref MaxSize
+      MinCapacity: !Ref MinSize
+      ResourceId: "spot-fleet-request/$(SpotFleet)"
+      RoleARN: !GetAtt [SpotFleetIAMRole, Arn]
+      ScalableDimension: 'ec2:spot-fleet-request:TargetCapacity'
+      ServiceNamespace: 'ec2'
+
+  FleetUpPolicy:
+    Type : "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Condition: UseSpotInstances
+    Properties:
+      PolicyName: FleetUpPolicy
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref SpotFleetScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: '1500'
+        MetricAggregationType: Average
+        StepAdjustments:
+          - MetricIntervalUpperBound: 10
+            MetricIntervalLowerBound: 0
+            ScalingAdjustment: 1
+          - MetricIntervalLowerBound: 10
+            ScalingAdjustment: 1

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -290,14 +290,14 @@ Outputs:
       "Fn::If": [CreateSecretsBucket, { Ref: ManagedSecretsLoggingBucket }, "" ]
 
 Conditions:
-    UseSpotInstances:
+    UseSpotFleet:
       "Fn::Not": [ "Fn::Equals": [ { Ref: SpotPrice }, 0 ] ]
 
-    UseSpotInstancesWithAutoPricing:
+    UseSpotFleetWithAutoPricing:
       "Fn::Equals": [ { Ref: SpotPrice }, "auto" ]
 
-    UseOnDemandInstances:
-      "Fn::Not": { Condition: UseAutoscaling }
+    UseAutoScalingGroup:
+      "Fn::Not": { Condition: UseSpotFleet }
 
     CreateVpcResources:
       "Fn::Equals": [ { Ref: VpcId }, "" ]
@@ -329,11 +329,8 @@ Conditions:
     UseECR:
       "Fn::Not": [ "Fn::Equals": [ { Ref: ECRAccessPolicy }, "none" ] ]
 
-    UseAutoscaling:
-      "Fn::Not": [ "Fn::Equals": [ { Ref: MaxSize }, { Ref: MinSize } ] ]
-
     CreateMetricsStack:
-      Condition: UseAutoscaling
+      "Fn::Not": [ "Fn::Equals": [ { Ref: MaxSize }, { Ref: MinSize } ] ]
 
     UseCostAllocationTags:
       "Fn::Equals": [ { Ref: EnableCostAllocationTags }, "true" ]
@@ -652,60 +649,3 @@ Resources:
       Tags:
       - Key: Name
         Value: { Ref: 'AWS::StackName' }
-
-  SpotFleetIAMRole:
-    Type: AWS::IAM::Role
-    Condition: UseSpotInstances
-    Properties:
-      ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
-      AssumeRolePolicyDocument:
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: [ spotfleet.amazonaws.com ]
-            Action: sts:AssumeRole
-      Path: /
-
-  SpotFleet:
-    Type: AWS::EC2::SpotFleet
-    Condition: UseSpotInstances
-    Properties:
-      SpotFleetRequestConfigData:
-        AllocationStrategy: lowestPrice
-        IamFleetRole: !GetAtt SpotFleetIAMRole.Arn
-        TargetCapacity: !Ref MinSize
-        SpotPrice: !Ref SpotPrice
-        LaunchTemplateConfigs:
-          - LaunchTemplateSpecification:
-            LaunchTemplateId: { Ref: AgentLaunchTemplate }
-            Version: { "Fn::GetAtt" : ["AgentLaunchTemplate", "LatestVersionNumber"] }
-
-  SpotFleetScalableTarget:
-    Type: AWS::ApplicationAutoScaling::ScalableTarget
-    Condition: UseSpotInstances
-    Properties:
-      MaxCapacity: !Ref MaxSize
-      MinCapacity: !Ref MinSize
-      ResourceId: "spot-fleet-request/$(SpotFleet)"
-      RoleARN: !GetAtt [SpotFleetIAMRole, Arn]
-      ScalableDimension: 'ec2:spot-fleet-request:TargetCapacity'
-      ServiceNamespace: 'ec2'
-
-  FleetUpPolicy:
-    Type : "AWS::ApplicationAutoScaling::ScalingPolicy"
-    Condition: UseSpotInstances
-    Properties:
-      PolicyName: FleetUpPolicy
-      PolicyType: StepScaling
-      ScalingTargetId: !Ref SpotFleetScalableTarget
-      StepScalingPolicyConfiguration:
-        AdjustmentType: ChangeInCapacity
-        Cooldown: '1500'
-        MetricAggregationType: Average
-        StepAdjustments:
-          - MetricIntervalUpperBound: 10
-            MetricIntervalLowerBound: 0
-            ScalingAdjustment: 1
-          - MetricIntervalLowerBound: 10
-            ScalingAdjustment: 1

--- a/templates/spot-fleet.yml
+++ b/templates/spot-fleet.yml
@@ -1,0 +1,58 @@
+
+Resources:
+  SpotFleetIAMRole:
+    Type: AWS::IAM::Role
+    Condition: UseSpotFleet
+    Properties:
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ spotfleet.amazonaws.com ]
+            Action: sts:AssumeRole
+      Path: /
+
+  SpotFleet:
+    Type: AWS::EC2::SpotFleet
+    Condition: UseSpotFleet
+    Properties:
+      SpotFleetRequestConfigData:
+        AllocationStrategy: lowestPrice
+        IamFleetRole: !GetAtt SpotFleetIAMRole.Arn
+        TargetCapacity: !Ref MinSize
+        SpotPrice: !Ref SpotPrice
+        LaunchTemplateConfigs:
+          - LaunchTemplateSpecification:
+            LaunchTemplateId: { Ref: AgentLaunchTemplate }
+            Version: { "Fn::GetAtt" : ["AgentLaunchTemplate", "LatestVersionNumber"] }
+
+  SpotFleetScalableTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Condition: UseSpotFleet
+    Properties:
+      MaxCapacity: !Ref MaxSize
+      MinCapacity: !Ref MinSize
+      ResourceId: "spot-fleet-request/$(SpotFleet)"
+      RoleARN: !GetAtt [SpotFleetIAMRole, Arn]
+      ScalableDimension: 'ec2:spot-fleet-request:TargetCapacity'
+      ServiceNamespace: 'ec2'
+
+  FleetUpPolicy:
+    Type : "AWS::ApplicationAutoScaling::ScalingPolicy"
+    Condition: UseSpotFleet
+    Properties:
+      PolicyName: FleetUpPolicy
+      PolicyType: StepScaling
+      ScalingTargetId: !Ref SpotFleetScalableTarget
+      StepScalingPolicyConfiguration:
+        AdjustmentType: ChangeInCapacity
+        Cooldown: '1500'
+        MetricAggregationType: Average
+        StepAdjustments:
+          - MetricIntervalUpperBound: 10
+            MetricIntervalLowerBound: 0
+            ScalingAdjustment: 1
+          - MetricIntervalLowerBound: 10
+            ScalingAdjustment: 1


### PR DESCRIPTION
Very early thinking for spot fleets.

At this stage I'm thinking we will provide a built-in list of instances and weights and the only parameter that will be customisable is the spot price param we currently have. 

Because of how Spot Fleet scaling works, we need to implement scaling and launch configurations both in the old ASGs and the new Spot Fleets. It's a pain, but should be largely invisible to the user.

