### PR TITLE
Add a dependency on the Gateway for the DefaultRoute

### DIFF
--- a/templates/vpc.yml
+++ b/templates/vpc.yml
@@ -58,6 +58,7 @@ Resources:
 
   Routes:
     Type: AWS::EC2::RouteTable
+    DependsOn: Gateway
     Condition: CreateVpcResources
     Properties:
       VpcId: { Ref: Vpc }
@@ -68,6 +69,7 @@ Resources:
   RouteDefault:
     Type: AWS::EC2::Route
     Condition: CreateVpcResources
+    DependsOn: Gateway
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: { Ref: Gateway }


### PR DESCRIPTION
Fixes a bug raised by @pda where there is a race condition between the gateway creation and the default route. Something something eventual consistency. 

![image](https://user-images.githubusercontent.com/15758/29992457-e9e0b50a-8fde-11e7-8b6b-6c96723281ad.png)
