### PR TITLE
Revert "Bump docker to 18.03.1-ce and docker-compose to 1.22.0"

### DIFF
--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=18.03.1-ce
+DOCKER_VERSION=18.03.0-ce
 DOCKER_RELEASE="stable"
-DOCKER_COMPOSE_VERSION=1.22.0
+DOCKER_COMPOSE_VERSION=1.21.1
 
 # This performs a manual install of Docker.
 


### PR DESCRIPTION
We've been having strange spurious docker failures. Let's try going back. 

Reverts buildkite/elastic-ci-stack-for-aws#455