### PR TITLE
Prevent systemd from killing agent process group

### DIFF
--- a/packer/conf/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packer/conf/buildkite-agent/systemd/buildkite-agent@.service
@@ -14,7 +14,9 @@ Environment="USER=buildkite-agent"
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
-TimeoutSec=10
+TimeoutStartSec=10
+TimeoutStopSec=infinity
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The agent handles the termination of the bootstrap. This was preventing the agent from gracefully terminating.

Closes #520.