### PR TITLE
Add configuration option to enable EBS volume encryption.

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -32,6 +32,7 @@ Metadata:
         - AuthorizedUsersUrl
         - BootstrapScriptUrl
         - RootVolumeSize
+        - EncryptRootVolume
         - AssociatePublicIpAddress
         - ManagedPolicyARN
 
@@ -179,6 +180,14 @@ Parameters:
     Type: Number
     Default: 250
     MinValue: 10
+
+  EncryptRootVolume:
+    Description: Encrypt instance root EBS volumes (will require a supported instance type)
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: "false"
 
   SecurityGroupId:
     Type: String
@@ -453,7 +462,7 @@ Resources:
         { "Fn::If": [ "UseDefaultAMI", { "Fn::FindInMap": [ AWSRegion2AMI, { Ref: 'AWS::Region' }, 'AMI'] }, { Ref: ImageId } ] }
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
-          Ebs: { VolumeSize: { Ref: RootVolumeSize }, VolumeType: gp2 }
+          Ebs: { VolumeSize: { Ref: RootVolumeSize }, VolumeType: gp2, Encrypted: { Ref: EncryptRootVolume } }
       UserData:
         "Fn::Base64":
           "Fn::Sub":


### PR DESCRIPTION
Adds support for #318. So far not tested due to other issues.

Note that if set to true, the instance types available for use [will be limited](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#EBSEncryption_supported_instances).