### PR TITLE
Update lifecycled to 2.0.1

### DIFF
--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -37,4 +37,10 @@ log_group_name = /buildkite/elastic-stack-init
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
+[/buildkite/lifecycled]
+file = /var/log/lifecycled
+log_group_name = /buildkite/lifecycled
+log_stream_name = {instance_id}
+datetime_format = %b %d %H:%M:%S
+
 # buildkite-agent logs config is written into here by elastic-stack-init

--- a/packer/scripts/install-lifecycled.sh
+++ b/packer/scripts/install-lifecycled.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
-LIFECYCLED_VERSION=v2.0.0
+LIFECYCLED_VERSION=v2.0.1
 
-echo "Installing lifecycled..."
+echo "Installing lifecycled ${LIFECYCLED_VERSION}..."
 
 sudo touch /etc/lifecycled
 sudo curl -Lf -o /usr/bin/lifecycled \


### PR DESCRIPTION
This introduces a simpler lifecycled upstart script which I'm hoping will allow for SQS queue cleanup on shutdown (#358).