### PR TITLE
Default EnableDockerUserNamespaceRemap to true

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -250,11 +250,11 @@ Parameters:
 
   EnableDockerUserNamespaceRemap:
     Type: String
-    Description: Enables experimental Docker userns-remap support
+    Description: Enables Docker user namespace remapping so docker runs as buildkite-agent
     AllowedValues:
       - true
       - false
-    Default: "false"
+    Default: "true"
 
   EnableCostAllocationTags:
     Type: String


### PR DESCRIPTION
When bringing back `EnableDockerUserNamespaceRemap` in #410, we forgot to default to `true`. This fixes that.