### PR TITLE
Namespace and rename the CloudWatch log groups

### DIFF
--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -1,9 +1,9 @@
 [general]
 state_file = /var/awslogs/state/agent-state
 
-[/buildkite/systemd]
+[/buildkite/system]
 file = /var/log/messages
-log_group_name = /buildkite/systemd
+log_group_name = /buildkite/system
 log_stream_name = {instance_id}
 datetime_format = %b %d %H:%M:%S
 
@@ -25,14 +25,16 @@ log_group_name = /buildkite/cloud-init
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
-[/buildkite/cloud-init-output]
+[/buildkite/cloud-init/output]
 file = /var/log/cloud-init-output.log
-log_group_name = /buildkite/cloud-init-output
+log_group_name = /buildkite/cloud-init/output
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
-[/buildkite/buildkite-agent]
+[/buildkite/elastic-stack-init]
 file = /var/log/elastic-stack.log
-log_group_name = /buildkite/buildkite-agent
+log_group_name = /buildkite/elastic-stack-init
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
+
+# buildkite-agent logs config is written into here by elastic-stack-init

--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -1,38 +1,38 @@
 [general]
 state_file = /var/awslogs/state/agent-state
 
-[/var/log/messages]
+[/buildkite/systemd]
 file = /var/log/messages
-log_group_name = /var/log/messages
+log_group_name = /buildkite/systemd
 log_stream_name = {instance_id}
 datetime_format = %b %d %H:%M:%S
 
-[/var/log/docker]
+[/buildkite/docker-daemon]
 file = /var/log/docker
-log_group_name = /var/log/docker
+log_group_name = /buildkite/docker-daemon
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%S.%f
 
-[/var/log/cfn-init.log]
+[/buildkite/cfn-init]
 file = /var/log/cfn-init.log
-log_group_name = /var/log/cfn-init.log
+log_group_name = /buildkite/cfn-init
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
-[/var/log/cloud-init.log]
+[/buildkite/cloud-init]
 file = /var/log/cloud-init.log
-log_group_name = /var/log/cloud-init.log
+log_group_name = /buildkite/cloud-init
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
-[/var/log/cloud-init-output.log]
+[/buildkite/cloud-init-output]
 file = /var/log/cloud-init-output.log
-log_group_name = /var/log/cloud-init-output.log
+log_group_name = /buildkite/cloud-init-output
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
-[/var/log/elastic-stack.log]
+[/buildkite/buildkite-agent]
 file = /var/log/elastic-stack.log
-log_group_name = /var/log/elastic-stack.log
+log_group_name = /buildkite/buildkite-agent
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -84,9 +84,9 @@ for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
 
 	# Setup logging first so we capture everything
 	cat <<- EOF > "/etc/awslogs/config/buildkite-agent-${i}.conf"
-	[/var/log/buildkite-agent-${i}.log]
+	[/buildkite/buildkite-agent-${i}.log]
 	file = /var/log/buildkite-agent-${i}.log
-	log_group_name = /var/log/buildkite-agent.log
+	log_group_name = /buildkite/buildkite-agent
 	log_stream_name = {instance_id}-${i}
 	datetime_format = %Y-%m-%d %H:%M:%S
 	EOF


### PR DESCRIPTION
As reported in #342, the CloudWatch log groups are currently quite roughly named, and not namespaced to Buildkite. If you’re using the stack in an existing AWS account this can create a bit of mess.

This PR namespaces everything under `/buildkite` and renames the groups to be consistent and a little more friendly.

Closes #342