### PR TITLE
Remove temporary packer key

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -51,6 +51,12 @@
     {
       "type": "shell",
       "script": "scripts/install-git-lfs.sh"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "rm /home/ec2-user/.ssh/authorized_keys"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Looks like a temporary packer key was left on the instances. These are destroyed after builds by packer, but good to remove it from `authorized_keys`. 

Fixes #544.