### PR TITLE
Use spawn vs multiple systemd units

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -52,6 +52,10 @@ service:
     enabled: true
     running: true
 
+  buildkite-agent:
+    enabled: true
+    running: true
+
 user:
   buildkite-agent:
     exists: true

--- a/packer/conf/buildkite-agent/scripts/stop-agent-gracefully
+++ b/packer/conf/buildkite-agent/scripts/stop-agent-gracefully
@@ -5,7 +5,7 @@ set -eu -o pipefail
 eval "$(cat /var/lib/buildkite-agent/cfn-env)"
 
 echo "Stopping buildkite-agent gracefully"
-systemctl stop "buildkite-agent@*"
+systemctl stop "buildkite-agent"
 
 # Need to ensure it's the buildkite-agent user, so it doesn't match this lifecycled handler script
 while pgrep -u buildkite-agent buildkite-agent > /dev/null; do

--- a/packer/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Buildkite Agent (%i)
+Description=Buildkite Agent
 Documentation=https://buildkite.com/agent
 After=syslog.target
 After=network.target

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -48,7 +48,7 @@ sudo mkdir -p /var/lib/buildkite-agent/plugins
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/plugins
 
 echo "Adding systemd service template..."
-sudo cp /tmp/conf/buildkite-agent/systemd/buildkite-agent@.service /etc/systemd/system/buildkite-agent@.service
+sudo cp /tmp/conf/buildkite-agent/systemd/buildkite-agent.service /etc/systemd/system/buildkite-agent.service
 
 echo "Adding termination scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/stop-agent-gracefully /usr/local/bin/stop-agent-gracefully


### PR DESCRIPTION
This simplifies things a bit by using the new `--spawn` parameter for multiple parallel agents with a single system service. 