### PR TITLE
Ensure region is set before starting awslogsd

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -38,9 +38,11 @@ cwlogs = cwlogs
 region = $AWS_REGION
 EOF
 
+systemctl enable awslogsd.service
+
 # Start logging daemons as soon as possible to ensure failures in this script get sent
 systemctl restart rsyslog
-systemctl start awslogsd
+systemctl restart awslogsd
 
 PLUGINS_ENABLED=()
 [[ $SECRETS_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("secrets")

--- a/packer/scripts/install-awslogs.sh
+++ b/packer/scripts/install-awslogs.sh
@@ -12,6 +12,3 @@ sudo cp /tmp/conf/awslogs/awslogs.conf /etc/awslogs/awslogs.conf
 
 echo "Adding rsyslogd configs..."
 sudo cp /tmp/conf/awslogs/rsyslog.d/* /etc/rsyslog.d/
-
-echo "Configure awslogsd to run on startup..."
-sudo systemctl enable awslogsd.service


### PR DESCRIPTION
We recently upgraded our stacks to 4.0.1 and noticed that all our logs are being sent to us-east-1, despite the stacks being created in us-west-2. In a similar vein to #507, we should ensure that the awslogsd service is not started until the region is properly set via the `bk-install-elastic-stack.sh` script.

It looks like this was previously added in #225 but was accidentally removed in 4.0 during the switch to Amazon Linux 2/systemd.