### PR TITLE
Add Buildkite Org to Cloudwatch Metrics as a Dimension to support multiple orgs per AWS account

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -679,6 +679,7 @@ Resources:
             BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
             BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
             BUILDKITE_QUEUE="${BuildkiteQueue}" \
+            BUILDKITE_ORG_SLUG="${BuildkiteOrgSlug}" \
             BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
             BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
             BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
@@ -756,6 +757,9 @@ Resources:
         - Key: BuildkiteAgentRelease
           Value: !Ref BuildkiteAgentRelease
           PropagateAtLaunch: true
+        - Key: BuildkiteOrgSlug
+          Value: !Ref BuildkiteOrgSlug
+          PropagateAtLaunch: true
         - Key: BuildkiteQueue
           Value: !Ref BuildkiteQueue
           PropagateAtLaunch: true
@@ -765,7 +769,6 @@ Resources:
             Value: !Ref CostAllocationTagValue
             PropagateAtLaunch: true
           - !Ref "AWS::NoValue"
-
     CreationPolicy:
       ResourceSignal:
         Timeout: !Ref InstanceCreationTimeout
@@ -827,6 +830,8 @@ Resources:
       Dimensions:
         - Name: Queue
           Value: !Ref BuildkiteQueue
+        - Name: Org
+          Value: !Ref BuildkiteOrgSlug
       ComparisonOperator: GreaterThanThreshold
 
   AgentUtilizationAlarmLow:
@@ -844,6 +849,8 @@ Resources:
       Dimensions:
         - Name: Queue
           Value: !Ref BuildkiteQueue
+        - Name: Org
+          Value: !Ref BuildkiteOrgSlug
       ComparisonOperator: LessThanOrEqualToThreshold
 
   LambdaExecutionRole:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -830,14 +830,14 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ !Ref AgentScaleUpPolicy ]
-      Dimensions:
-        - Name: Queue
-          Value: !Ref BuildkiteQueue
-        - !If
-          - HasOrgSlug
+      Dimensions: !If
+        - HasOrgSlug
+        - - Name: Queue
+            Value: !Ref BuildkiteQueue
           - Name: Org
             Value: !Ref BuildkiteOrgSlug
-          - !Ref "AWS::NoValue"
+        - - Name: Queue
+            Value: !Ref BuildkiteQueue
       ComparisonOperator: GreaterThanThreshold
 
   AgentUtilizationAlarmLow:
@@ -852,14 +852,14 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ !Ref AgentScaleDownPolicy ]
-      Dimensions:
-        - Name: Queue
-          Value: !Ref BuildkiteQueue
-        - !If
-          - HasOrgSlug
+      Dimensions: !If
+        - HasOrgSlug
+        - - Name: Queue
+            Value: !Ref BuildkiteQueue
           - Name: Org
             Value: !Ref BuildkiteOrgSlug
-          - !Ref "AWS::NoValue"
+        - - Name: Queue
+            Value: !Ref BuildkiteQueue
       ComparisonOperator: LessThanOrEqualToThreshold
 
   LambdaExecutionRole:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -95,9 +95,9 @@ Parameters:
     Default: "stable"
 
   BuildkiteOrgSlug:
-    Description: Buildkite organization slug
+    Description: Buildkite organization slug (optional, but required if you have multiple accounts)
     Type: String
-    Default: "none"
+    Default: ""
 
   BuildkiteAgentToken:
     Description: Buildkite agent registration token
@@ -375,6 +375,9 @@ Conditions:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
     HasKeyName:
+      !Not [ !Equals [ !Ref KeyName, "" ] ]
+
+    HasOrgSlug:
       !Not [ !Equals [ !Ref KeyName, "" ] ]
 
     EnableSshIngress:
@@ -830,8 +833,11 @@ Resources:
       Dimensions:
         - Name: Queue
           Value: !Ref BuildkiteQueue
-        - Name: Org
-          Value: !Ref BuildkiteOrgSlug
+        - !If
+          - HasOrgSlug
+          - Name: Org
+            Value: !Ref BuildkiteOrgSlug
+          - !Ref "AWS::NoValue"
       ComparisonOperator: GreaterThanThreshold
 
   AgentUtilizationAlarmLow:
@@ -849,8 +855,11 @@ Resources:
       Dimensions:
         - Name: Queue
           Value: !Ref BuildkiteQueue
-        - Name: Org
-          Value: !Ref BuildkiteOrgSlug
+        - !If
+          - HasOrgSlug
+          - Name: Org
+            Value: !Ref BuildkiteOrgSlug
+          - !Ref "AWS::NoValue"
       ComparisonOperator: LessThanOrEqualToThreshold
 
   LambdaExecutionRole:
