### PR TITLE
AMI update from 2017-11-22 to 2018-01-17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## unreleased
+
+- AMI built from ami-97785bed (Amazon Linux AMI 2017.09.1 released on 2018-01-17)
+
 ## v2.3.4 - 2018-02-13
 ### Fixed
 - Configure docker before it starts to avoid corruption [\#377](https://github.com/buildkite/elastic-ci-stack-for-aws/issues/377)

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,13 +3,13 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-55ef662f",
+      "source_ami": "ami-97785bed",
       "instance_type": "i3.large",
       "spot_price": "auto",
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",
       "ssh_username": "ec2-user",
       "ami_name": "buildkite-stack-{{isotime | clean_ami_name}}",
-      "ami_description": "Buildkite CloudFormation Stack base image (Amazon Linux, buildkite-agent, docker, docker-compose, docker-gc, jq)",
+      "ami_description": "Buildkite CloudFormation Stack base image (Amazon Linux 2017.09.1 ami-97785bed 2018-01-17, buildkite-agent, docker, docker-compose, docker-gc, jq)",
       "ami_groups": ["all"]
     }
   ],


### PR DESCRIPTION
Update the Amazon Linux source AMI from `ami-55ef662f` (built 2017-11-22) to `ami-97785bed` (built 2018-02-14). It would be nice to be running a post-spectre-meltdown AMI build, even if Amazon Linux or Buildkite's AMI builds have maybe mitigated the issue some other way.

I've also added the version and release date to the AMI description;

```diff
-Buildkite CloudFormation Stack base image (Amazon Linux, buildkite-agent, docker, docker-compose, docker-gc, jq)
+Buildkite CloudFormation Stack base image (Amazon Linux 2017.09.1 ami-97785bed 2018-01-17, buildkite-agent, docker, docker-compose, docker-gc, jq)
```

This makes it possible to figure out from the AWS AMI listing what the base distro version is. This is pretty important for security etc. However it will need to be manually updated each time the AMI is bumped. If that seems too error prone, I'm happy to remove it from there.

Note that the Amazon Linux version identifier is not enough on its own; e.g. `2017.09.1` had at least two builds/releases; 2017-11-22 and 2018-01-17.

---

Previous source AMI:
https://web.archive.org/web/20180107235304/https://aws.amazon.com/amazon-linux-ami/
The latest Amazon Linux AMI 2017.09.1 was released on 2017-11-22.
HVM (SSD) EBS-Backed 64-bit US East N. Virginia
ami-55ef662f

New source AMI:
https://aws.amazon.com/amazon-linux-ami/ (2018-02-14)
The latest Amazon Linux AMI 2017.09.1 was released on 2018-01-17.
HVM (SSD) EBS-Backed 64-bit US East N. Virginia
ami-97785bed

---

Here's my notes from figuring out which versions use which base AMI:

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/buildkite-ami.json#L6
ami-55ef662f (2017-11-22)

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/v2.3.4/packer/buildkite-ami.json#L6
ami-55ef662f (2017-11-22)

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/v2.3.3/packer/buildkite-ami.json#L6
ami-55ef662f (2017-11-22)

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/v2.3.2/packer/buildkite-ami.json#L6
ami-643b1972 (unsure what version this is)

https://aws.amazon.com/amazon-linux-ami/ (2018-02-14)
The latest Amazon Linux AMI 2017.09.1 was released on 2018-01-17.
ami-97785bed
HVM (SSD) EBS-Backed 64-bit US East N. Virginia

https://web.archive.org/web/20180107235304/https://aws.amazon.com/amazon-linux-ami/
The latest Amazon Linux AMI 2017.09.1 was released on 2017-11-22.
ami-55ef662f
HVM (SSD) EBS-Backed 64-bit US East N. Virginia

https://web.archive.org/web/20171118024619/https://aws.amazon.com/amazon-linux-ami/
The latest Amazon Linux AMI 2017.09.0 was released on 2017-10-03.
ami-8c1be5f6
HVM (SSD) EBS-Backed 64-bit US East N. Virginia