### PR TITLE
Bump docker to 18.09.2

### DIFF
--- a/packer/scripts/install-docker.sh
+++ b/packer/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=18.09.1
+DOCKER_VERSION=18.09.2
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.23.2
 


### PR DESCRIPTION
This addresses [CVE-2019-5736](https://access.redhat.com/security/cve/cve-2019-5736) https://aws.amazon.com/security/security-bulletins/AWS-2019-002/ 

Closes #531.