### PR TITLE
Add back deprecated DOCKER_HUB_USER variables

### DIFF
--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -10,6 +10,18 @@ if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" 
 fi
 
 if [[ -n "${DOCKER_LOGIN_USER:-}" && "${DOCKER_LOGIN_PLUGIN_ENABLED:-}" == "1" ]] ; then
+
+  if [[ -n "${DOCKER_HUB_USER:-}" && -n "${DOCKER_HUB_PASSWORD:-}" ]]; then
+    echo "~~~ :warning: Deprecated DOCKER_HUB_* env variables"
+    echo "The following environment variables have been deprecated, and will be removed"
+    echo "in Elastic CI Stack for AWS v3 and above:"
+    echo "  * DOCKER_HUB_USER - has been renamed to DOCKER_LOGIN_USER"
+    echo "  * DOCKER_HUB_PASSWORD - has been renamed to DOCKER_LOGIN_PASSWORD"
+    echo "Please update your secrets bucket env hook."
+    DOCKER_LOGIN_USER="${DOCKER_HUB_USER}"
+    DOCKER_LOGIN_PASSWORD="${DOCKER_HUB_PASSWORD}"
+  fi
+
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="$DOCKER_LOGIN_USER"
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_PASSWORD="$DOCKER_LOGIN_PASSWORD"
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_SERVER="${DOCKER_LOGIN_SERVER:-}"


### PR DESCRIPTION
This reverts commit fbe85162182331d0b76d2046d09ca61cd2660b24 and adds back support for `DOCKER_HUB_USER` - to be removed in v3