### PR TITLE
Fix cfn stack instance profile name

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -36,6 +36,7 @@ Metadata:
         - RootVolumeSize
         - AssociatePublicIpAddress
         - ManagedPolicyARN
+        - InstanceRoleName
 
       - Label:
           default: Auto-scaling Configuration
@@ -204,6 +205,11 @@ Parameters:
     Description: Optional - ARN of a managed IAM policy to attach to the instance role
     Default: ""
 
+  InstanceRoleName:
+    Type: String
+    Description: Optional - A name for the IAM Role attached to the Instance Profile
+    Default: ""
+
   ECRAccessPolicy:
     Type: String
     Description: ECR access policy to give container instances
@@ -268,6 +274,9 @@ Conditions:
     CreateSecretsBucket:
       "Fn::Equals": [ { Ref: SecretsBucket }, "" ]
 
+    SetInstanceRoleName:
+      "Fn::Not": [ "Fn::Equals": [ { Ref: InstanceRoleName }, "" ] ]
+
     UseSpecifiedSecretsBucket:
       "Fn::Not": [ "Fn::Equals": [ { Ref: SecretsBucket }, "" ] ]
 
@@ -326,7 +335,7 @@ Resources:
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: { "Fn::Sub": "${AWS::StackName}-Role" }
+      RoleName: { "Fn::If": [ SetInstanceRoleName, { Ref: InstanceRoleName }, { "Fn::Sub": "${AWS::StackName}-Role" } ] }
       ManagedPolicyArns:
         - "Fn::If":
           - UseManagedPolicyARN


### PR DESCRIPTION
The current version of the stack names the IAM Role in the Instance Profile with ${AWS::StackName}-Role.

Theis results in an IAM Role with a role name like 'the-build-stack-xyzqwrpqr-Role' when the stack is generated by a process which does not fix the stack name (as happens if this template is used as a nested stack). This role name changes every time the stack is re-deployed or updated.
Having this unpredictable role name is problematic if you want the build agent to assume a role, as the 'Principal' of an IAM policy needs to be fixed.
My change allows the user the option to specify a role name if needed. 