### PR TITLE
Make sure /buildkite/system log group exists

### DIFF
--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -21,6 +21,7 @@ packer_file="${packer_hash}.packer"
 if ! aws s3 cp "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}" . ; then
   make packer
   aws s3 cp packer.output "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}"
+  mv packer.output "${packer_file}"
 else
   echo "Skipping packer build, no changes"
 fi

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -117,6 +117,11 @@ LIFECYCLED_SNS_TOPIC=${BUILDKITE_LIFECYCLE_TOPIC}
 LIFECYCLED_HANDLER=/usr/local/bin/stop-agent-gracefully
 EOF
 
+# make sure that the log group for system is created as it's not awslogs managed
+aws logs create-log-group --log-group-name "/buildkite/system" || (
+  echo "Failed to create log group /buildkite/system"
+)
+
 systemctl start lifecycled
 systemctl start awslogsd
 systemctl start journald-cloudwatch-logs

--- a/packer/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.conf
+++ b/packer/conf/journald-cloudwatch-logs/journald-cloudwatch-logs.conf
@@ -1,2 +1,2 @@
 state_file = "/var/lib/journald-cloudwatch-logs/state"
-log_group = "/buildkite/systemd"
+log_group = "/buildkite/system"


### PR DESCRIPTION
Currently systemd logs fail as `/buildkite/systemd` isn't created. This rolls back the group name to `/buildkite/system` which is what it was previously and also makes sure that group is created. 