### PR TITLE
Use the docker directory to check for disk space

### DIFF
--- a/packer/conf/bin/bk-check-disk-space.sh
+++ b/packer/conf/bin/bk-check-disk-space.sh
@@ -4,18 +4,20 @@ set -euo pipefail
 DISK_MIN_AVAILABLE=${DISK_MIN_AVAILABLE:-1048576} # 1GB
 DISK_MIN_INODES=${DISK_MIN_INODES:-250000} # docker needs lots
 
-disk_avail=$(df -k --output=avail "$PWD" | tail -n1)
+DOCKER_DIR="/var/lib/docker/"
 
-echo "Disk space free: $(df -k -h --output=avail "$PWD" | tail -n1 | sed -e 's/^[[:space:]]//')"
+disk_avail=$(df -k --output=avail "$DOCKER_DIR" | tail -n1)
+
+echo "Disk space free: $(df -k -h --output=avail "$DOCKER_DIR" | tail -n1 | sed -e 's/^[[:space:]]//')"
 
 if [[ $disk_avail -lt $DISK_MIN_AVAILABLE ]]; then
   echo "Not enough disk space free, cutoff is ${DISK_MIN_AVAILABLE} 🚨" >&2
   return 1
 fi
 
-inodes_avail=$(df -k --output=iavail "$PWD" | tail -n1)
+inodes_avail=$(df -k --output=iavail "$DOCKER_DIR" | tail -n1)
 
-echo "Inodes free: $(df -k -h --output=iavail "$PWD" | tail -n1 | sed -e 's/^[[:space:]]//')"
+echo "Inodes free: $(df -k -h --output=iavail "$DOCKER_DIR" | tail -n1 | sed -e 's/^[[:space:]]//')"
 
 if [[ $inodes_avail -lt $DISK_MIN_INODES ]]; then
   echo "Not enough inodes free, cutoff is ${DISK_MIN_INODES} 🚨" >&2


### PR DESCRIPTION
Some people might use a RAM drive for docker to get better performance. By specifying the docker dir, we make sure we are checking for disk space in the right filesystem.