@@ -895,7 +904,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-metrics-v4.0.0-lambda.zip"
+        S3Key: "buildkite-metrics-v4.1.0-lambda.zip"
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler
@@ -908,7 +917,6 @@ Resources:
           AWS_STACK_ID: !Ref "AWS::StackId"
           AWS_STACK_NAME: !Ref "AWS::StackName"
           AWS_ACCOUNT_ID: !Ref "AWS::AccountId"
-          BUILDKITE_CLOUDWATCH_DIMENSIONS: !Sub "Org=${BuildkiteOrgSlug}"
 
   ScheduledRule:
     Type: "AWS::Events::Rule"

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -95,7 +95,7 @@ Parameters:
     Default: "stable"
 
   BuildkiteOrgSlug:
-    Description: Buildkite organization slug (optional, but required if you have multiple accounts)
+    Description: Optional Buildkite organization slug (e.g. "my-org"). This only needs to be set when running stacks for different Buildkite organisations in a single AWS account.
     Type: String
     Default: ""
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -819,9 +819,9 @@ Resources:
       ScalingAdjustment: !Ref ScaleDownAdjustment
 
   AgentUtilizationAlarmHigh:
-   Type: AWS::CloudWatch::Alarm
-   Condition: UseAutoscaling
-   Properties:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseAutoscaling
+    Properties:
       AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
       MetricName: ScheduledJobsCount
       Namespace: Buildkite

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -906,7 +906,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-agent-metrics/v4.1.0/handler.zip"
+        S3Key: "buildkite-agent-metrics/v4.1.1/handler.zip"
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -830,20 +830,21 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ !Ref AgentScaleUpPolicy ]
-      Dimensions: !If
-        - HasOrgSlug
-        - - Name: Queue
-            Value: !Ref BuildkiteQueue
-          - Name: Org
-            Value: !Ref BuildkiteOrgSlug
-        - - Name: Queue
-            Value: !Ref BuildkiteQueue
+      Dimensions:
+        !If
+          - HasOrgSlug
+          - - Name: Queue
+              Value: !Ref BuildkiteQueue
+            - Name: Org
+              Value: !Ref BuildkiteOrgSlug
+          - - Name: Queue
+              Value: !Ref BuildkiteQueue
       ComparisonOperator: GreaterThanThreshold
 
   AgentUtilizationAlarmLow:
-   Type: AWS::CloudWatch::Alarm
-   Condition: UseAutoscaling
-   Properties:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseAutoscaling
+    Properties:
       AlarmDescription: Scale-down if UnfinishedJobs == 0 for N minutes
       MetricName: UnfinishedJobsCount
       Namespace: Buildkite
@@ -852,14 +853,15 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 0
       AlarmActions: [ !Ref AgentScaleDownPolicy ]
-      Dimensions: !If
-        - HasOrgSlug
-        - - Name: Queue
-            Value: !Ref BuildkiteQueue
-          - Name: Org
-            Value: !Ref BuildkiteOrgSlug
-        - - Name: Queue
-            Value: !Ref BuildkiteQueue
+      Dimensions:
+        !If
+          - HasOrgSlug
+          - - Name: Queue
+              Value: !Ref BuildkiteQueue
+            - Name: Org
+              Value: !Ref BuildkiteOrgSlug
+          - - Name: Queue
+              Value: !Ref BuildkiteQueue
       ComparisonOperator: LessThanOrEqualToThreshold
 
   LambdaExecutionRole:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -10,6 +10,7 @@ Metadata:
         Parameters:
         - BuildkiteAgentToken
         - BuildkiteQueue
+        - BuildkiteOrgSlug
 
       - Label:
           default: Advanced Buildkite Configuration
@@ -92,6 +93,11 @@ Parameters:
       - beta
       - edge
     Default: "stable"
+
+  BuildkiteOrgSlug:
+    Description: Buildkite organization slug
+    Type: String
+    Default: "none"
 
   BuildkiteAgentToken:
     Description: Buildkite agent registration token
@@ -882,11 +888,11 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-metrics-v3.0.0-lambda.zip"
+        S3Key: "buildkite-metrics-v4.0.0-lambda.zip"
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 120
-      Handler: handler.handle
-      Runtime: python2.7
+      Handler: handler
+      Runtime: go1.1x
       MemorySize: 128
       Environment:
         Variables:
@@ -895,6 +901,7 @@ Resources:
           AWS_STACK_ID: !Ref "AWS::StackId"
           AWS_STACK_NAME: !Ref "AWS::StackName"
           AWS_ACCOUNT_ID: !Ref "AWS::AccountId"
+          BUILDKITE_CLOUDWATCH_DIMENSIONS: !Sub "Org=${BuildkiteOrgSlug}"
 
   ScheduledRule:
     Type: "AWS::Events::Rule"

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -836,7 +836,7 @@ Resources:
           - - Name: Queue
               Value: !Ref BuildkiteQueue
             - Name: Org
