### PR TITLE
Cleanup agent params

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -8,11 +8,15 @@ Metadata:
       - Label:
           default: Buildkite Configuration
         Parameters:
-        - BuildkiteAgentRelease
         - BuildkiteAgentToken
+        - BuildkiteQueue
+
+      - Label:
+          default: Advanced Buildkite Configuration
+        Parameters:
+        - BuildkiteAgentRelease
         - BuildkiteAgentTags
         - BuildkiteAgentTimestampLines
-        - BuildkiteQueue
         - BuildkiteAgentExperiments
 
       - Label:
@@ -103,6 +107,9 @@ Parameters:
   BuildkiteAgentTimestampLines:
     Description: Set to true to prepend timestamps to every line of output
     Type: String
+    AllowedValues:
+      - "true"
+      - "false"
     Default: "false"
 
   BuildkiteAgentExperiments:


### PR DESCRIPTION
This cleans up how a few of the agent parameters in the stack are presented and moves some of the optional ones to an `Advanced Buildkite Configuration` heading.



