### PR TITLE
Turn off cost allocation tags by default

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -36,9 +36,6 @@ Metadata:
         - RootVolumeSize
         - AssociatePublicIpAddress
         - ManagedPolicyARN
-        - EnableCostAllocationTags
-        - CostAllocationTagName
-        - CostAllocationTagValue
 
       - Label:
           default: Auto-scaling Configuration
@@ -48,6 +45,13 @@ Metadata:
         - ScaleUpAdjustment
         - ScaleDownAdjustment
         - ScaleDownPeriod
+
+      - Label:
+          default: Cost Allocation Configuration
+        Parameters:
+        - EnableCostAllocationTags
+        - CostAllocationTagName
+        - CostAllocationTagValue
 
       - Label:
           default: Docker Registry Configuration

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -36,6 +36,9 @@ Metadata:
         - RootVolumeSize
         - AssociatePublicIpAddress
         - ManagedPolicyARN
+        - EnableCostAllocationTags
+        - CostAllocationTagName
+        - CostAllocationTagValue
 
       - Label:
           default: Auto-scaling Configuration
@@ -45,9 +48,6 @@ Metadata:
         - ScaleUpAdjustment
         - ScaleDownAdjustment
         - ScaleDownPeriod
-
-      # - Label:
-      #     default: Docker Daemon Configuration
 
       - Label:
           default: Docker Registry Configuration

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -246,12 +246,20 @@ Parameters:
       - false
     Default: "true"
 
-  BuildkiteBillingTagName:
+  EnableCostAllocationTags:
+    Type: String
+    Description: Enables AWS Cost Allocation tags for all resources in the stack. See https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html
+    AllowedValues:
+      - true
+      - false
+    Default: "false"
+
+  CostAllocationTagName:
     Type: String
     Description: The name of the Cost Allocation Tag used for billing purposes
     Default: "aws:createdBy"
 
-  BuildkiteBillingTagValue:
+  CostAllocationTagValue:
     Type: String
     Description: The value of the Cost Allocation Tag used for billing purposes
     Default: "buildkite-elastic-ci-stack-for-aws"
@@ -301,6 +309,9 @@ Conditions:
 
     CreateMetricsStack:
       "Fn::And": [ Condition: UseAutoscaling, { "Fn::Not": [ "Fn::Equals": [ { Ref: BuildkiteApiAccessToken }, "" ] ] } ]
+
+    UseCostAllocationTags:
+      "Fn::Equals": [ { Ref: EnableCostAllocationTags }, "true" ]
 
 Mappings:
   ECRManagedPolicy:
@@ -575,9 +586,12 @@ Resources:
         - Key: BuildkiteQueue
           Value: { Ref: BuildkiteQueue }
           PropagateAtLaunch: true
-        - Key: { Ref: BuildkiteBillingTagName }
-          Value: { Ref: BuildkiteBillingTagValue }
-          PropagateAtLaunch: true
+        - "Fn::If":
+          - UseCostAllocationTags
+          - Key: { Ref: CostAllocationTagName }
+            Value: { Ref: CostAllocationTagValue }
+            PropagateAtLaunch: true
+          - { Ref: "AWS::NoValue" }
 
     CreationPolicy:
       ResourceSignal:


### PR DESCRIPTION
The addition of cost allocation tags in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/398 broke our tests because it needs to be activated per-account:

https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/activate-built-in-tags.html

I've added a `EnableCostAllocationTags` that defaults to `false`, and also renamed the parameters `CostAllocationTagName` and `CostAllocationTagValue`.