### PR TITLE
Set InstanceRoleName output from IAMRole resource

### DIFF
--- a/templates/outputs.yml
+++ b/templates/outputs.yml
@@ -3,4 +3,4 @@ Outputs:
   AutoScalingGroupName:
     Value: { Ref: AgentAutoScaleGroup }
   InstanceRoleName:
-    Value: { Ref: InstanceRoleName }
+    Value: !GetAtt IAMRole.RoleName


### PR DESCRIPTION
If the `InstanceRoleName` parameter (optional) is unset, the CloudFormation stack generates a name for you based on the stack name.

This commit updates the output to extract the name from the resource directly which accounts for both cases, and should be more reliable going forward.

Follow up to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/421. Addresses https://github.com/buildkite/elastic-ci-stack-for-aws/pull/421#issuecomment-392137428