### PR TITLE
Set the priority of the agent to its instance integer

### DIFF
--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -101,6 +101,7 @@ hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins
 experiment="${BUILDKITE_AGENT_EXPERIMENTS}"
+priority=%n
 EOF
 
 if [[ "${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB:-false}" == "true" ]] ; then


### PR DESCRIPTION
This will ensure that we optimize for leveraging the instances that are available to us, rather than unintentionally packing all jobs onto a single instance.

Fixes #540 

Signed-off-by: Tom Duffield <tom@chef.io>