### PR TITLE
Support assuming IAM roles for job execution

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -8,6 +8,29 @@ source ~/cfn-env
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 
+if [[ -n "${AWS_ASSUME_IAM_ROLE:-}"]] ; then
+  IAM_ROLE=${AWS_ASSUME_IAM_ROLE}
+  aws_cred_tmp=$(mktemp -t aws-json-XXXXXX)
+
+  echo "Assuming IAM Role $AWS_ASSUME_IAM_ROLE"
+  aws sts assume-role --role-arn "${role}" --role-session-name bk-${BUILDKITE_JOB_ID} > "${aws_cred_tmp}"
+
+  export AWS_ACCESS_KEY_ID=$(cat ${aws_cred_tmp} | jq -r ".Credentials.AccessKeyId")
+  export AWS_SECRET_ACCESS_KEY=$(cat ${aws_cred_tmp} | jq -r ".Credentials.SecretAccessKey")
+  export AWS_SESSION_TOKEN=$(cat ${aws_cred_tmp} | jq -r ".Credentials.SessionToken")
+  export AWS_SESSION_EXPIRATION=$(cat ${aws_cred_tmp} | jq -r ".Credentials.Expiration")
+
+  rm aws_cred_tmp
+
+  # If we have a role, block the metadata service
+  export AWS_BLOCK_METADATA_SERVICE=true
+fi
+
+if [[ ${AWS_BLOCK_METADATA_SERVICE:-false} =~ (on|1|true)]] ; then
+  echo "Blocking AWS Metadata Serrvice"
+  sudo /usr/bin/block-ec2-metadata-service
+fi
+
 echo "Checking docker processes"
 pgrep -lf docker
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -8,26 +8,25 @@ source ~/cfn-env
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 
-if [[ -n "${AWS_ASSUME_IAM_ROLE:-}"]] ; then
-  IAM_ROLE=${AWS_ASSUME_IAM_ROLE}
+if [[ -n "${AWS_ASSUME_IAM_ROLE:-}" ]] ; then
   aws_cred_tmp=$(mktemp -t aws-json-XXXXXX)
 
   echo "Assuming IAM Role $AWS_ASSUME_IAM_ROLE"
-  aws sts assume-role --role-arn "${role}" --role-session-name bk-${BUILDKITE_JOB_ID} > "${aws_cred_tmp}"
+  aws sts assume-role --role-arn "${AWS_ASSUME_IAM_ROLE}" --role-session-name "bk-${BUILDKITE_JOB_ID}" > "${aws_cred_tmp}"
 
-  export AWS_ACCESS_KEY_ID=$(cat ${aws_cred_tmp} | jq -r ".Credentials.AccessKeyId")
-  export AWS_SECRET_ACCESS_KEY=$(cat ${aws_cred_tmp} | jq -r ".Credentials.SecretAccessKey")
-  export AWS_SESSION_TOKEN=$(cat ${aws_cred_tmp} | jq -r ".Credentials.SessionToken")
-  export AWS_SESSION_EXPIRATION=$(cat ${aws_cred_tmp} | jq -r ".Credentials.Expiration")
+  export AWS_ACCESS_KEY_ID; AWS_ACCESS_KEY_ID=$(jq -r ".Credentials.AccessKeyId" "${aws_cred_tmp}")
+  export AWS_SECRET_ACCESS_KEY; AWS_SECRET_ACCESS_KEY=$(jq -r ".Credentials.SecretAccessKey" "${aws_cred_tmp}")
+  export AWS_SESSION_TOKEN; AWS_SESSION_TOKEN=$(jq -r ".Credentials.SessionToken" "${aws_cred_tmp}")
+  export AWS_SESSION_EXPIRATION; AWS_SESSION_EXPIRATION=$(jq -r ".Credentials.Expiration" "${aws_cred_tmp}")
 
-  rm aws_cred_tmp
+  rm "${aws_cred_tmp}"
 
   # If we have a role, block the metadata service
   export AWS_BLOCK_METADATA_SERVICE=true
 fi
 
-if [[ ${AWS_BLOCK_METADATA_SERVICE:-false} =~ (on|1|true)]] ; then
-  echo "Blocking AWS Metadata Serrvice"
+if [[ ${AWS_BLOCK_METADATA_SERVICE:-false} =~ (on|1|true) ]] ; then
+  echo "Blocking AWS Metadata Service"
   sudo /usr/bin/block-ec2-metadata-service
 fi
 

--- a/packer/conf/buildkite-agent/scripts/block-ec2-metadata-service
+++ b/packer/conf/buildkite-agent/scripts/block-ec2-metadata-service
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+iptables -A OUTPUT -m owner ! --uid-owner root -d 169.254.169.254 -j DROP

--- a/packer/conf/buildkite-agent/sudoers.conf
+++ b/packer/conf/buildkite-agent/sudoers.conf
@@ -1,1 +1,2 @@
 buildkite-agent ALL=NOPASSWD: /usr/bin/fix-buildkite-agent-builds-permissions
+buildkite-agent ALL=NOPASSWD: /usr/bin/block-ec2-metadata-service


### PR DESCRIPTION
This adds support passing in an IAM role in `AWS_ASSUME_IAM_ROLE` that will be assumed in the `environment` hook. The EC2 metadata service gets firewalled off at that point, so the job that runs has the permissions of the assumed role.

The motivation here is to make a secure way to give a given pipeline a set of AWS permissions. 