### PR TITLE
Expose AgentLifecycleTopic for programatic scaling

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -332,6 +332,9 @@ Outputs:
   InstanceRoleName:
     Value: !Ref IAMRole
 
+  AgentLifecycleTopic:
+    Value: !Ref AgentLifecycleTopic
+
 Conditions:
     UseSpotInstances:
       !Not [ !Equals [ !Ref SpotPrice, 0 ] ]


### PR DESCRIPTION
Expose the `AgentLifecycleTopic` name so that users can use utilities like Terraform to easily create custom integrations to supplement the Cloudwatch Alarms already provided by the ElasticStack.

Specifically, we want to be able to write custom alarms that can enforce additional scaling events outside of just the default alarms. 

Signed-off-by: Tom Duffield <tom@chef.io>