### PR TITLE
Backport SECRETS_PLUGIN_ENABLED for disabling secrets in 2.1.x

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -43,11 +43,11 @@ export AWS_REGION
 export AWS_DEFAULT_REGION
 export AWS_ECR_LOGIN
 
-echo "Starting an SSH Agent..."
-eval "$(ssh-agent -s)"
-echo
+if [[ "${SECRETS_PLUGIN_ENABLED:-1}" != "1" ]] && [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
+  echo "Starting an SSH Agent..."
+  eval "$(ssh-agent -s)"
+  echo
 
-if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" ]] ; then
   if [[ -n "${BUILDKITE_SECRETS_KEY:-}" ]] ; then
     echo "~~~ :warning: Deprecated BUILDKITE_SECRETS_KEY env variable"
     echo "AWS KMS is now the supported method for decrypting files from your secrets bucket."


### PR DESCRIPTION
This allows for the secrets functionality to be entirely disabled. It backports `SECRETS_PLUGIN_ENABLED` like in the forthcoming 2.2.x series. 

You can then just set this in env and it will skip the secrets code.