### PR TITLE
Drop support for buildkite-agent v2, stable is 3.0.0

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -67,13 +67,6 @@ fi
 # Choose the right agent binary
 ln -s "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
 
-# Once 3.0 is stable we can just remove this and let the agent do the right thing
-if [[ "${BUILDKITE_AGENT_RELEASE}" == "stable" ]]; then
-	BOOTSTRAP_SCRIPT="/etc/buildkite-agent/bootstrap.sh"
-else
-	BOOTSTRAP_SCRIPT="buildkite-agent bootstrap"
-fi
-
 agent_metadata=(
 	"queue=${BUILDKITE_QUEUE}"
 	"docker=${DOCKER_VERSION}"
@@ -90,9 +83,8 @@ fi
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
-meta-data=$(IFS=, ; echo "${agent_metadata[*]}")
-meta-data-ec2=true
-bootstrap-script="${BOOTSTRAP_SCRIPT}"
+tags=$(IFS=, ; echo "${agent_metadata[*]}")
+tags-from-ec2=true
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -22,13 +22,6 @@ sudo curl -Lsf -o /usr/bin/buildkite-agent-beta \
 sudo chmod +x /usr/bin/buildkite-agent-beta
 buildkite-agent-beta --version
 
-echo "Downloading legacy bootstrap.sh for v2 stable agent..."
-sudo mkdir -p /etc/buildkite-agent
-sudo curl -Lsf -o /etc/buildkite-agent/bootstrap.sh \
-  https://raw.githubusercontent.com/buildkite/agent/2-1-stable/templates/bootstrap.sh
-sudo chmod +x /etc/buildkite-agent/bootstrap.sh
-sudo chown -R buildkite-agent: /etc/buildkite-agent
-
 echo "Adding scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/* /usr/bin
 


### PR DESCRIPTION
A simpler take on #399, this just removes the v2 bash bootstrap.