### PR TITLE
Decrease the lambda timeout to less than 60s

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1081,8 +1081,8 @@ Resources:
           ASG_NAME:              !Ref AgentAutoScaleGroup
           MIN_SIZE:              !Ref MinSize
           MAX_SIZE:              !Ref MaxSize
-          LAMBDA_TIMEOUT:        "1m"
-          LAMBDA_INTERVAL:       "8s"
+          LAMBDA_TIMEOUT:        "50s"
+          LAMBDA_INTERVAL:       "10s"
 
   AutoscalingLambdaScheduledRule:
     Type: "AWS::Events::Rule"


### PR DESCRIPTION
Currently the lambda timeout is about the same as the scheduled execution frequently, which means occasionally the function doubles up and runs in parallel.