### PR TITLE
Add journald cloudwatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Provide us with logs from Cloudwatch Logs:
 
 ```
 /buildkite/elastic-stack/{instance-id}
-/buildkite/docker-daemon/{instance-id}
+/buildkite/systemd/{instance-id}
 ```
 
 Alternately, drop by `#aws-stack` and `#aws` channels in [Buildkite Community Slack](https://chat.buildkite.com/) and ask your question!

--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -26,6 +26,10 @@
     },
     {
       "type": "shell",
+      "script": "scripts/install-journald-cloudwatch-logs.sh"
+    },
+    {
+      "type": "shell",
       "script": "scripts/install-utils.sh"
     },
     {

--- a/packer/conf/awslogs/awslogs.conf
+++ b/packer/conf/awslogs/awslogs.conf
@@ -1,18 +1,6 @@
 [general]
 state_file = /var/awslogs/state/agent-state
 
-[/buildkite/system]
-file = /var/log/messages
-log_group_name = /buildkite/system
-log_stream_name = {instance_id}
-datetime_format = %b %d %H:%M:%S
-
-[/buildkite/docker-daemon]
-file = /var/log/docker
-log_group_name = /buildkite/docker-daemon
-log_stream_name = {instance_id}
-datetime_format = %Y-%m-%dT%H:%M:%S.%f
-
 [/buildkite/cfn-init]
 file = /var/log/cfn-init.log
 log_group_name = /buildkite/cfn-init
@@ -36,11 +24,3 @@ file = /var/log/elastic-stack.log
 log_group_name = /buildkite/elastic-stack
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%d %H:%M:%S,%f
-
-[/buildkite/lifecycled]
-file = /var/log/lifecycled
-log_group_name = /buildkite/lifecycled
-log_stream_name = {instance_id}
-datetime_format = %b %d %H:%M:%S
-
-# buildkite-agent logs config is written into here by elastic-stack-init

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -93,19 +93,6 @@ EOF
 
 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
-for i in $(seq 1 "${BUILDKITE_AGENTS_PER_INSTANCE}"); do
-	touch "/var/log/buildkite-agent-${i}.log"
-
-	# Setup logging first so we capture everything
-	cat <<- EOF > "/etc/awslogs/config/buildkite-agent-${i}.conf"
-	[/buildkite/buildkite-agent-${i}.log]
-	file = /var/log/buildkite-agent-${i}.log
-	log_group_name = /buildkite/buildkite-agent
-	log_stream_name = {instance_id}-${i}
-	datetime_format = %Y-%m-%d %H:%M:%S
-	EOF
-done
-
 if [[ -n "${BUILDKITE_AUTHORIZED_USERS_URL}" ]] ; then
 	cat <<- EOF > /etc/cron.hourly/authorized_keys
 	/usr/local/bin/bk-fetch.sh "${BUILDKITE_AUTHORIZED_USERS_URL}" /tmp/authorized_keys
@@ -132,6 +119,7 @@ EOF
 
 systemctl start lifecycled
 systemctl start awslogsd
+systemctl start journald-cloudwatch-logs
 
 # wait for docker to start
 next_wait_time=0

--- a/packer/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.conf
+++ b/packer/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.conf
@@ -1,0 +1,2 @@
+state_file = "/var/lib/journald-cloudwatch-logs/state"
+log_group = "/buildkite/systemd"

--- a/packer/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.service
+++ b/packer/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=journald-cloudwatch-logs
+Wants=basic.target
+After=basic.target network.target
+
+[Service]
+ExecStart=/usr/local/bin/journald-cloudwatch-logs /etc/journald-cloudwatch-logs.conf
+KillMode=process
+Restart=on-failure
+RestartSec=42s

--- a/packer/scripts/install-journald-cloudwatch-logs.sh
+++ b/packer/scripts/install-journald-cloudwatch-logs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing journald-cloudwatch-logs..."
+
+# Install sj26 fork of journald-cloudwatch-logs
+sudo curl -Lfs -o /usr/local/bin/journald-cloudwatch-logs https://github.com/sj26/journald-cloudwatch-logs/releases/download/v0.0.1-text/journald-cloudwatch-logs
+sudo chmod +x /usr/local/bin/journald-cloudwatch-logs
+sudo mkdir -p /var/lib/journald-cloudwatch-logs
+sudo cp /tmp/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.conf /etc/journald-cloudwatch-logs.conf
+
+# Setup systemd
+sudo cp /tmp/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.service /etc/systemd/system/journald-cloudwatch-logs.service
+
+echo "Configure journald-cloudwatch-logs to run on startup..."
+sudo systemctl enable journald-cloudwatch-logs.service


### PR DESCRIPTION
Since we swapped to Amazon Linux 2 (and systemd) lots of our logs go via `systemd`, which isn't supported by `awslogs`. This adds @sj26's fork of https://github.com/sj26/journald-cloudwatch-logs to copy the systemd journal to cloudwatch logs.

Closes #459 