### PR TITLE
Upgrade Git

### DIFF
--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -9,7 +9,7 @@ sudo yum update -y -q
 sudo yum install -y zip unzip
 
 echo "Installing bats..."
-sudo yum install -y git
+sudo yum install -y git # bump 2018-06-04
 sudo git clone https://github.com/sstephenson/bats.git /tmp/bats
 sudo /tmp/bats/install.sh /usr/local
 


### PR DESCRIPTION
Upgrades Git to 2.17.1 for [CVE-2018-11233](https://nvd.nist.gov/vuln/detail/CVE-2018-11233) and [CVE-2018-11235](https://nvd.nist.gov/vuln/detail/CVE-2018-11235)