### PR TITLE
Backport fixes for v2.3.2

### DIFF
--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -45,7 +45,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, { Ref: 'AWS::Region' }, 'Bucket'] }
-        S3Key: "buildkite-metrics-2.0.0-lambda.zip"
+        S3Key: "buildkite-metrics-v2.0.2-lambda.zip"
       Role:
         Fn::GetAtt:
         - LambdaExecutionRole
@@ -59,6 +59,9 @@ Resources:
           BUILDKITE_TOKEN: { Ref: BuildkiteApiAccessToken }
           BUILDKITE_ORG: { Ref: BuildkiteOrgSlug }
           BUILDKITE_QUEUE: { Ref: BuildkiteQueue }
+          AWS_STACK_ID: { Ref: "AWS::StackId" }
+          AWS_STACK_NAME: { Ref: "AWS::StackName" }
+          AWS_ACCOUNT_ID: { Ref: "AWS::AccountId" }
 
   ScheduledRule:
     Type: "AWS::Events::Rule"


### PR DESCRIPTION
This backports #364 and #366 to predate the recent major network changes for a v2.3.2 release. 