### PR TITLE
Enable, behind a parameter, pre-emptive scaling

### DIFF
--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -39,13 +39,13 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: PreemptiveScaling
     Properties:
-      AlarmDescription: Scale-up if IdleAgentCount > 1 for N minute
+      AlarmDescription: Scale-up if IdleAgentCount > X for Y minute
       MetricName: IdleAgentCount
       Namespace: Buildkite
       Statistic: Maximum
       Period: { Ref: ScaleDownPeriod }
       EvaluationPeriods: 1
-      Threshold: 1
+      Threshold: { Ref: AgentsPerInstance }
       AlarmActions: [ { Ref: AgentScaleDownPolicy } ]
       Dimensions:
         - Name: Queue

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -35,6 +35,23 @@ Resources:
           Value: { Ref: BuildkiteQueue }
       ComparisonOperator: LessThanThreshold
 
+  AgentSpareAlarmLow:
+    Type: AWS::CloudWatch::Alarm
+    Condition: PreemptiveScaling
+    Properties:
+      AlarmDescription: Scale-up if IdleAgentCount > 1 for N minute
+      MetricName: IdleAgentCount
+      Namespace: Buildkite
+      Statistic: Maximum
+      Period: { Ref: ScaleDownPeriod }
+      EvaluationPeriods: 1
+      Threshold: 1
+      AlarmActions: [ { Ref: AgentScaleDownPolicy } ]
+      Dimensions:
+        - Name: Queue
+          Value: { Ref: BuildkiteQueue }
+      ComparisonOperator: GreaterThanThreshold
+
   AgentUtilizationAlarmHigh:
    Type: AWS::CloudWatch::Alarm
    Condition: StandardScaling
@@ -54,7 +71,7 @@ Resources:
 
   AgentUtilizationAlarmLow:
    Type: AWS::CloudWatch::Alarm
-   Condition: UseAutoscaling
+   Condition: StandardScaling
    Properties:
       AlarmDescription: Scale-down if UnfinishedJobs == 0 for N minutes
       MetricName: UnfinishedJobsCount

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -18,9 +18,26 @@ Resources:
       Cooldown: 300
       ScalingAdjustment: { Ref: ScaleDownAdjustment }
 
+  AgentSpareAlarmHigh:
+    Type: AWS::CloudWatch::Alarm
+    Condition: PreemptiveScaling
+    Properties:
+      AlarmDescription: Scale-up if IdleAgentCount < 1 for 1 minute
+      MetricName: IdleAgentCount
+      Namespace: Buildkite
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      AlarmActions: [ { Ref: AgentScaleUpPolicy } ]
+      Dimensions:
+        - Name: Queue
+          Value: { Ref: BuildkiteQueue }
+      ComparisonOperator: LessThanThreshold
+
   AgentUtilizationAlarmHigh:
    Type: AWS::CloudWatch::Alarm
-   Condition: UseAutoscaling
+   Condition: StandardScaling
    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount

--- a/templates/autoscale.yml
+++ b/templates/autoscale.yml
@@ -39,7 +39,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: PreemptiveScaling
     Properties:
-      AlarmDescription: Scale-up if IdleAgentCount > X for Y minute
+      AlarmDescription: Scale-down if IdleAgentCount > X for Y minute
       MetricName: IdleAgentCount
       Namespace: Buildkite
       Statistic: Maximum

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -245,6 +245,14 @@ Parameters:
       - false
     Default: "false"
 
+  EnablePreemptiveScaling:
+    Type: String
+    Description: Whether or not to always keep a spare Buildkite Agent running
+    AllowedValues:
+      - true
+      - false
+    Default: "false"
+
 Outputs:
   ManagedSecretsBucket:
     Value:
@@ -287,6 +295,12 @@ Conditions:
 
     UseAutoscaling:
       "Fn::Not": [ "Fn::Equals": [ { Ref: MaxSize }, { Ref: MinSize } ] ]
+
+    PreemptiveScaling:
+      "Fn::And": [ Condition: UseAutoscaling, [ "Fn::Equals": [ { Ref: EnablePreemptiveScaling }, "true" ] ] ]
+
+    StandardScaling:
+      "Fn::And": [ Condition: UseAutoscaling, { "Fn::Not": [ "Fn::Equals": [ { Ref: EnablePreemptiveScaling }, "true" ] ] } ]
 
     CreateMetricsStack:
       "Fn::And": [ Condition: UseAutoscaling, { "Fn::Not": [ "Fn::Equals": [ { Ref: BuildkiteApiAccessToken }, "" ] ] } ]

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -247,7 +247,7 @@ Parameters:
 
   EnablePreemptiveScaling:
     Type: String
-    Description: Whether or not to always keep a spare Buildkite Agent running
+    Description: Whether or not to always keep a spare Buildkite Agent running. Note your ASG will never scale down to 0.
     AllowedValues:
       - true
       - false

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -297,7 +297,7 @@ Conditions:
       "Fn::Not": [ "Fn::Equals": [ { Ref: MaxSize }, { Ref: MinSize } ] ]
 
     PreemptiveScaling:
-      "Fn::And": [ Condition: UseAutoscaling, [ "Fn::Equals": [ { Ref: EnablePreemptiveScaling }, "true" ] ] ]
+      "Fn::And": [ Condition: UseAutoscaling, { "Fn::Equals": [ { Ref: EnablePreemptiveScaling }, "true" ] } ]
 
     StandardScaling:
       "Fn::And": [ Condition: UseAutoscaling, { "Fn::Not": [ "Fn::Equals": [ { Ref: EnablePreemptiveScaling }, "true" ] ] } ]


### PR DESCRIPTION
## Context

In some scenarios we like to scale up pre-emptively, to always have a spare agent available no matter what. This ensures we are never waiting on an agent to boot (2-3minutes) while the site is down and we're trying to push through a fix.

## Changes

Create two new alarms, enabled behind a parameter, that scale up if there is less than one idle agent or down if there is more than n where n is the number of Agents Per Instance.

We also disable the normal alarms if this flag is set.