### PR TITLE
Rename the log group name we are using for elastic-stack.log file so we are consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ aws cloudformation describe-stacks --stack-name MY_STACK_NAME \
 Provide us with logs from Cloudwatch Logs:
 
 ```
-/buildkite/elastic-stack-init/{instance-id}
+/buildkite/elastic-stack/{instance-id}
 /buildkite/docker-daemon/{instance-id}
 ```
 

--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -31,9 +31,9 @@ log_group_name = /buildkite/cloud-init/output
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 
-[/buildkite/elastic-stack-init]
+[/buildkite/elastic-stack]
 file = /var/log/elastic-stack.log
-log_group_name = /buildkite/elastic-stack-init
+log_group_name = /buildkite/elastic-stack
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 


### PR DESCRIPTION
I think this change makes sense. Let me know if I'm mistaken.