### PR TITLE
Add helpers to Makefile for building packer image

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -1,9 +1,13 @@
 {
+  "variables": {
+    "region": "us-east-1",
+    "ami": "ami-7105540e"
+  },
   "builders": [
     {
       "type": "amazon-ebs",
-      "region": "us-east-1",
-      "source_ami": "ami-7105540e",
+      "region": "{{user `region`}}",
+      "source_ami": "{{user `ami`}}",
       "instance_type": "i3.large",
       "spot_price": "auto",
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",


### PR DESCRIPTION
This adds some simple helpers to the Makefile to make building custom AMIs for dev a little bit easier. It also ensures that we're building against the latest Amazon 2 AMI by default.

Signed-off-by: Tom Duffield <tom@chef.io>