### PR TITLE
Fix typo in docker experimental config

### DIFF
--- a/packer/conf/bin/bk-configure-docker.sh
+++ b/packer/conf/bin/bk-configure-docker.sh
@@ -15,5 +15,5 @@ fi
 
 # Set experimental in config
 if [[ "${DOCKER_EXPERIMENTAL:-false}" == "true" ]] ; then
-  cat <<< "$(jq '.experimental="buildkite-agent"' /etc/docker/daemon.json)" > /etc/docker/daemon.json
+  cat <<< "$(jq '.experimental="true"' /etc/docker/daemon.json)" > /etc/docker/daemon.json
 fi


### PR DESCRIPTION
There was a copy and paste error in #506 which meant that the `EnableDockerExperimental` param didn't work. 