### PR TITLE
Clean up disk space in environment

### DIFF
--- a/packer/conf/bin/bk-check-disk-space.sh
+++ b/packer/conf/bin/bk-check-disk-space.sh
@@ -6,7 +6,7 @@ DISK_MIN_INODES=${DISK_MIN_INODES:-10000}
 
 disk_avail=$(df -k --output=avail "$PWD" | tail -n1)
 
-echo "Disk space free: $(df -k -h --output=avail "$PWD" | tail -n1)"
+echo "Disk space free: $(df -k -h --output=avail "$PWD" | tail -n1 | sed -e 's/^[[:space:]]//')"
 
 if [[ $disk_avail -lt $DISK_MIN_AVAILABLE ]]; then
   echo "Not enough disk space free, cutoff is ${DISK_MIN_AVAILABLE} 🚨" >&2
@@ -15,7 +15,7 @@ fi
 
 inodes_avail=$(df -k --output=iavail "$PWD" | tail -n1)
 
-echo "Inodes free: $(df -k -h --output=iavail "$PWD" | tail -n1)"
+echo "Inodes free: $(df -k -h --output=iavail "$PWD" | tail -n1 | sed -e 's/^[[:space:]]//')"
 
 if [[ $inodes_avail -lt $DISK_MIN_INODES ]]; then
   echo "Not enough inodes free, cutoff is ${DISK_MIN_INODES inodes} 🚨" >&2

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -8,11 +8,23 @@ source ~/cfn-env
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 
-echo "Checking docker processes"
+echo ":docker: Checking docker processes"
 pgrep -lf docker
 
 echo "Checking disk space"
-/usr/local/bin/bk-check-disk-space.sh
+if ! /usr/local/bin/bk-check-disk-space.sh ; then
+  echo ":warning: Disk space is low, generally this is either your builds or docker"
+  du -d 4 -h -t 100M /var/lib | sort -h
+
+  echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL:-4h}"
+  docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL:-4h}"
+
+  echo "Checking disk space again"
+  if ! /usr/local/bin/bk-check-disk-space.sh ; then
+    echo "Disk health checks failed" >&2
+    exit 1
+  fi
+fi
 
 echo "Configuring built-in plugins"
 

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -13,8 +13,6 @@ pgrep -lf docker
 
 echo "Checking disk space"
 if ! /usr/local/bin/bk-check-disk-space.sh ; then
-  echo ":warning: Disk space is low, generally this is either your builds or docker"
-  du -d 4 -h -t 100M /var/lib | sort -h
 
   echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL:-4h}"
   docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL:-4h}"

--- a/packer/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/conf/docker/cron.hourly/docker-low-disk-gc
@@ -26,7 +26,7 @@ if ! /usr/local/bin/bk-check-disk-space.sh ; then
   echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL}"
   docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
 
-  if ! check_disk_healthy ; then
+  if ! /usr/local/bin/bk-check-disk-space.sh ; then
     echo "Disk health checks failed" >&2
     exit 1
   fi


### PR DESCRIPTION
This follows up on #373 and actually tries to clear disk up before a build if space is low. This should be a good balance between not always doing this, but not failing builds because we haven't been aggressive enough on disk cleaning.