### PR TITLE
Update buildkite-metrics to v2.0.0

### DIFF
--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -45,7 +45,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, { Ref: 'AWS::Region' }, 'Bucket'] }
-        S3Key: "buildkite-metrics-v2.0.0-lambda.zip"
+        S3Key: "buildkite-metrics-2.0.0-lambda.zip"
       Role:
         Fn::GetAtt:
         - LambdaExecutionRole

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -45,7 +45,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, { Ref: 'AWS::Region' }, 'Bucket'] }
-        S3Key: "buildkite-metrics-v1.5.0-lambda.zip"
+        S3Key: "buildkite-metrics-v2.0.0-lambda.zip"
       Role:
         Fn::GetAtt:
         - LambdaExecutionRole


### PR DESCRIPTION
This brings in a new buildkite-metrics version that respects our rate limiting and reduces the volume of metrics api requests.