### PR TITLE
Support timestamp-lines

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -89,6 +89,7 @@ name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
 tags=$(IFS=, ; echo "${agent_metadata[*]}")
 tags-from-ec2=true
+timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -11,6 +11,7 @@ Metadata:
         - BuildkiteAgentRelease
         - BuildkiteAgentToken
         - BuildkiteAgentTags
+        - BuildkiteAgentTimestampLines
         - BuildkiteQueue
         - BuildkiteAgentExperiments
 
@@ -98,6 +99,11 @@ Parameters:
     Description: Additional tags seperated by commas to provide to the agent. E.g os=linux,llamas=always
     Type: String
     Default: ""
+
+  BuildkiteAgentTimestampLines:
+    Description: Set to true to prepend timestamps to every line of output
+    Type: String
+    Default: "false"
 
   BuildkiteAgentExperiments:
     Description: Agent experiments to enable, comma delimited. See https://github.com/buildkite/agent/blob/master/EXPERIMENTS.md.
@@ -647,6 +653,7 @@ Resources:
             BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
             BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
             BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
+            BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
             BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
             BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
             BUILDKITE_QUEUE="${BuildkiteQueue}" \


### PR DESCRIPTION
This fixes #485.
See: https://github.com/buildkite/agent/pull/501 and https://buildkite.com/docs/agent/v3/configuration