### PR TITLE
Move AMI copy into a dedicated step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,6 +40,13 @@ steps:
       queue: "testqueue-${BUILDKITE_BUILD_NUMBER}"
 
   - wait
+  - name: ":cloudformation: 🚚 🌎"
+    command: .buildkite/steps/copy.sh
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    artifact_paths: "templates/mappings.yml"
+
+  - wait
   - name: ":cloudformation: :rocket:"
     command: .buildkite/steps/publish.sh
     agents:

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+set -euo pipefail
+
+# Copies an AMI to all other regions and outputs a templates/mappings.yml file
+# Local Usage: .buildkite/steps/copy.sh <ami_id>
+
+copy_ami_to_region() {
+  local source_image_id="$1"
+  local source_region="$2"
+  local destination_image_region="$3"
+  local destination_image_name="$4"
+
+  aws ec2 copy-image \
+    --source-image-id "$source_image_id" \
+    --source-region "$source_region" \
+    --name "$destination_image_name" \
+    --region "$destination_image_region" \
+    --query "ImageId" \
+    --output text
+}
+
+wait_for_ami_to_be_available() {
+  local image_id="$1"
+  local region="$2"
+  local image_state
+
+  while true; do
+    image_state=$(aws ec2 describe-images --region "$region" --image-ids "$image_id" --output text --query 'Images[*].State');
+    echo "$image_id ($region) is $image_state"
+
+    if [[ "$image_state" == "available" ]]; then
+      break
+    elif [[ "$image_state" == "pending" ]]; then
+      sleep 10
+    else
+      exit 1
+    fi
+  done
+}
+
+make_ami_public() {
+  local image_id="$1"
+  local region="$2"
+
+  aws ec2 modify-image-attribute \
+    --region "$region" \
+    --image-id "$image_id" \
+    --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
+}
+
+if [[ -n "${BUILDKITE_AWS_STACK_BUCKET}" ]] ; then
+  echo "Must set an s3 bucket in BUILDKITE_AWS_STACK_BUCKET for temporary files"
+  exit 1
+fi
+
+ALL_REGIONS=(
+  us-east-1
+  us-east-2
+  us-west-1
+  us-west-2
+  eu-west-1
+  eu-west-2
+  eu-central-1
+  ap-northeast-1
+  ap-northeast-2
+  ap-southeast-1
+  ap-southeast-2
+  ap-south-1
+  sa-east-1
+)
+
+IMAGES=(
+)
+
+# Configuration
+source_image_id="${1:-}"
+source_region="${AWS_REGION}"
+mapping_file="$templates/mappings.yml"
+s3_mappings_cache="s3://${BUILDKITE_AWS_STACK_BUCKET}/mappings-${image_id}-${BUILDKITE_BRANCH}.yml"
+
+# Read the source_image_id from meta-data if empty
+if [[ -z "$source_image_id" ]] ; then
+  source_image_id=$(buildkite-agent meta-data get image_id)
+fi
+
+# If we're not on the master branch or a tag build skip the copy
+if [[ $BUILDKITE_BRANCH != "master" ]] && [[ "$BUILDKITE_TAG" != "$BUILDKITE_BRANCH" ]] ; then
+  echo "--- Skipping AMI copy on non-master/tag branch " >&2
+  cat << EOF > "$mapping_file"
+Mappings:
+  AWSRegion2AMI:
+    ${AWS_REGION} : { AMI: $source_image_id }
+EOF
+  exit 0
+fi
+
+# Check if there is a previously copy in the cache bucket
+if aws s3 cp "${s3_mappings_cache}" "$mapping_file" ; then
+  echo "--- Skipping AMI copy, was previously copied"
+  exit 0
+fi
+
+# Get the image name to copy to other amis
+source_image_name=$(aws ec2 describe-images \
+  --image-ids "$source_image_id" \
+  --output text \
+  --region "$source_region" \
+  --query 'Images[*].Name')
+
+# Copy to all other regions
+for region in ${ALL_REGIONS[*]}; do
+  if [[ $region != $source_region ]] ; then
+    echo "--- Copying $source_image_id to $region" >&2
+    IMAGES+=("$(copy_ami_to_region "$source_image_id" "$source_region" "$region" "${source_image_name}-${region}")")
+  else
+    IMAGES+=("$source_image_id")
+  fi
+done
+
+# Write yaml preamble
+cat << EOF > "$mapping_file"
+Mappings:
+  AWSRegion2AMI:
+EOF
+
+echo "--- Waiting for AMIs to become available"  >&2
+for ((i=0; i<${#IMAGES[*]}; i++)); do
+  region="${ALL_REGIONS[i]}"
+  image_id="${IMAGES[i]}"
+
+  wait_for_ami_to_be_available "$image_id" "$region" >&2
+
+  # Make the AMI public if it's not the source image
+  if [[ $image_id != $source_image_id ]] ; then
+    echo "Making ${image_id} public" >&2
+    make_ami_public "$image_id" "$region"
+  fi
+
+  # Write yaml to file
+  echo "    $region : { AMI: $image_id }"  >> "$mapping_file"
+done
+
+echo "--- Uploading mapping to s3 cache"
+aws s3 cp "$mapping_file" "${s3_mappings_cache}"

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -1,22 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[ -n "${BUILDKITE_AWS_STACK_BUCKET}" ]] ; then
+  echo "Must set an s3 bucket in BUILDKITE_AWS_STACK_BUCKET for temporary files"
+  exit 1
+fi
+
 mkdir -p build
 
+# Build a hash of packer files and the agent versions
 packer_files_sha=$(find packer/ plugins/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
-echo "Packer files hash is $packer_files_sha"
-
 stable_agent_sha=$(curl -Lfs https://download.buildkite.com/agent/stable/latest/buildkite-agent-linux-amd64.sha256)
-echo "Agent stable sha256 is $stable_agent_sha"
-
 unstable_agent_sha=$(curl -Lfs https://download.buildkite.com/agent/unstable/latest/buildkite-agent-linux-amd64.sha256)
-echo "Agent unstable sha256 is $unstable_agent_sha"
-
 packer_hash=$(echo "$packer_files_sha" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
-echo "Packer image hash is $packer_hash"
 
+echo "Packer image hash is $packer_hash"
 packer_file="${packer_hash}.packer"
 
+# Only build packer image if one with the same hash doesn't exist
 if ! aws s3 cp "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}" . ; then
   make build-ami | tee "$packer_file"
   aws s3 cp "${packer_file}" "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}"
@@ -24,7 +25,8 @@ else
   echo "Skipping packer build, no changes"
 fi
 
-image_id=$(grep -Eo "us-east-1: (ami-.+)$" "$packer_file" | awk '{print $2}')
-echo "AMI for us-east-1 is $image_id"
+# Get the image id from the packer build output for later steps
+image_id=$(grep -Eo "${AWS_REGION}: (ami-.+)$" "$packer_file" | awk '{print $2}')
+echo "AMI for ${AWS_REGION} is $image_id"
 
 buildkite-agent meta-data set image_id "$image_id"

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -1,29 +1,5 @@
 #!/bin/bash
-
-set -eu
-
-# us-east-1 is the base image
-DESTINATION_REGIONS=(
-  us-east-2
-  us-west-1
-  us-west-2
-  eu-west-1
-  eu-west-2
-  eu-central-1
-  ap-northeast-1
-  ap-northeast-2
-  ap-southeast-1
-  ap-southeast-2
-  ap-south-1
-  sa-east-1
-)
-
-DESTINATION_AMIS=(
-)
-
-is_tag_build() {
-  [[ "$BUILDKITE_TAG" = "$BUILDKITE_BRANCH" ]]
-}
+set -euo pipefail
 
 is_latest_tag() {
   [[ "$BUILDKITE_TAG" = $(git describe --abbrev=0 --tags --match 'v*') ]]
@@ -33,136 +9,26 @@ is_release_candidate_tag() {
   [[ "$BUILDKITE_TAG" =~ -rc ]]
 }
 
-copy_ami_to_region() {
-  local source_ami_id="$1"
-  local source_region="$2"
-  local destination_image_region="$3"
-  local destination_image_name="$4"
-
-  echo "Copying $source_ami_id to $destination_image_region..." >&2
-
-  aws ec2 copy-image \
-    --source-image-id "$source_ami_id" \
-    --source-region "$source_region" \
-    --name "$destination_image_name" \
-    --region "$destination_image_region" \
-    --query "ImageId" \
-    --output text
-}
-
-wait_for_ami_to_be_available() {
-  local image_id="$1"
-  local region="$2"
-  local image_state
-
-  while true; do
-    image_state=$(aws ec2 describe-images --region "$region" --image-ids "$image_id" --output text --query 'Images[*].State');
-    echo "$image_id ($region) is $image_state"
-
-    if [[ "$image_state" == "available" ]]; then
-      break
-    elif [[ "$image_state" == "pending" ]]; then
-      sleep 5
-    else
-      exit 1
-    fi
-  done
-}
-
-make_ami_public() {
-  local image_id="$1"
-  local region="$2"
-
-  aws ec2 modify-image-attribute \
-    --region "$region" \
-    --image-id "$image_id" \
-    --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
-}
-
-fetch_ami_name() {
-  local ami_id="$1"
-  local region="$2"
-
-  echo "Fetching ami name for $ami_id..." >&2
-
-  aws ec2 describe-images \
-    --image-ids "$ami_id" \
-    --region "$region" \
-    --output text \
-    --query 'Images[*].Name'
-}
-
-copy_ami_and_create_mappings_yml() {
-  local base_image_id="$1"
-  local destination_yml="$2"
-  local image_name
-  local region
-  local region_ami
-  local i
-
-  image_name=$(fetch_ami_name "$base_image_id" us-east-1)
-
-  cat << EOF > "$destination_yml"
-Mappings:
-  AWSRegion2AMI:
-    us-east-1 : { AMI: $base_image_id }
-EOF
-
-  if [[ $BUILDKITE_BRANCH == "master" ]] || is_tag_build ; then
-    for region in ${DESTINATION_REGIONS[*]}; do
-      echo "--- Copying $image_id to $region"
-      region_ami=$(copy_ami_to_region "$base_image_id" us-east-1 "$region" "$image_name-$region")
-
-      DESTINATION_AMIS+=("$region_ami")
-    done
-
-    echo "--- Waiting for AMIs to become available"
-    for ((i=0; i<${#DESTINATION_AMIS[*]}; i++)); do
-      region="${DESTINATION_REGIONS[i]}"
-      region_ami="${DESTINATION_AMIS[i]}"
-
-      wait_for_ami_to_be_available "$region_ami" "$region"
-      make_ami_public "$region_ami" "$region"
-
-      echo "    $region : { AMI: $region_ami }" >> "$destination_yml"
-    done
-  fi
-}
-
-generate_mappings() {
-  local image_id
-  local s3_mappings_cache
-
-  image_id=$(buildkite-agent meta-data get image_id)
-  s3_mappings_cache="s3://${BUILDKITE_AWS_STACK_BUCKET}/mappings-${image_id}-${BUILDKITE_BRANCH}.yml"
-
-  if aws s3 cp "${s3_mappings_cache}" templates/mappings.yml ; then
-    echo "Skipping creating additional AZ mappings, base AMI has not changed"
-  else
-    copy_ami_and_create_mappings_yml "$image_id" templates/mappings.yml
-    aws s3 cp templates/mappings.yml "${s3_mappings_cache}"
-  fi
-}
-
 s3_upload_templates() {
   local bucket_prefix="${1:-}"
 
-  aws s3 cp --acl public-read templates/mappings.yml "s3://buildkite-aws-stack/${bucket_prefix}mappings.yml"
-  aws s3 cp --acl public-read build/aws-stack.json "s3://buildkite-aws-stack/${bucket_prefix}aws-stack.json"
-  aws s3 cp --acl public-read build/aws-stack.yml "s3://buildkite-aws-stack/${bucket_prefix}aws-stack.yml"
-
-  echo "Published https://s3.amazonaws.com/buildkite-aws-stack/${bucket_prefix}mappings.yml"
-  echo "Published https://s3.amazonaws.com/buildkite-aws-stack/${bucket_prefix}aws-stack.json"
-  echo "Published https://s3.amazonaws.com/buildkite-aws-stack/${bucket_prefix}aws-stack.yml"
+  aws s3 cp --acl public-read templates/mappings.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}mappings.yml"
+  aws s3 cp --acl public-read build/aws-stack.json "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.json"
+  aws s3 cp --acl public-read build/aws-stack.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.yml"
 }
 
+if [[ -n "${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}" ]] ; then
+  echo "Must set an s3 bucket in BUILDKITE_AWS_STACK_TEMPLATE_BUCKET for publishing templates to"
+  exit 1
+fi
+
+echo "--- Downloading mappings.yml artifact"
+buildkite-agent artifact download templates/mappings.yml templates/
+
+echo "--- Fetching latest git tags"
 git fetch --tags
-make clean
 
-echo "--- Generating mappings"
-generate_mappings
-
-echo "--- Building stack"
+echo "--- Building :cloudformation: templates"
 make build
 
 # Publish the top-level mappings only on when we see the most recent tag on master
@@ -175,8 +41,14 @@ else
   echo "Skipping publishing latest, '$BUILDKITE_TAG' doesn't match '$(git describe origin/master --tags --match='v*')'"
 fi
 
+echo "--- Uploading :cloudformation: templates"
+
 # Publish the most recent commit from each branch
 s3_upload_templates "${BUILDKITE_BRANCH}/"
 
 # Publish each build to a unique URL, to let people roll back to old versions
 s3_upload_templates "${BUILDKITE_BRANCH}/${BUILDKITE_COMMIT}."
+
+cat << EOF | buildkite-agent annotate --style "info"
+Published template <a href="https://s3.amazonaws.com/${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${BUILDKITE_BRANCH}/aws-stack.yml">${BUILDKITE_BRANCH}/aws-stack.yml</a>
+EOF


### PR DESCRIPTION
This splits out the AMI copy to it's own step that produces an artifact that the later publish stage consumes.

This is part of a series of changes to pull in some of the tooling improvements from https://github.com/buildkite/elastic-ci-stack-for-aws/pull/483.