### PR TITLE
Publish a latest template with the stable release

### DIFF
--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -9,5 +9,5 @@ grep -rl '^#!/.*sh' . | while read -r file ; do
 
   echo "Processing $file"
   docker run --rm -v "$PWD:/mnt" koalaman/shellcheck "$file"
-  echo -e "Ok.\n"
+  echo -e 'Ok.\n'
 done

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -26,7 +26,7 @@ is_tag_build() {
 }
 
 is_latest_tag() {
-  [[ "$BUILDKITE_TAG" = $(git describe --abbrev=0 --tags --match 'v*' | grep -v '-rc') ]]
+  [[ "$BUILDKITE_TAG" = $(git describe --abbrev=0 --tags --match 'v*' | grep -v -- '-rc') ]]
 }
 
 is_release_candidate_tag() {

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -28,10 +28,10 @@ stack_follow() {
   done
   if [[ $status =~ FAILED ]] ; then
     stack_events "$1"
-    echo -e "\033[33;31mStack creation failed!\n$(stack_failures "$1")\033[0m"
+    echo -e "\\033[33;31mStack creation failed!\\n$(stack_failures "$1")\\033[0m"
     return 1
   else
-    echo -e "\033[33;32mStack completed successfully\033[0m"
+    echo -e '\033[33;32mStack completed successfully\033[0m'
   fi
 }
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Features:
 
 See the [Elastic CI Stack for AWS guide](https://buildkite.com/docs/guides/elastic-ci-stack-aws) for a step-by-step guide, or jump straight in:
 
-[![Launch AWS Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json)
+[![Launch AWS Stack](https://cdn.rawgit.com/buildkite/cloudformation-launch-stack-button-svg/master/launch-stack.svg)](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=buildkite&templateURL=https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.json)
 
 Current release is ![](https://img.shields.io/github/release/buildkite/elastic-ci-stack-for-aws.svg). See [Releases](https://github.com/buildkite/elastic-ci-stack-for-aws/releases) for older releases, or [Versions](#versions) for development version
 
@@ -61,7 +61,7 @@ If you'd like to use the [AWS CLI](https://aws.amazon.com/cli/), download [`conf
 aws cloudformation create-stack \
   --output text \
   --stack-name buildkite \
-  --template-url "https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json" \
+  --template-url "https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.json" \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --parameters $(cat config.json)
 ```

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -40,7 +40,7 @@ AWS_REGION=$AWS_REGION
 EOF
 
 if [[ "${BUILDKITE_ECR_POLICY:-none}" != "none" ]] ; then
-	printf "AWS_ECR_LOGIN=1\n" >> /var/lib/buildkite-agent/cfn-env
+	printf 'AWS_ECR_LOGIN=1\n' >> /var/lib/buildkite-agent/cfn-env
 fi
 
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then


### PR DESCRIPTION
Currently release candidates are published to https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json, which has lead to some people opt-ing into release candidates without realizing it.

This change keeps the behaviour for https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json, but adds https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.json that refers to the latest release (excluding pre-releases).