### PR TITLE
Only start lifecycled after install

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -20,6 +20,10 @@ file:
     owner: buildkite-agent
     group: buildkite-agent
 
+  /usr/local/bin/stop-agent-gracefully:
+    exists: true
+    mode: "0755"
+
 port:
   tcp:22:
     listening: true

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -122,6 +122,7 @@ LIFECYCLED_SNS_TOPIC=${BUILDKITE_LIFECYCLE_TOPIC}
 LIFECYCLED_HANDLER=/usr/local/bin/stop-agent-gracefully
 EOF
 
+systemctl enable lifecycled.service
 systemctl start lifecycled
 
 # wait for docker to start

--- a/packer/scripts/install-lifecycled.sh
+++ b/packer/scripts/install-lifecycled.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-LIFECYCLED_VERSION=v3.0.0
+LIFECYCLED_VERSION=v3.0.1
 
 echo "Installing lifecycled ${LIFECYCLED_VERSION}..."
 

--- a/packer/scripts/install-lifecycled.sh
+++ b/packer/scripts/install-lifecycled.sh
@@ -12,5 +12,3 @@ sudo chmod +x /usr/bin/lifecycled
 sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
 	https://raw.githubusercontent.com/lox/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit
 
-echo "Configure lifecycled to run on startup..."
-sudo systemctl enable lifecycled.service


### PR DESCRIPTION
It appears that lifecycled has been starting without its handler script in place. I believe this is because the daemon is currently set to start on boot and the handler script is only configured after boot.

The [latest lifecycled version 3.0.1](https://github.com/buildkite/lifecycled/releases/tag/v3.0.1) makes this parameter required. 