### PR TITLE
Default BuildkiteAgentRelease to stable

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -82,7 +82,7 @@ Parameters:
       - stable
       - beta
       - edge
-    Default: "beta"
+    Default: "stable"
 
   BuildkiteAgentToken:
     Description: Buildkite agent registration token


### PR DESCRIPTION
Currently the default is `beta` which is confusing, we use `stable` since 3.x