### PR TITLE
Revert "Docker 17.06.0-ce, was 17.05.0-ce."

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 
 * [Amazon Linux 2017.03.1](https://aws.amazon.com/amazon-linux-ami/)
 * [Buildkite Agent](https://buildkite.com/docs/agent)
-* [Docker 17.06.0-ce](https://www.docker.com)
+* [Docker 17.05.0-ce](https://www.docker.com)
 * [Docker Compose 1.14.0](https://docs.docker.com/compose/)
 * [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks
 * [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from cli tools such as aws-cli or the Buildkite API

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=17.06.0-ce
+DOCKER_VERSION=17.05.0-ce
 DOCKER_COMPOSE_VERSION=1.14.0
 ECR_LOGIN_VERSION=v1.0.0
 


### PR DESCRIPTION
Reverts buildkite/elastic-ci-stack-for-aws#307

There are some breaking changes around ecr-login that I would prefer not to deal with yet, and the URL is broken.