### PR TITLE
Docker 17.06.0-ce, was 17.05.0-ce.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 
 * [Amazon Linux 2017.03.1](https://aws.amazon.com/amazon-linux-ami/)
 * [Buildkite Agent](https://buildkite.com/docs/agent)
-* [Docker 17.05.0-ce](https://www.docker.com)
+* [Docker 17.06.0-ce](https://www.docker.com)
 * [Docker Compose 1.14.0](https://docs.docker.com/compose/)
 * [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks
 * [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from cli tools such as aws-cli or the Buildkite API

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=17.05.0-ce
+DOCKER_VERSION=17.06.0-ce
 DOCKER_COMPOSE_VERSION=1.14.0
 
 # This performs a manual install of Docker. The init.d script is from the


### PR DESCRIPTION
Docker 17.06 supports [multi-stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) in a single Dockerfile, which is a massive win for CI builds.

I haven't tested this version bump in any way, but I don't see any breaking changes between 17.05 and 17.06 in the announcement: https://blog.docker.com/2017/06/announcing-docker-17-06-community-edition-ce/
