### PR TITLE
Add debugging to s3 bucket deletion

### DIFF
--- a/.buildkite/steps/cleanup.sh
+++ b/.buildkite/steps/cleanup.sh
@@ -18,6 +18,10 @@ fi
 echo "--- Deleting test managed secrets buckets created"
 aws s3api list-buckets \
   --output text \
+  --query "$(printf 'Buckets[?CreationDate<`%s`].Name' "$cutoff_date" )"
+
+aws s3api list-buckets \
+  --output text \
   --query "$(printf 'Buckets[?CreationDate<`%s`].Name' "$cutoff_date" )" \
   | xargs -n1 \
   | grep -E 'buildkite-aws-stack-test-(\d+-)?managedsecrets' \


### PR DESCRIPTION
I can't figure out why s3 bucket deletion doesn't work in our cleanup process. This adds some debugging. 