### PR TITLE
Added Timeout as parameter so it can be passed from stack parameters.

### DIFF
--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -45,6 +45,7 @@ Metadata:
         - ScaleUpAdjustment
         - ScaleDownAdjustment
         - ScaleDownPeriod
+        - Timeout
 
       - Label:
           default: Cost Allocation Configuration
@@ -185,6 +186,11 @@ Parameters:
     Description: Number of seconds UnfinishedJobs must equal 0 before scale down
     Type: Number
     Default: 1800
+
+  Timeout:
+    Description: Timeout period for Autoscaling Group Creation Policy
+    Type: String
+    Default: "PT5M"
 
   RootVolumeSize:
     Description: Size of each instance's root EBS volume (in GB)
@@ -641,7 +647,7 @@ Resources:
 
     CreationPolicy:
       ResourceSignal:
-        Timeout: PT5M
+        Timeout: { !Ref Timeout }
         Count: { Ref: MinSize }
     UpdatePolicy:
       AutoScalingReplacingUpdate:

--- a/templates/buildkite-elastic.yml
+++ b/templates/buildkite-elastic.yml
@@ -45,7 +45,7 @@ Metadata:
         - ScaleUpAdjustment
         - ScaleDownAdjustment
         - ScaleDownPeriod
-        - Timeout
+        - InstanceCreationTimeout
 
       - Label:
           default: Cost Allocation Configuration
@@ -187,7 +187,7 @@ Parameters:
     Type: Number
     Default: 1800
 
-  Timeout:
+  InstanceCreationTimeout:
     Description: Timeout period for Autoscaling Group Creation Policy
     Type: String
     Default: "PT5M"
@@ -647,7 +647,7 @@ Resources:
 
     CreationPolicy:
       ResourceSignal:
-        Timeout: { !Ref Timeout }
+        Timeout: { Ref: InstanceCreationTimeout }
         Count: { Ref: MinSize }
     UpdatePolicy:
       AutoScalingReplacingUpdate:
@@ -670,7 +670,7 @@ Resources:
   SecurityGroupSshIngress:
     Condition: EnableSshIngress
     Type: AWS::EC2::SecurityGroupIngress
-    Properties: 
+    Properties:
       GroupId: !GetAtt SecurityGroup.GroupId
       IpProtocol: tcp
       FromPort: 22


### PR DESCRIPTION
When using the template, timeout value for autoscaling group->creation policy can now be customised. 
Default value is PT5M which sometimes blocks the deployment as the job it is running is too heavy and 5mins is not able to finish the ASG setup.
