### PR TITLE
Reference security group by id rather than name

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -652,7 +652,7 @@ Resources:
     Condition: EnableSshIngress
     Type: AWS::EC2::SecurityGroupIngress
     Properties: 
-      GroupName: !Ref SecurityGroup
+      GroupId: !GetAtt SecurityGroup.GroupId
       IpProtocol: tcp
       FromPort: 22
       ToPort: 22


### PR DESCRIPTION
This handles default vs non default VPC reference rules per
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html#cfn-ec2-security-group-ingress-groupid

This follows on from #444 which made the rule conditional. 