### PR TITLE
Add logging for disk space issues

### DIFF
--- a/packer/conf/bin/bk-check-disk-space.sh
+++ b/packer/conf/bin/bk-check-disk-space.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+DISK_MIN_AVAILABLE=${DISK_MIN_AVAILABLE:-1048576} # 1GB
+DISK_MIN_INODES=${DISK_MIN_INODES:-10000}
+
+disk_avail=$(df -k --output=avail "$PWD" | tail -n1)
+
+if [[ $disk_avail -lt $DISK_MIN_AVAILABLE ]]; then
+  echo "Not enough disk space free 🚨" >&2
+  return 1
+else
+  echo "Disk space free: $disk_avail ✅"
+fi
+
+inodes_avail=$(df -k --output=iavail "$PWD" | tail -n1)
+
+if [[ $inodes_avail -lt $DISK_MIN_INODES ]]; then
+  echo "Not enough inodes free 🚨" >&2
+  return 1
+else
+  echo "Inodes free: $inodes_avail ✅"
+fi

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 ## Installs the Buildkite Agent, run from the CloudFormation template
 
-exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+# Write to system console and to our log file
+# See https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee  /var/log/elastic-stack.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 on_error() {
 	local exitCode="$?"

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -11,6 +11,9 @@ cat ~/cfn-env
 echo "Checking docker processes"
 pgrep -lf docker
 
+echo "Checking disk space"
+/usr/local/bin/bk-check-disk-space.sh
+
 echo "Configuring built-in plugins"
 
 [[ ! ${SECRETS_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/secrets/}

--- a/packer/conf/docker/cron.hourly/docker-gc
+++ b/packer/conf/docker/cron.hourly/docker-gc
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+if [[ $EUID -eq 0 ]]; then
+  exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+fi
 
 DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-4h}
 

--- a/packer/conf/docker/cron.hourly/docker-gc
+++ b/packer/conf/docker/cron.hourly/docker-gc
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+
 DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-4h}
 
 ## ------------------------------------------

--- a/packer/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/conf/docker/cron.hourly/docker-low-disk-gc
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+if [[ $EUID -eq 0 ]]; then
+  exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+fi
 
 DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-1h}
 

--- a/packer/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/conf/docker/cron.hourly/docker-low-disk-gc
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-DISK_MIN_AVAILABLE=${DISK_MIN_AVAILABLE:-1048576} # 1GB
-DISK_MIN_INODES=${DISK_MIN_INODES:-10000}
+exec > /var/log/elastic-stack.log 2>&1 # Logs to elastic-stack.log
+
 DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-1h}
 
 mark_instance_unhealthy() {
@@ -15,31 +15,13 @@ mark_instance_unhealthy() {
     --health-status Unhealthy
 }
 
-check_disk_healthy() {
-  disk_avail=$(df -k --output=avail "$PWD" | tail -n1)
-  echo "Disk space free: $disk_avail"
-
-  if [[ $disk_avail -lt $DISK_MIN_AVAILABLE ]]; then
-    echo "Not enough disk space free" >&2
-    return 1
-  fi
-
-  inodes_avail=$(df -k --output=iavail "$PWD" | tail -n1)
-  echo "Inodes free: $inodes_avail"
-
-  if [[ $inodes_avail -lt $DISK_MIN_INODES ]]; then
-    echo "Not enough inodes free" >&2
-    return 1
-  fi
-}
-
 trap mark_instance_unhealthy ERR
 
 ## -----------------------------------------------------------------
 ## Check disk, we only want to prune images/containers if we have to
 
-if ! check_disk_healthy ; then
-  echo "~~~ Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL}"
+if ! /usr/local/bin/bk-check-disk-space.sh ; then
+  echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL}"
   docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
 
   if ! check_disk_healthy ; then

--- a/tests/cron.bats
+++ b/tests/cron.bats
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 
 @test "Check low disk docker cron script can run" {
-	run sudo /etc/cron.daily/docker-low-disk-gc
+	run /etc/cron.daily/docker-low-disk-gc
   echo "status = ${status}"
   echo "output = ${output}"
 	[ $status = 0 ]
 }
 
 @test "Check docker cron script can run" {
-	run sudo /etc/cron.daily/docker-gc
+	run /etc/cron.daily/docker-gc
   echo "status = ${status}"
   echo "output = ${output}"
 	[ $status = 0 ]

--- a/tests/cron.bats
+++ b/tests/cron.bats
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 
 @test "Check low disk docker cron script can run" {
-	run /etc/cron.daily/docker-low-disk-gc
+	run sudo /etc/cron.daily/docker-low-disk-gc
   echo "status = ${status}"
   echo "output = ${output}"
 	[ $status = 0 ]
 }
 
 @test "Check docker cron script can run" {
-	run /etc/cron.daily/docker-gc
+	run sudo /etc/cron.daily/docker-gc
   echo "status = ${status}"
   echo "output = ${output}"
 	[ $status = 0 ]


### PR DESCRIPTION
It turns out the the output of `/etc/cron.daily/docker-gc` and `/etc/cron.daily/docker-low-disk-gc` wasn't getting output anywhere.

This PR appends that to the system log. Beyond that, it checks the system disk usage as part of each job.

The motivation for these changes are the issues customers have been having with instances running out of disk. Because these checks currently only happen daily, my theory is that the instances are running out of disk before the clean up can happen. Alternately, it's possible the scripts aren't running for some reason 🤷🏼‍♂️

/cc @maria-v