### PR TITLE
Bump Amazon Linux to 2018.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 
 ## What’s On Each Machine?
 
-* [Amazon Linux 2017.09.1](https://aws.amazon.com/amazon-linux-ami/)
+* [Amazon Linux 2018.03](https://aws.amazon.com/amazon-linux-ami/)
 * [Buildkite Agent](https://buildkite.com/docs/agent)
 * [Docker 17.12.0-ce](https://www.docker.com)
 * [Docker Compose 1.18.0](https://docs.docker.com/compose/)

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -3,7 +3,7 @@
     {
       "type": "amazon-ebs",
       "region": "us-east-1",
-      "source_ami": "ami-55ef662f",
+      "source_ami": "ami-0c7d8678e345b414c",
       "instance_type": "i3.large",
       "spot_price": "auto",
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",


### PR DESCRIPTION
Bump the stable release to the latest Amazon Linux