### PR TITLE
Add a ScaleDownPeriod param to control scale-down timeframe

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -6,7 +6,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown: 120
+      Cooldown: 300
       ScalingAdjustment : $(ScaleUpAdjustment)
 
   AgentScaleDownPolicy:
@@ -15,7 +15,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: $(AgentAutoScaleGroup)
-      Cooldown: 60
+      Cooldown: 300
       ScalingAdjustment: $(ScaleDownAdjustment)
 
   AgentUtilizationAlarmHigh:
@@ -39,12 +39,12 @@ Resources:
    Type: AWS::CloudWatch::Alarm
    Condition: UseAutoscaling
    Properties:
-      AlarmDescription: Scale-down if UnfinishedJobs == 0 for 30 minutes
+      AlarmDescription: Scale-down if UnfinishedJobs == 0 for N minutes
       MetricName: UnfinishedJobsCount
       Namespace: Buildkite
       Statistic: Maximum
-      Period: 300
-      EvaluationPeriods: 6
+      Period: $(ScaleDownPeriod)
+      EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ $(AgentScaleDownPolicy) ]
       Dimensions:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -161,6 +161,11 @@ Parameters:
     Default: -1
     MaxValue: 0
 
+  ScaleDownPeriod:
+    Description: Number of seconds UnfinishedJobs must equal 0 before scale down
+    Type: Number
+    Default: 1800
+
   RootVolumeSize:
     Description: Size of each instance's root EBS volume (in GB)
     Type: Number


### PR DESCRIPTION
Based on discussion in slack, this adds the ability to tune the timeframe around which scale down occurs.

It also slightly increases both the scale up and down cooldown timers (60 seconds to 300 seconds), because I've been meaning to for ages. The current stack will scale up again before the new instance has even finished booting.  