### PR TITLE
Default the agent to beta

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -61,7 +61,7 @@ Parameters:
       - stable
       - beta
       - edge
-    Default: "stable"
+    Default: "beta"
 
   BuildkiteAgentToken:
     Description: Buildkite agent token


### PR DESCRIPTION
Seeing as this is the advice I tend to give in the slack channel anyway, default the agent to beta. :rocket: