### PR TITLE
Make sure we reload the systemd unit files

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -116,6 +116,9 @@ EOF
 ExecStopPost=/usr/local/bin/terminate-instance ${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_DECREASE_DESIRED_CAPACITY}
 ExecStopPost=/bin/sudo poweroff
 EOF
+
+  # If we modify the systemd, we need to rebuild the dependency tree
+  systemctl daemon-reload
 fi
 
 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -598,6 +598,7 @@ Resources:
               - autoscaling:RecordLifecycleActionHeartbeat
               - autoscaling:CompleteLifecycleAction
               - autoscaling:SetInstanceHealth
+              - autoscaling:TerminateInstanceInAutoScalingGroup
             Resource: "*"
           - Effect: Allow
             Action:


### PR DESCRIPTION
This is a bug affected the new terminate functionality in 4.1.0. 

If we do not reload the unit files, the new power-off.conf file gets ignored.

Signed-off-by: Tom Duffield <tom@chef.io>