-              Value: !Ref BuildkiteOrgSlug
+              Value:  !If [ HasOrgSlug, !Ref BuildkiteOrgSlug, "" ]
           - - Name: Queue
               Value: !Ref BuildkiteQueue
       ComparisonOperator: GreaterThanThreshold
@@ -859,7 +859,7 @@ Resources:
           - - Name: Queue
               Value: !Ref BuildkiteQueue
             - Name: Org
-              Value: !Ref BuildkiteOrgSlug
+              Value: !If [ HasOrgSlug, !Ref BuildkiteOrgSlug, "" ]
           - - Name: Queue
               Value: !Ref BuildkiteQueue
       ComparisonOperator: LessThanOrEqualToThreshold

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -400,19 +400,19 @@ Mappings:
     full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
 
   MetricsLambdaBucket:
-    us-east-1 : { Bucket: "buildkite-metrics" }
-    us-east-2 : { Bucket: "buildkite-metrics-us-east-2" }
-    us-west-1 : { Bucket: "buildkite-metrics-us-west-1" }
-    us-west-2 : { Bucket: "buildkite-metrics-us-west-2" }
-    eu-west-1 : { Bucket: "buildkite-metrics-eu-west-1" }
-    eu-west-2 : { Bucket: "buildkite-metrics-eu-west-2" }
-    eu-central-1 : { Bucket: "buildkite-metrics-eu-central-1" }
-    ap-northeast-1 : { Bucket: "buildkite-metrics-ap-northeast-1" }
-    ap-northeast-2 : { Bucket: "buildkite-metrics-ap-northeast-2" }
-    ap-southeast-1 : { Bucket: "buildkite-metrics-ap-southeast-1" }
-    ap-southeast-2 : { Bucket: "buildkite-metrics-ap-southeast-2" }
-    ap-south-1 : { Bucket: "buildkite-metrics-ap-south-1" }
-    sa-east-1 : { Bucket: "buildkite-metrics-sa-east-1" }
+    us-east-1 : { Bucket: "buildkite-lambdas" }
+    us-east-2 : { Bucket: "buildkite-lambdas-us-east-2" }
+    us-west-1 : { Bucket: "buildkite-lambdas-us-west-1" }
+    us-west-2 : { Bucket: "buildkite-lambdas-us-west-2" }
+    eu-west-1 : { Bucket: "buildkite-lambdas-eu-west-1" }
+    eu-west-2 : { Bucket: "buildkite-lambdas-eu-west-2" }
+    eu-central-1 : { Bucket: "buildkite-lambdas-eu-central-1" }
+    ap-northeast-1 : { Bucket: "buildkite-lambdas-ap-northeast-1" }
+    ap-northeast-2 : { Bucket: "buildkite-lambdas-ap-northeast-2" }
+    ap-southeast-1 : { Bucket: "buildkite-lambdas-ap-southeast-1" }
+    ap-southeast-2 : { Bucket: "buildkite-lambdas-ap-southeast-2" }
+    ap-south-1 : { Bucket: "buildkite-lambdas-ap-south-1" }
+    sa-east-1 : { Bucket: "buildkite-lambdas-sa-east-1" }
 
   # build/mappings.yml
 
@@ -904,7 +904,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-metrics-v4.1.0-lambda.zip"
+        S3Key: "buildkite-agent-metrics/v4.1.0/handler.zip"
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -908,7 +908,7 @@ Resources:
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler
-      Runtime: go1.1x
+      Runtime: go1.x
       MemorySize: 128
       Environment:
         Variables:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -906,7 +906,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [MetricsLambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-agent-metrics/v4.1.1/handler.zip"
+        S3Key: "buildkite-agent-metrics/v4.1.2/handler.zip"
       Role: !GetAtt LambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -378,7 +378,7 @@ Conditions:
       !Not [ !Equals [ !Ref KeyName, "" ] ]
 
     HasOrgSlug:
-      !Not [ !Equals [ !Ref KeyName, "" ] ]
+      !Not [ !Equals [ !Ref BuildkiteOrgSlug, "" ] ]
 
     EnableSshIngress:
       !And


### PR DESCRIPTION
We removed `BuildkiteOrgSlug` when we introduced the new Agent Metrics API. The idea was to reduce the number of required parameters, but we also removed the piece of data that was needed to support multiple Buildkite Orgs per AWS account, as otherwise the metrics are disambiguated only by queue. 

This adds back `BuildkiteOrgSlug` with a default of `` and then adds an `Org` dimension to the metrics we publish to Cloudwatch.

Closes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/452.