### PR TITLE
Bump the lambda metrics timeout to 5m

### DIFF
--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -50,7 +50,7 @@ Resources:
         Fn::GetAtt:
         - LambdaExecutionRole
         - Arn
-      Timeout: 120
+      Timeout: 300
       Handler: handler.handle
       Runtime: python2.7
       MemorySize: 128


### PR DESCRIPTION
We've been seeing some larger deployments having issues with metrics lamba's timing out due to the new rate limiting exponential backoff. This should at least reduce the dogpile effect whilst we figure out the root cause. 