### PR TITLE
[WIP] Windows support - #286

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -14,6 +14,13 @@
     }
   ],
   "provisioners": [
+      {
+           "type": "powershell",
+           "inline": [
+              "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))",
+              "choco install -y 7zip git"
+           ]
+       },
        {
            "type": "powershell",
            "script": "scripts/windows-init.ps1"

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,40 +3,20 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-c58c1dd3",
-      "region": "us-east-1",
+      "source_ami": "ami-17106201",
       "instance_type": "c4.large",
-      "ssh_username": "ec2-user",
-      "ami_name": "buildkite-stack-{{isotime | clean_ami_name}}",
-      "ami_description": "Buildkite CloudFormation Stack base image (Amazon Linux, buildkite-agent, docker, docker-compose, docker-gc, jq)",
+      "ami_name": "buildkite-stack-windows-{{isotime | clean_ami_name}}",
+      "user_data_file": "scripts/ec2-userdata.ps1",
+      "communicator": "winrm",
+      "winrm_username": "Administrator",
+      "ami_description": "Buildkite CloudFormation Stack base image (Windows-Server-2016-English-Full-Containers, buildkite-agent, docker-compose, docker-gc, jq)",
       "ami_groups": ["all"]
     }
   ],
   "provisioners": [
-    {
-      "type": "file",
-      "source": "conf",
-      "destination": "/tmp"
-    },
-    {
-      "type": "shell",
-      "script": "scripts/install-utils.sh"
-    },
-    {
-      "type": "shell",
-      "script": "scripts/install-awslogs.sh"
-    },
-    {
-      "type": "shell",
-      "script": "scripts/install-terminationd.sh"
-    },
-    {
-      "type": "shell",
-      "script": "scripts/install-docker.sh"
-    },
-    {
-      "type": "shell",
-      "script": "scripts/install-buildkite-agent.sh"
-    }
+       {
+           "type": "powershell",
+           "script": "scripts/windows-init.ps1"
+       }
   ]
 }

--- a/packer/scripts/ec2-userdata.ps1
+++ b/packer/scripts/ec2-userdata.ps1
@@ -1,0 +1,35 @@
+<powershell>
+
+write-output "Running User Data Script"
+write-host "(host) Running User Data Script"
+
+Set-ExecutionPolicy Unrestricted -Scope LocalMachine -Force -ErrorAction Ignore
+
+# Don't set this before Set-ExecutionPolicy as it throws an error
+$ErrorActionPreference = "stop"
+
+# Remove HTTP listener
+Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
+
+# WinRM
+write-output "Setting up WinRM"
+write-host "(host) setting up WinRM"
+
+cmd.exe /c winrm quickconfig -q
+cmd.exe /c winrm quickconfig '-transport:http'
+cmd.exe /c winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
+cmd.exe /c winrm set "winrm/config/winrs" '@{MaxMemoryPerShellMB="1024"}'
+cmd.exe /c winrm set "winrm/config/service" '@{AllowUnencrypted="true"}'
+cmd.exe /c winrm set "winrm/config/client" '@{AllowUnencrypted="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
+cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
+cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTP" '@{Port="5985"}'
+cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
+cmd.exe /c netsh firewall add portopening TCP 5985 "Port 5985"
+cmd.exe /c net stop winrm
+cmd.exe /c sc config winrm start= auto
+cmd.exe /c net start winrm
+cmd.exe /c wmic useraccount where "name='vagrant'" set PasswordExpires=FALSE
+
+</powershell>

--- a/packer/scripts/windows-init.ps1
+++ b/packer/scripts/windows-init.ps1
@@ -1,0 +1,5 @@
+<powershell>
+
+write-output "Running init Script"
+
+</powershell>


### PR DESCRIPTION
- build from AMI image Windows_Server-2016-English-Full-Containers-2017.05.10
- install chocolatey
- use chocolatey to install 7zip, git, later we can add more applications. If you can package buildkite via chocolatey, that will be simpler as well.

This PR is still in WIP, please don't merge it.

Let me know how to arrange the templates for linux and windows. Currently I didn't update `Makefile` and use the same template name to easily build the new image.