### PR TITLE
Use boothook to configure docker

### DIFF
--- a/packer/conf/bin/bk-configure-docker.sh
+++ b/packer/conf/bin/bk-configure-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+## Configures docker before system starts
+
+# Write to system console and to our log file
+# See https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee -a /var/log/elastic-stack.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+# Swap in the userns remap config
+if [[ "${DOCKER_USERNS_REMAP:-false}" == "true" ]] ; then
+	cp /etc/sysconfig/docker.userns-remap /etc/sysconfig/docker
+fi

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -32,12 +32,6 @@ cwlogs = cwlogs
 region = $AWS_REGION
 EOF
 
-if [[ "${DOCKER_USERNS_REMAP:-false}" == "true" ]] ; then
-	echo "Enabling docker userns-remap"
-	cp /etc/sysconfig/docker.userns-remap /etc/sysconfig/docker
-	service docker restart
-fi
-
 PLUGINS_ENABLED=()
 [[ $SECRETS_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("secrets")
 [[ $ECR_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("ecr")

--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -eu -o pipefail
 
 # shellcheck source=/dev/null
@@ -8,8 +7,16 @@ source ~/cfn-env
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 
-echo "Checking docker processes"
-pgrep -lf docker
+
+echo "Checking docker"
+if ! docker ps ; then
+  echo "^^^ +++"
+  echo ":alert: Docker isn't running!"
+  set -x
+  pgrep -lf docker
+  tail -n 50 /var/log/docker
+  exit 1
+fi
 
 echo "Checking disk space"
 /usr/local/bin/bk-check-disk-space.sh

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -465,6 +465,15 @@ Resources:
         "Fn::Base64":
           "Fn::Sub":
             - |
+              Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+              MIME-Version: 1.0
+              --==BOUNDARY==
+              Content-Type: text/cloud-boothook; charset="us-ascii"
+              DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+                /usr/local/bin/bk-configure-docker.sh
+
+              --==BOUNDARY==
+              Content-Type: text/x-shellscript; charset="us-ascii"
               #!/bin/bash -xv
               BUILDKITE_STACK_NAME="${AWS::StackName}" \
               BUILDKITE_STACK_VERSION=dev \
@@ -485,6 +494,7 @@ Resources:
               DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
               AWS_REGION=${AWS::Region} \
                 /usr/local/bin/bk-install-elastic-stack.sh
+              --==BOUNDARY==--
             - LocalSecretsBucket:
                 "Fn::If":
                   - CreateSecretsBucket


### PR DESCRIPTION
We frequently have folks running into an issue where their docker daemon is non-responsive on boot. Historically we saw this in #266, but continue to see it sporadically. 

This uses [cloud-init boothooks](https://cloudinit.readthedocs.io/en/latest/topics/format.html#cloud-boothook) to configure docker before it boots, which avoids the (suspected) race condition entirely. 

Given it also avoids a docker restart, it should make for faster boot times too. 