### PR TITLE
Fixes permissions issues accessing docker socket

### DIFF
--- a/packer/conf/docker/docker.userns-remap.conf
+++ b/packer/conf/docker/docker.userns-remap.conf
@@ -1,8 +1,0 @@
-# We use the overlay2 storage driver for performance
-OPTIONS="-s overlay2 --debug  --userns-remap=buildkite-agent"
-
-DAEMON_MAXFILES=4096
-DAEMON_PIDFILE_TIMEOUT=30
-
-# Force native resolver to work around https://github.com/docker/docker/issues/22673
-export GODEBUG=netdns=cgo

--- a/packer/conf/docker/subgid
+++ b/packer/conf/docker/subgid
@@ -1,2 +1,2 @@
-buildkite-agent:2000:1
+buildkite-agent:1001:1
 buildkite-agent:100000:65536

--- a/tests/docker.bats
+++ b/tests/docker.bats
@@ -9,7 +9,7 @@
   run docker run -v "$PWD:/pwd" --rm -it alpine:latest mkdir /pwd/llamas
  	[ $status = 0 ]
   stat llamas
-  stat llamas | grep 'Uid: ( 2000/buildkite-agent)   Gid: ( 1001/docker)'
+  stat llamas | grep 'Uid: ( 2000/buildkite-agent)   Gid: ( 1001/  docker)'
 }
 
 @test "Containers can access docker socket" {

--- a/tests/docker.bats
+++ b/tests/docker.bats
@@ -9,5 +9,10 @@
   run docker run -v "$PWD:/pwd" --rm -it alpine:latest mkdir /pwd/llamas
  	[ $status = 0 ]
   stat llamas
-  stat llamas | grep 'Uid: ( 2000/buildkite-agent)   Gid: ( 2000/buildkite-agent)'
+  stat llamas | grep 'Uid: ( 2000/buildkite-agent)   Gid: ( 1001/docker)'
+}
+
+@test "Containers can access docker socket" {
+  run docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker:latest version
+ 	[ $status = 0 ]
 }


### PR DESCRIPTION
This makes sure that the gid inside containers is mapped to the docker group on the host, so that if the docker socket is mounted in it can be accessed.

See https://www.jujens.eu/posts/en/2017/Jul/02/docker-userns-remap/#id2 for more context.