### PR TITLE
Unfortunately IAMRole.RoleName doesn't exist, so output ARN instead

### DIFF
--- a/templates/outputs.yml
+++ b/templates/outputs.yml
@@ -2,5 +2,5 @@
 Outputs:
   AutoScalingGroupName:
     Value: { Ref: AgentAutoScaleGroup }
-  InstanceRoleName:
-    Value: !GetAtt IAMRole.RoleName
+  InstanceRoleArn:
+    Value: !GetAtt IAMRole.Arn


### PR DESCRIPTION
This is a follow on from https://github.com/buildkite/elastic-ci-stack-for-aws/pull/428.

@dblandin unfortunately IAMRole.RoleName doesn't exist, so we'll have to settle for the ARN.