### PR TITLE
Download the edge binary on install / startup

### DIFF
--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -12,10 +12,7 @@ echo "Agent stable sha256 is $stable_agent_sha"
 unstable_agent_sha=$(curl -Lfs https://download.buildkite.com/agent/unstable/latest/buildkite-agent-linux-amd64.sha256)
 echo "Agent unstable sha256 is $unstable_agent_sha"
 
-experimental_agent_sha=$(curl -Lfs https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64.sha256)
-echo "Agent experimental sha256 is $experimental_agent_sha"
-
-packer_hash=$(echo "$packer_files_sha" "$stable_agent_sha" "$unstable_agent_sha" "$experimental_agent_sha" | sha1sum | awk '{print $1}')
+packer_hash=$(echo "$packer_files_sha" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
 echo "Packer image hash is $packer_hash"
 
 packer_file="${packer_hash}.packer"

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -43,6 +43,14 @@ if [[ "${BUILDKITE_ECR_POLICY:-none}" != "none" ]] ; then
 	printf "AWS_ECR_LOGIN=1\n" >> /var/lib/buildkite-agent/cfn-env
 fi
 
+if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
+	echo "Downloading buildkite-agent edge..."
+	curl -Lsf -o /usr/bin/buildkite-agent-edge \
+		"https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64"
+	chmod +x /usr/bin/buildkite-agent-edge
+	buildkite-agent-edge --version
+fi
+
 # Choose the right agent binary
 ln -s "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
 

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -22,12 +22,6 @@ sudo curl -Lsf -o /usr/bin/buildkite-agent-beta \
 sudo chmod +x /usr/bin/buildkite-agent-beta
 buildkite-agent-beta --version
 
-echo "Downloading buildkite-agent edge..."
-sudo curl -Lsf -o /usr/bin/buildkite-agent-edge \
-  "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64"
-sudo chmod +x /usr/bin/buildkite-agent-edge
-buildkite-agent-edge --version
-
 echo "Downloading legacy bootstrap.sh for v2 stable agent..."
 sudo mkdir -p /etc/buildkite-agent
 sudo curl -Lsf -o /etc/buildkite-agent/bootstrap.sh \


### PR DESCRIPTION
Currently the edge binary is installed to the AMI. This makes iterating on edge difficult. This change defers download and install for edge to the install / boot of the host.

This means it's possible to bump edge version by scaling down the stack and letting new instances be spun up. 