### PR TITLE
Login as buildkite user

### DIFF
--- a/packer/conf/buildkite-agent/init.d/buildkite-agent
+++ b/packer/conf/buildkite-agent/init.d/buildkite-agent
@@ -37,7 +37,7 @@ case "$1" in
         echo "Already started"
     else
         echo "Starting $name"
-        sudo -u "$user" $cmd >>"$log" 2>&1 &
+        sudo -iu "$user" $cmd >>"$log" 2>&1 &
         echo $! > "$pid_file"
         if ! is_running; then
             echo "Unable to start, see log"


### PR DESCRIPTION
## Context

Recently we found `/usr/local/bin` was not in `buildkite-agent` user's path. I tried adding it to the bash_profile for the user, but that didn't work because we're calling sudo and it defaults to the `secure_path`, which by default is very restrictive

## Change

Emulate user login when launching buildkite-agent so we get all the env variables sourced from `.bash_profile`