### PR TITLE
Older versions of systemd don't support infinity

### DIFF
--- a/packer/conf/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packer/conf/buildkite-agent/systemd/buildkite-agent@.service
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
 TimeoutStartSec=10
-TimeoutStopSec=infinity
+TimeoutStopSec=0
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Turns out that systemd before 229 didn't support `infinity`, so we use `0` to disable the stop timeout.