### PR TITLE
Set InstanceRoleName as stack template output

### DIFF
--- a/templates/outputs.yml
+++ b/templates/outputs.yml
@@ -2,3 +2,5 @@
 Outputs:
   AutoScalingGroupName:
     Value: { Ref: AgentAutoScaleGroup }
+  InstanceRoleName:
+    Value: { Ref: InstanceRoleName }


### PR DESCRIPTION
We allow Buildkite agents to assume other IAM roles for certain deployment/operational actions. The role to be assumed needs to include the role ARN within its assume role policy.

It would be great to thread a dependency between the stack and the assume policy document via the stack output.

We use the existing `AutoScalingGroupName` stack output to create/update scheduled actions on the ASG and would like to use the role name to aid in other resources creation.