### PR TITLE
Add a EnableDockerExperimental param

### DIFF
--- a/packer/conf/bin/bk-configure-docker.sh
+++ b/packer/conf/bin/bk-configure-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2094
 set -euo pipefail
 
 ## Configures docker before system starts
@@ -9,10 +10,10 @@ exec > >(tee -a /var/log/elastic-stack.log|logger -t user-data -s 2>/dev/console
 
 # Set user namespace remapping in config
 if [[ "${DOCKER_USERNS_REMAP:-false}" == "true" ]] ; then
-  cat <<< "$(jq '."userns-remap"="buildkite-agent"' < /etc/docker/daemon.json)" > /etc/docker/daemon.json
+  cat <<< "$(jq '."userns-remap"="buildkite-agent"' /etc/docker/daemon.json)" > /etc/docker/daemon.json
 fi
 
 # Set experimental in config
 if [[ "${DOCKER_EXPERIMENTAL:-false}" == "true" ]] ; then
-  cat <<< "$(jq '.experimental="buildkite-agent"' < /etc/docker/daemon.json)" > /etc/docker/daemon.json
+  cat <<< "$(jq '.experimental="buildkite-agent"' /etc/docker/daemon.json)" > /etc/docker/daemon.json
 fi

--- a/packer/conf/bin/bk-configure-docker.sh
+++ b/packer/conf/bin/bk-configure-docker.sh
@@ -7,9 +7,12 @@ set -euo pipefail
 # See https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee -a /var/log/elastic-stack.log|logger -t user-data -s 2>/dev/console) 2>&1
 
-# Swap in the userns remap config
+# Set user namespace remapping in config
 if [[ "${DOCKER_USERNS_REMAP:-false}" == "true" ]] ; then
-	mv /etc/docker/daemon.userns-remap.json /etc/docker/daemon.json
-else
-  rm /etc/docker/daemon.userns-remap.json
+  cat <<< "$(jq '."userns-remap"="buildkite-agent"' < /etc/docker/daemon.json)" > /etc/docker/daemon.json
+fi
+
+# Set experimental in config
+if [[ "${DOCKER_EXPERIMENTAL:-false}" == "true" ]] ; then
+  cat <<< "$(jq '.experimental="buildkite-agent"' < /etc/docker/daemon.json)" > /etc/docker/daemon.json
 fi

--- a/packer/conf/docker/daemon.userns-remap.json
+++ b/packer/conf/docker/daemon.userns-remap.json
@@ -1,4 +1,0 @@
-{
-  "userns-remap": "buildkite-agent",
-  "storage-driver": "overlay2"
-}

--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -19,7 +19,6 @@ rm docker.tgz
 
 sudo mkdir -p /etc/docker
 sudo cp /tmp/conf/docker/daemon.json /etc/docker/daemon.json
-sudo cp /tmp/conf/docker/daemon.userns-remap.json /etc/docker/daemon.userns-remap.json
 sudo cp /tmp/conf/docker/subuid /etc/subuid
 sudo cp /tmp/conf/docker/subgid /etc/subgid
 sudo chown -R ec2-user:docker /etc/docker

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -61,6 +61,7 @@ Metadata:
           default: Docker Daemon Configuration
         Parameters:
         - EnableDockerUserNamespaceRemap
+        - EnableDockerExperimental
 
       - Label:
           default: Docker Registry Configuration
@@ -275,6 +276,14 @@ Parameters:
       - "true"
       - "false"
     Default: "true"
+
+  EnableDockerExperimental:
+    Type: String
+    Description: Enables Docker experimental features
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
 
   EnableCostAllocationTags:
     Type: String
@@ -641,6 +650,7 @@ Resources:
             --==BOUNDARY==
             Content-Type: text/cloud-boothook; charset="us-ascii"
             DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+            DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
               /usr/local/bin/bk-configure-docker.sh
 
             --==BOUNDARY==
@@ -664,7 +674,6 @@ Resources:
             SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
             ECR_PLUGIN_ENABLED=${EnableECRPlugin} \
             DOCKER_LOGIN_PLUGIN_ENABLED=${EnableDockerLoginPlugin} \
-            DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
             AWS_REGION=${AWS::Region} \
               /usr/local/bin/bk-install-elastic-stack.sh
             --==BOUNDARY==--


### PR DESCRIPTION
This adds a flag for turning on Docker's experimental mode so that we can experiment with BuildKit (not confusing at all). 

This also reconciles how we set docker daemon parameters (now using jq). 