### PR TITLE
Use parfait for watching stack progress

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -87,5 +87,5 @@ aws cloudformation create-stack \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
   --parameters "$(cat config.json)"
 
-echo "--- :cloudformation: ⌛️ Waiting for update to complete"
+echo "+++ :cloudformation: ⌛️ Waiting for update to complete"
 ./parfait watch-stack "${AWS_STACK_NAME}"


### PR DESCRIPTION
The aws stack waiter fails with out showing the stack error:

![image](https://user-images.githubusercontent.com/15758/40529301-8792d53e-6037-11e8-9eca-f5f09c6a62b9.png)

This moves to using https://github.com/lox/parfait to poll the stack, which gives much better error output. 