### PR TITLE
Copy docker cron scripts to hourly not daily

### DIFF
--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -37,9 +37,9 @@ sudo chmod +x /usr/bin/docker-compose
 docker-compose --version
 
 echo "Adding docker cron tasks..."
-sudo cp /tmp/conf/docker/cron.hourly/docker-gc /etc/cron.daily/docker-gc
-sudo cp /tmp/conf/docker/cron.hourly/docker-low-disk-gc /etc/cron.daily/docker-low-disk-gc
-sudo chmod +x /etc/cron.daily/docker-*
+sudo cp /tmp/conf/docker/cron.hourly/docker-gc /etc/cron.hourly/docker-gc
+sudo cp /tmp/conf/docker/cron.hourly/docker-low-disk-gc /etc/cron.hourly/docker-low-disk-gc
+sudo chmod +x /etc/cron.hourly/docker-*
 
 echo "Downloading jq..."
 sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64


### PR DESCRIPTION
The packer folder is `cron.hourly`, but we copy it into `cron.daily`.

This reconciles that down to hourly. 