### PR TITLE
Restart agent on SIGPIPE (journald restart)

### DIFF
--- a/packer/conf/buildkite-agent/systemd/buildkite-agent@.service
+++ b/packer/conf/buildkite-agent/systemd/buildkite-agent@.service
@@ -14,6 +14,7 @@ Environment="USER=buildkite-agent"
 ExecStart=/usr/bin/buildkite-agent start
 RestartSec=5
 Restart=on-failure
+RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
 TimeoutStopSec=0
 KillMode=process


### PR DESCRIPTION
We had an issue where the agent failed to restart on SIGPIPE, which turns out to be a thing when systemd and journald restart. 

Similar to https://github.com/influxdata/telegraf/pull/2716. 