### PR TITLE
Revert "Spin up new ASG and replace on update"

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -561,8 +561,18 @@ Resources:
         Timeout: PT5M
         Count: { Ref: MinSize }
     UpdatePolicy:
-      AutoScalingReplacingUpdate:
-        WillReplace: true
+      AutoScalingRollingUpdate:
+        MinInstancesInService: 0
+        MaxBatchSize: 5
+        # On rollback this might have to wait for an agent to finish
+        # a job. The agent's init script waits 30 minutes, so we wait
+        # a maximum of 40 minutes to be safe.
+        PauseTime: PT40M
+        WaitOnResourceSignals: true
+        # Ignore scaling alarms during update
+        SuspendProcesses:
+          - AlarmNotification
+          - ScheduledActions
 
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
In commit 35a23b3295bfe21b8ce4a78fd35c0cb1da781883 we changed the stack to spin up a new ASG in parallel, which speeds up stack updates, but at the expense of not giving the old instances that still might be running builds time to finish. 

