### PR TITLE
Pass AWS_ECR_LOGIN_REGISTRY_IDS to ecr plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ You can disable this in individual pipelines by setting `AWS_ECR_LOGIN=false`.
 
 If you want to login to an ECR server on another AWS account, you can set `AWS_ECR_LOGIN_REGISTRY_IDS="id1,id2,id3"`.
 
+The AWS ECR options are powered by an embedded version of the [ECR plugin](https://github.com/buildkite-plugins/ecr-buildkite-plugin), so if you require options that aren't listed here, you can disable the embedded version as above and call the plugin directly. See [it's README](https://github.com/buildkite-plugins/ecr-buildkite-plugin) for more examples (requires Agent v3.x).
+
 ## Versions
 
 We recommend running the latest release, which is available at `https://s3.amazonaws.com/buildkite-aws-stack/aws-stack.json`, or on the [releases page](https://github.com/buildkite/elastic-ci-stack-for-aws/releases).

--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -5,6 +5,11 @@ set -eu -o pipefail
 if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" ]] ; then
   export BUILDKITE_PLUGIN_ECR_LOGIN=1
 
+  # map AWS_ECR_LOGIN_REGISTRY_IDS into the plugin list format
+  if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
+    export BUILDKITE_PLUGIN_ECR_REGISTRY_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
+  fi
+
   # shellcheck source=/dev/null
   source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/pre-command
 fi


### PR DESCRIPTION
The docs mention `AWS_ECR_LOGIN_REGISTRY_IDS`, but we weren't mapping it through to the internal ECR plugin variable.