### PR TITLE
VPC: fix explicit DependsOn: GatewayAttachment

### DIFF
--- a/templates/vpc.yml
+++ b/templates/vpc.yml
@@ -20,7 +20,6 @@ Resources:
 
   GatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
-    DependsOn: Gateway
     Condition: CreateVpcResources
     Properties:
       InternetGatewayId: { Ref: Gateway }
@@ -58,7 +57,7 @@ Resources:
 
   Routes:
     Type: AWS::EC2::RouteTable
-    DependsOn: Gateway
+    DependsOn: GatewayAttachment
     Condition: CreateVpcResources
     Properties:
       VpcId: { Ref: Vpc }
@@ -69,7 +68,6 @@ Resources:
   RouteDefault:
     Type: AWS::EC2::Route
     Condition: CreateVpcResources
-    DependsOn: Gateway
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: { Ref: Gateway }

--- a/templates/vpc.yml
+++ b/templates/vpc.yml
@@ -57,7 +57,6 @@ Resources:
 
   Routes:
     Type: AWS::EC2::RouteTable
-    DependsOn: GatewayAttachment
     Condition: CreateVpcResources
     Properties:
       VpcId: { Ref: Vpc }
@@ -68,6 +67,7 @@ Resources:
   RouteDefault:
     Type: AWS::EC2::Route
     Condition: CreateVpcResources
+    DependsOn: GatewayAttachment
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: { Ref: Gateway }


### PR DESCRIPTION
Follow-up to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/336

`DependsOn` is required for implicit dependencies that aren't represented by things like `Ref: Foo`. I think the only implicit dependency here is `RouteDefault` depending on `GatewayAttachment`; the dependency on the `Gateway` itself is explicit via `GatewayId: { Ref: Gateway }`, but that `Gateway` must be attached to the `Vpc` before the `Route` can be created, so there's an implicit dependency on `GatewayAttachment`.

See similar use-case in https://github.com/awslabs/ecs-refarch-cloudformation/blob/8a10c808/infrastructure/vpc.yaml#L137-L143