### PR TITLE
Installs the latest agent version on boot vs build

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -60,10 +60,11 @@ EOF
 download_agent() {
   local release="$1"
   local channel="$2"
+  local version="${BUILDKITE_AGENT_VERSION:-latest}"
 
-  echo "Downloading buildkite-agent ${release}..."
+  echo "Downloading buildkite-agent ${release}/${version}..."
   sudo curl -Lsf -o "/usr/bin/buildkite-agent" \
-    "https://download.buildkite.com/agent/${channel}/latest/buildkite-agent-linux-amd64"
+    "https://download.buildkite.com/agent/${channel}/${version}/buildkite-agent-linux-amd64"
   sudo chmod +x "/usr/bin/buildkite-agent"
   "buildkite-agent" --version
 }

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -97,9 +97,8 @@ fi
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
-meta-data=$(IFS=, ; echo "${agent_metadata[*]}")
-meta-data-ec2=true
-bootstrap-script="${BOOTSTRAP_SCRIPT}"
+tags=$(IFS=, ; echo "${agent_metadata[*]}")
+tags-from-ec2=true
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -10,25 +10,6 @@ echo "Creating buildkite-agent user..."
 sudo useradd --base-dir /var/lib buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
-echo "Downloading buildkite-agent stable..."
-sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
-  "https://download.buildkite.com/agent/stable/latest/buildkite-agent-linux-amd64"
-sudo chmod +x /usr/bin/buildkite-agent-stable
-buildkite-agent-stable --version
-
-echo "Downloading buildkite-agent beta..."
-sudo curl -Lsf -o /usr/bin/buildkite-agent-beta \
-  "https://download.buildkite.com/agent/unstable/latest/buildkite-agent-linux-amd64"
-sudo chmod +x /usr/bin/buildkite-agent-beta
-buildkite-agent-beta --version
-
-echo "Downloading legacy bootstrap.sh for v2 stable agent..."
-sudo mkdir -p /etc/buildkite-agent
-sudo curl -Lsf -o /etc/buildkite-agent/bootstrap.sh \
-  https://raw.githubusercontent.com/buildkite/agent/2-1-stable/templates/bootstrap.sh
-sudo chmod +x /etc/buildkite-agent/bootstrap.sh
-sudo chown -R buildkite-agent: /etc/buildkite-agent
-
 echo "Adding scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/* /usr/bin
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -77,8 +77,12 @@ Parameters:
     Default: "beta"
 
   BuildkiteAgentVersion:
-    Description: A specific version of the agent to pin to, must exist in the release specified in BuildkiteAgentRelease
+    Description: >
+      A specific version of the agent to pin to, must exist in the release specified in BuildkiteAgentRelease.
+      The version must be in the form of 3.X.X, or 3.X-beta.X, or latest.
+      Note that for beta releases BuildkiteAgentRelease must be set to either beta or edge.
     Type: String
+    AllowedPattern: "^(latest|3\.[0-9]+\.[0-9]+|3\.[0-9]+.beta\.[0-9]+)$"
     Default: "latest"
 
   BuildkiteAgentToken:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -6,6 +6,7 @@ Metadata:
           default: Buildkite Configuration
         Parameters:
         - BuildkiteAgentRelease
+        - BuildkiteAgentVersion
         - BuildkiteAgentToken
         - BuildkiteAgentTags
         - BuildkiteQueue
@@ -74,6 +75,11 @@ Parameters:
       - beta
       - edge
     Default: "beta"
+
+  BuildkiteAgentVersion:
+    Description: A specific version of the agent to pin to, must exist in the release specified in BuildkiteAgentRelease
+    Type: String
+    Default: "latest"
 
   BuildkiteAgentToken:
     Description: Buildkite agent token
@@ -483,6 +489,7 @@ Resources:
               BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
               BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
               BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
+              BUILDKITE_AGENT_VERSION="${BuildkiteAgentVersion}" \
               BUILDKITE_QUEUE="${BuildkiteQueue}" \
               BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
               BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -82,7 +82,7 @@ Parameters:
       The version must be in the form of 3.X.X, or 3.X-beta.X, or latest.
       Note that for beta releases BuildkiteAgentRelease must be set to either beta or edge.
     Type: String
-    AllowedPattern: "^(latest|3\.[0-9]+\.[0-9]+|3\.[0-9]+.beta\.[0-9]+)$"
+    AllowedPattern: "^(latest|3\\.[0-9]+\\.[0-9]+|3\\.[0-9]+.beta\\.[0-9]+)$"
     Default: "latest"
 
   BuildkiteAgentToken:


### PR DESCRIPTION
Previously we installed the latest stable and beta at build time, which speeds up boot time, but means that the versions installed depend on the most recent stack update. 

This switches to installing then on instance boot, which ensures that security and stability updates make it to build instances regardless of the age of the stack. 

This also drops support for the v2 line of agents which required a custom `bootstrap.sh`.