### PR TITLE
Use new Metrics API, drop requirement for org-slug and api-token 🎉

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -13,16 +13,8 @@ echo "Using AMI $image_id"
 cat << EOF > config.json
 [
   {
-    "ParameterKey": "BuildkiteOrgSlug",
-    "ParameterValue": "$BUILDKITE_AWS_STACK_ORG_SLUG"
-  },
-  {
     "ParameterKey": "BuildkiteAgentToken",
     "ParameterValue": "$BUILDKITE_AWS_STACK_AGENT_TOKEN"
-  },
-  {
-    "ParameterKey": "BuildkiteApiAccessToken",
-    "ParameterValue": "$BUILDKITE_AWS_STACK_API_TOKEN"
   },
   {
     "ParameterKey": "BuildkiteQueue",

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Examples:
 
 ## Autoscaling
 
-If you have provided `BuildkiteApiAccessToken` and your `MinSize` < `MaxSize`, the stack will automatically scale up and down based on the number of scheduled jobs.
+If you have configured `MinSize` < `MaxSize`, the stack will automatically scale up and down based on the number of scheduled jobs.
 
 This means you can scale down to zero when idle, which means you can use larger instances for the same cost.
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,15 +1,7 @@
 [
   {
-    "ParameterKey": "BuildkiteOrgSlug",
-    "ParameterValue": "MyOrg"
-  },
-  {
     "ParameterKey": "BuildkiteAgentToken",
     "ParameterValue": "TokenGoesHere"
-  },
-  {
-    "ParameterKey": "BuildkiteApiAccessToken",
-    "ParameterValue": "ApiTokenGoesHere"
   },
   {
     "ParameterKey": "KeyName",

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -9,8 +9,6 @@ Metadata:
         - BuildkiteAgentToken
         - BuildkiteAgentTags
         - BuildkiteQueue
-        - BuildkiteOrgSlug
-        - BuildkiteApiAccessToken
 
       - Label:
           default: Network Configuration
@@ -80,26 +78,15 @@ Parameters:
     Default: "beta"
 
   BuildkiteAgentToken:
-    Description: Buildkite agent token
+    Description: Buildkite agent registration token
     Type: String
     NoEcho: true
-    MinLength: 1
-
-  BuildkiteOrgSlug:
-    Description: Buildkite organization slug
-    Type: String
     MinLength: 1
 
   BuildkiteAgentTags:
     Description: Additional tags seperated by commas to provide to the agent. E.g os=linux,llamas=always
     Type: String
     Default: ""
-
-  BuildkiteApiAccessToken:
-    Description: Buildkite API access token with read_pipelines, read_builds and read_agents (required for metrics)
-    Type: String
-    NoEcho: true
-    MinLength: 1
 
   BuildkiteQueue:
     Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -299,7 +299,7 @@ Conditions:
       "Fn::Not": [ "Fn::Equals": [ { Ref: MaxSize }, { Ref: MinSize } ] ]
 
     CreateMetricsStack:
-      "Fn::And": [ Condition: UseAutoscaling, { "Fn::Not": [ "Fn::Equals": [ { Ref: BuildkiteApiAccessToken }, "" ] ] } ]
+      Condition: UseAutoscaling
 
     UseCostAllocationTags:
       "Fn::Equals": [ { Ref: EnableCostAllocationTags }, "true" ]

--- a/templates/metrics.yml
+++ b/templates/metrics.yml
@@ -32,7 +32,6 @@ Resources:
           - logs:CreateLogStream
           - logs:PutLogEvents
           - cloudwatch:PutMetricData
-          - autoscaling:SetInstanceHealth
           Resource:
           - "*"
 
@@ -45,7 +44,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, { Ref: 'AWS::Region' }, 'Bucket'] }
-        S3Key: "buildkite-metrics-v2.0.2-lambda.zip"
+        S3Key: "buildkite-metrics-v3.0.0-lambda.zip"
       Role:
         Fn::GetAtt:
         - LambdaExecutionRole
@@ -56,8 +55,7 @@ Resources:
       MemorySize: 128
       Environment:
         Variables:
-          BUILDKITE_TOKEN: { Ref: BuildkiteApiAccessToken }
-          BUILDKITE_ORG: { Ref: BuildkiteOrgSlug }
+          BUILDKITE_AGENT_TOKEN: { Ref: BuildkiteAgentToken }
           BUILDKITE_QUEUE: { Ref: BuildkiteQueue }
           AWS_STACK_ID: { Ref: "AWS::StackId" }
           AWS_STACK_NAME: { Ref: "AWS::StackName" }


### PR DESCRIPTION
Using the new private elastic stack metrics API that @sj26 created we can drop the requirement for a personal access token, allowing just an agent registration token. 

Hoping this will be a big win for teams that have to manage lots of personal access tokens just for elastic stacks. 