### PR TITLE
Set correct variable to pass to upstream ecr plugin

### DIFF
--- a/packer/conf/buildkite-agent/hooks/pre-command
+++ b/packer/conf/buildkite-agent/hooks/pre-command
@@ -7,7 +7,7 @@ if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" 
 
   # map AWS_ECR_LOGIN_REGISTRY_IDS into the plugin list format
   if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
-    export BUILDKITE_PLUGIN_ECR_REGISTRY_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
+    export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
   fi
 
   # shellcheck source=/dev/null


### PR DESCRIPTION
I believe the variable exported after reading `AWS_ECR_LOGIN_REGISTRY_IDS` isn't correct to configure the ecr login plugin. We're currently getting around this by explicitly setting `BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0` in our stack, but thought it was worth trying to get fixed to configure this the documented way.

https://github.com/buildkite-plugins/ecr-buildkite-plugin/blob/3068b26de2eb43b8ae6ebf081b1f0626d018d8c0/hooks/pre-command#L58

Thanks!