### PR TITLE
TMPDIR is unbound in the environment hook

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -39,6 +39,7 @@ echo "Sourcing CloudFormation environment..."
 # shellcheck source=/dev/null
 source ~/cfn-env
 
+TMPDIR=${TMPDIR:-/tmp}
 export AWS_REGION
 export AWS_DEFAULT_REGION
 export AWS_ECR_LOGIN


### PR DESCRIPTION
Let's set it like [the plugin does](https://github.com/buildkite-plugins/s3-secrets-buildkite-plugin/blob/master/hooks/environment#L10).