### PR TITLE
Start logging daemons as soon as possile during bootstrap

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -38,6 +38,10 @@ cwlogs = cwlogs
 region = $AWS_REGION
 EOF
 
+# Start logging daemons as soon as possible to ensure failures in this script get sent
+systemctl start awslogsd
+systemctl start journald-cloudwatch-logs
+
 PLUGINS_ENABLED=()
 [[ $SECRETS_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("secrets")
 [[ $ECR_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("ecr")
@@ -118,8 +122,6 @@ LIFECYCLED_HANDLER=/usr/local/bin/stop-agent-gracefully
 EOF
 
 systemctl start lifecycled
-systemctl start awslogsd
-systemctl start journald-cloudwatch-logs
 
 # wait for docker to start
 next_wait_time=0


### PR DESCRIPTION
This fixes #450 by ensuring the logging agents are started as soon as possible (at least before the custom bootstrap script).

By design [journald-cloudwatch-logs](https://github.com/saymedia/journald-cloudwatch-logs) (" batch of new events will be written to CloudWatch Logs every second even if the buffer does not fill") will flush every second, and awslogsd will flush on exit (according to AWS). Hopefully this is enough to get logs shipped to AWS CW Logs.

I'm still testing this PR in a few scenarios, but it should be good for review :)