### PR TITLE
Make CloudFormation generate unique role names

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -325,7 +325,6 @@ Resources:
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: { "Fn::Sub": "${AWS::StackName}-Role" }
       ManagedPolicyArns:
         - "Fn::If":
           - UseManagedPolicyARN


### PR DESCRIPTION
At the moment, deploying the same stack (with the same details such as stack name) on multiple regions would cause an error: `IAM Role already exists`.

By not setting the IAM Role's RoleName, we can have CloudFormation generate a unique RoleName, allowing the same stack (with the same details such as stack name) to be deployed on multiple regions.