### PR TITLE
Replace AWS_REGION with BUILDKITE_STACK_REGION

### DIFF
--- a/packer/conf/buildkite-agent/hooks/environment
+++ b/packer/conf/buildkite-agent/hooks/environment
@@ -4,6 +4,11 @@ set -eu -o pipefail
 # shellcheck source=/dev/null
 source ~/cfn-env
 
+# We set BUILDKITE_STACK_REGION in the cfn-env file, so if no value is set by the job
+# then we use that to set the two environment variables that aws tools depend on
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-$BUILDKITE_STACK_REGION}"
+export AWS_REGION="${AWS_REGION:-$BUILDKITE_STACK_REGION}"
+
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -509,11 +509,10 @@ Resources:
               BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
               BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
               BUILDKITE_LIFECYCLE_TOPIC=${AgentLifecycleTopic} \
-              AWS_DEFAULT_REGION=${AWS::Region} \
+              BUILDKITE_STACK_REGION=${AWS::Region} \
               SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
               ECR_PLUGIN_ENABLED=${EnableECRPlugin} \
               DOCKER_LOGIN_PLUGIN_ENABLED=${EnableDockerLoginPlugin} \
-              AWS_REGION=${AWS::Region} \
                 /usr/local/bin/bk-install-elastic-stack.sh
               --==BOUNDARY==--
             - LocalSecretsBucket:


### PR DESCRIPTION
Currently the stack depends on having `AWS_REGION` and `AWS_DEFAULT_REGION` set, but this breaks builds that want to override these values for their own purposes. This PR unsets those values at a stack level and instead uses `BUILDKITE_STACK_REGION`. 

See #406 for more context.