### PR TITLE
Prevent unused images from filling up agent disk

### DIFF
--- a/packer/conf/docker/cron.daily/docker-gc
+++ b/packer/conf/docker/cron.daily/docker-gc
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 # prune stopped containers and images
-docker system prune -f
+docker system prune -af --filter "until=4h"


### PR DESCRIPTION
Using system prune works better than the previous `docker-gc` but we found after 10 days the unused images were enough to fill our 80GB disk.

This prunes unused images as well as "dangling" images (the default) older than 4 hours.

NOTE: This can have a nasty side effect that images are not available for use by the docker build cache, which results in slower build times. We have multiple ways to work around this internally, but it may not be desirable for all users.
Having the build cache around "forever" (as long as the instance is around) can be rather convenient.