### PR TITLE
Allow users to specify additional sudo permissions

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -70,6 +70,11 @@ if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
 	buildkite-agent-edge --version
 fi
 
+if [[ "${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" != "" ]] ; then
+  echo "buildkite-agent ALL=NOPASSWD: ${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" > /etc/sudoers.d/buildkite-agent-additional
+  chmod 440 /etc/sudoers.d/buildkite-agent-additional
+fi
+
 # Choose the right agent binary
 ln -s "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -22,6 +22,7 @@ Metadata:
         - BuildkiteTerminateInstanceAfterJob
         - BuildkiteTerminateInstanceAfterJobTimeout
         - BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity
+        - BuilkditeAdditionalSudoPermissions
 
       - Label:
           default: Network Configuration
@@ -148,6 +149,11 @@ Parameters:
       - "true"
       - "false"
     Default: "false"
+
+  BuildkiteAdditionalSudoPermissions:
+    Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo.
+    Type: String
+    Default: ""
 
   BuildkiteQueue:
     Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"
@@ -725,6 +731,7 @@ Resources:
             BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \
             BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_TIMEOUT=${BuildkiteTerminateInstanceAfterJobTimeout} \
             BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_DECREASE_DESIRED_CAPACITY=${BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity} \
+            BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${BuildkiteAdditionalSudoPermissions} \
             AWS_DEFAULT_REGION=${AWS::Region} \
             SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
             ECR_PLUGIN_ENABLED=${EnableECRPlugin} \


### PR DESCRIPTION
Specify a comma separated list into `BuildkiteAdditionalSudoPermissions`

This allows users to easily extend which commands buildkite-agent can run using sudo. The setting can also be set to `ALL` as an escape hatch for those who want to run a super-privileged agent (though this is not recommended).

Signed-off-by: Tom Duffield <tom@chef.io>