### PR TITLE
Add PutObject permission for managed secrets bucket

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -76,10 +76,6 @@ cat << EOF > config.json
     "ParameterValue": "t2.nano"
   },
   {
-    "ParameterKey": "SecretsBucket",
-    "ParameterValue": "${BUILDKITE_AWS_STACK_BUCKET}"
-  },
-  {
     "ParameterKey": "VpcId",
     "ParameterValue": "${vpc_id}"
   },

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -348,7 +348,7 @@ Resources:
               - s3:Get*
               - s3:Get
               - s3:List*
-              - s3:PutObject
+              - s3:Put*
             Resource:
               - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}/*" }
               - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}" }

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -222,6 +222,9 @@ Conditions:
     CreateSecretsBucket:
       "Fn::Equals": [ { Ref: SecretsBucket }, "" ]
 
+    UseSpecifiedSecretsBucket:
+      "Fn::Not": [ "Fn::Equals": [ { Ref: SecretsBucket }, "" ] ]
+
     UseSpecifiedAvailabilityZones:
       "Fn::Not": [ "Fn::Equals": [ "Fn::Join": [ "", { Ref: AvailabilityZones } ], "" ]  ]
 
@@ -333,8 +336,28 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
 
-  SecretsBucketPolicies:
+  ManagedSecretsBucketPolicy:
     Type: AWS::IAM::Policy
+    Condition: CreateSecretsBucket
+    Properties:
+      PolicyName: SecretsBucketPolicy
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:Get*
+              - s3:Get
+              - s3:List*
+              - s3:PutObject
+            Resource:
+              - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}/*" }
+              - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}" }
+      Roles:
+        - { Ref: IAMRole }
+
+  UnmanagedSecretsBucketPolicy:
+    Type: AWS::IAM::Policy
+    Condition: UseSpecifiedSecretsBucket
     Properties:
       PolicyName: SecretsBucketPolicy
       PolicyDocument:
@@ -345,14 +368,8 @@ Resources:
               - s3:Get
               - s3:List*
             Resource:
-              - "Fn::If":
-                - CreateSecretsBucket
-                - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}/*" }
-                - { "Fn::Sub": "arn:aws:s3:::${SecretsBucket}/*" }
-              - "Fn::If":
-                - CreateSecretsBucket
-                - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}" }
-                - { "Fn::Sub": "arn:aws:s3:::${SecretsBucket}" }
+              - { "Fn::Sub": "arn:aws:s3:::${SecretsBucket}/*" }
+              - { "Fn::Sub": "arn:aws:s3:::${SecretsBucket}" }
       Roles:
         - { Ref: IAMRole }
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -326,11 +326,20 @@ Resources:
       Roles:
         - { Ref: IAMRole }
 
+  ManagedSecretsLoggingBucket:
+    Type: AWS::S3::Bucket
+    Condition: CreateSecretsBucket
+    DeletionPolicy: Retain
+    Properties:
+      AccessControl: LogDeliveryWrite
+
   ManagedSecretsBucket:
     Type: AWS::S3::Bucket
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
+      LoggingConfiguration:
+        DestinationBucketName: { Ref: ManagedSecretsLoggingBucket }
       VersioningConfiguration:
         Status: Enabled
 
@@ -346,7 +355,6 @@ Resources:
               - s3:Get*
               - s3:Get
               - s3:List*
-              - s3:Put*
             Resource:
               - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}/*" }
               - { "Fn::Sub": "arn:aws:s3:::${ManagedSecretsBucket}" }

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -331,8 +331,6 @@ Resources:
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
-      LoggingConfiguration:
-        LogFilePrefix: logs/
       VersioningConfiguration:
         Status: Enabled
 


### PR DESCRIPTION
This fixes a bug where the permissions were incorrect for managed secrets bucket. 