### PR TITLE
Remove alarm based autoscaling

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -64,10 +64,6 @@ cat << EOF > config.json
   {
     "ParameterKey": "EnableDockerUserNamespaceRemap",
     "ParameterValue": "true"
-  },
-  {
-    "ParameterKey": "EnableExperimentalLambdaBasedAutoscaling",
-    "ParameterValue": "true"
   }
 ]
 EOF

--- a/packer/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/conf/buildkite-agent/scripts/terminate-instance
@@ -1,14 +1,10 @@
 #!/bin/bash
-
 set -euo pipefail
-
-if [[ "${1:-false}" == "true" ]] ; then
-  should_decrement="should"
-else
-  should_decrement="no-should"
-fi
 
 instance_id=$(curl -fsSL http://169.254.169.254/latest/meta-data/instance-id)
 region=$(curl -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--${should_decrement}-decrement-desired-capacity"
+aws autoscaling terminate-instance-in-auto-scaling-group \
+  --region "$region" \
+  --instance-id "$instance_id" \
+  --should-decrement-desired-capacity

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -10,7 +10,6 @@ Metadata:
         Parameters:
         - BuildkiteAgentToken
         - BuildkiteQueue
-        - BuildkiteOrgSlug
 
       - Label:
           default: Advanced Buildkite Configuration
@@ -21,7 +20,6 @@ Metadata:
         - BuildkiteAgentExperiments
         - BuildkiteTerminateInstanceAfterJob
         - BuildkiteTerminateInstanceAfterJobTimeout
-        - BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity
         - BuildkiteAdditionalSudoPermissions
 
       - Label:
@@ -56,10 +54,7 @@ Metadata:
         Parameters:
         - MinSize
         - MaxSize
-        - ScaleUpAdjustment
-        - ScaleDownAdjustment
-        - ScaleCooldownPeriod
-        - ScaleDownPeriod
+        - ScaleDownIdlePeriod
         - InstanceCreationTimeout
 
       - Label:
@@ -101,11 +96,6 @@ Parameters:
       - edge
     Default: "stable"
 
-  BuildkiteOrgSlug:
-    Description: Optional Buildkite organization slug (e.g. "my-org"). This only needs to be set when running stacks for different Buildkite organisations in a single AWS account.
-    Type: String
-    Default: ""
-
   BuildkiteAgentToken:
     Description: Buildkite agent registration token
     Type: String
@@ -143,14 +133,6 @@ Parameters:
     Type: Number
     Default: 1800
     MinValue: 1
-
-  BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity:
-    Description: Set to "true" to decrease the desired capacity of the autoscaling group by 1 when terminating an instance after the job completes.
-    Type: String
-    AllowedValues:
-      - "true"
-      - "false"
-    Default: "false"
 
   BuildkiteAdditionalSudoPermissions:
     Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo.
@@ -226,28 +208,11 @@ Parameters:
     Type: Number
     Default: 0
 
-  ScaleUpAdjustment:
-    Description: Number of instances to add on scale up events (ScheduledJobsCount > 0 for 1 min)
-    Type: Number
-    Default: 5
-    MinValue: 0
-
-  ScaleDownAdjustment:
-    Description: Number of instances to remove on scale down events (UnfinishedJobs == 0 for ScaleDownPeriod)
-    Type: Number
-    Default: -1
-    MaxValue: 0
-
-  ScaleCooldownPeriod:
-    Description: Minimum number of seconds to wait between scaling events. Must be greater than the time needed for an instance to boot.
+  ScaleDownIdlePeriod:
+    Description: Number of seconds an agent must be idle for before it scales in.
     Type: Number
     Default: 300
     MinValue: 10
-
-  ScaleDownPeriod:
-    Description: Number of seconds UnfinishedJobs must equal 0 before scale down
-    Type: Number
-    Default: 1800
 
   InstanceCreationTimeout:
     Description: Timeout period for Autoscaling Group Creation Policy
@@ -366,14 +331,6 @@ Parameters:
     Description: The value of the Cost Allocation Tag used for billing purposes
     Default: "buildkite-elastic-ci-stack-for-aws"
 
-  EnableExperimentalLambdaBasedAutoscaling:
-    Type: String
-    Description: Uses a custom lambda for autoscaling vs the standard AWS AutoScaling
-    AllowedValues:
-      - "true"
-      - "false"
-    Default: "false"
-
 Outputs:
   ManagedSecretsBucket:
     Value:
@@ -429,23 +386,14 @@ Conditions:
     HasVariableSize:
       !Not [ !Equals [ !Ref MaxSize, !Ref MinSize ] ]
 
-    EnableLambdaAutoscaling:
-      !Equals [ !Ref EnableExperimentalLambdaBasedAutoscaling, "true" ]
-
     UseLambdaAutoscaling:
-      !And [ Condition: EnableLambdaAutoscaling, Condition: HasVariableSize ]
-
-    UseNativeAutoscaling:
-      !And [ !Not [ Condition: EnableLambdaAutoscaling ], Condition: HasVariableSize ]
+      Condition: HasVariableSize
 
     UseCostAllocationTags:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
     HasKeyName:
       !Not [ !Equals [ !Ref KeyName, "" ] ]
-
-    HasOrgSlug:
-      !Not [ !Equals [ !Ref BuildkiteOrgSlug, "" ] ]
 
     EnableSshIngress:
       !And
@@ -743,7 +691,7 @@ Resources:
             BUILDKITE_STACK_NAME="${AWS::StackName}" \
             BUILDKITE_STACK_VERSION=%v \
             BUILDKITE_LAMBDA_AUTOSCALING=${LambdaAutoscaling} \
-            BUILDKITE_SCALE_DOWN_PERIOD=${ScaleDownPeriod} \
+            BUILDKITE_SCALE_DOWN_IDLE_PERIOD=${ScaleDownIdlePeriod} \
             BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
             BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
             BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
@@ -752,14 +700,12 @@ Resources:
             BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
             BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
             BUILDKITE_QUEUE="${BuildkiteQueue}" \
-            BUILDKITE_ORG_SLUG="${BuildkiteOrgSlug}" \
             BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
             BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
             BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
             BUILDKITE_LIFECYCLE_TOPIC=${AgentLifecycleTopic} \
             BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \
             BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_TIMEOUT=${BuildkiteTerminateInstanceAfterJobTimeout} \
-            BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_DECREASE_DESIRED_CAPACITY=${BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity} \
             BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${BuildkiteAdditionalSudoPermissions} \
             AWS_DEFAULT_REGION=${AWS::Region} \
             SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
@@ -776,8 +722,8 @@ Resources:
             LambdaAutoscaling:
               !If
                 - UseLambdaAutoscaling
-                - true
-                - false
+                - "true"
+                - "false"
 
   AgentLifecycleTopic:
     Type: AWS::SNS::Topic
@@ -818,7 +764,7 @@ Resources:
       LaunchConfigurationName: !Ref AgentLaunchConfiguration
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
-      Cooldown: 0
+      Cooldown: "0"
       MetricsCollection:
         - Granularity: 1Minute
           Metrics:
@@ -839,9 +785,6 @@ Resources:
           PropagateAtLaunch: true
         - Key: BuildkiteAgentRelease
           Value: !Ref BuildkiteAgentRelease
-          PropagateAtLaunch: true
-        - Key: BuildkiteOrgSlug
-          Value: !Ref BuildkiteOrgSlug
           PropagateAtLaunch: true
         - Key: BuildkiteQueue
           Value: !Ref BuildkiteQueue
@@ -879,141 +822,6 @@ Resources:
       FromPort: 22
       ToPort: 22
       CidrIp: 0.0.0.0/0
-
-  AgentScaleUpPolicy:
-    Type: AWS::AutoScaling::ScalingPolicy
-    Condition: UseNativeAutoscaling
-    Properties:
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref AgentAutoScaleGroup
-      Cooldown: !Ref ScaleCooldownPeriod
-      ScalingAdjustment : !Ref ScaleUpAdjustment
-
-  AgentScaleDownPolicy:
-    Type: AWS::AutoScaling::ScalingPolicy
-    Condition: UseNativeAutoscaling
-    Properties:
-      AdjustmentType: ChangeInCapacity
-      AutoScalingGroupName: !Ref AgentAutoScaleGroup
-      Cooldown: !Ref ScaleCooldownPeriod
-      ScalingAdjustment: !Ref ScaleDownAdjustment
-
-  AgentUtilizationAlarmHigh:
-    Type: AWS::CloudWatch::Alarm
-    Condition: UseNativeAutoscaling
-    Properties:
-      AlarmDescription: Scale-up if ScheduledJobs > 0 for 1 minute
-      MetricName: ScheduledJobsCount
-      Namespace: Buildkite
-      Statistic: Minimum
-      Period: 60
-      EvaluationPeriods: 1
-      Threshold: 0
-      AlarmActions: [ !Ref AgentScaleUpPolicy ]
-      Dimensions:
-        !If
-          - HasOrgSlug
-          - - Name: Queue
-              Value: !Ref BuildkiteQueue
-            - Name: Org
-              Value:  !If [ HasOrgSlug, !Ref BuildkiteOrgSlug, "" ]
-          - - Name: Queue
-              Value: !Ref BuildkiteQueue
-      ComparisonOperator: GreaterThanThreshold
-
-  AgentUtilizationAlarmLow:
-    Type: AWS::CloudWatch::Alarm
-    Condition: UseNativeAutoscaling
-    Properties:
-      AlarmDescription: Scale-down if UnfinishedJobs == 0 for N minutes
-      MetricName: UnfinishedJobsCount
-      Namespace: Buildkite
-      Statistic: Maximum
-      Period: !Ref ScaleDownPeriod
-      EvaluationPeriods: 1
-      Threshold: 0
-      AlarmActions: [ !Ref AgentScaleDownPolicy ]
-      Dimensions:
-        !If
-          - HasOrgSlug
-          - - Name: Queue
-              Value: !Ref BuildkiteQueue
-            - Name: Org
-              Value: !If [ HasOrgSlug, !Ref BuildkiteOrgSlug, "" ]
-          - - Name: Queue
-              Value: !Ref BuildkiteQueue
-      ComparisonOperator: LessThanOrEqualToThreshold
-
-  MetricsLambdaExecutionRole:
-    Type: AWS::IAM::Role
-    Condition: UseNativeAutoscaling
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-          Action:
-          - sts:AssumeRole
-      Path: "/"
-
-  MetricsLambdaExecutionPolicy:
-    Type: AWS::IAM::Policy
-    Condition: UseNativeAutoscaling
-    Properties:
-      PolicyName: AccessToCloudwatchForBuildkiteMetrics
-      Roles:
-      - !Ref MetricsLambdaExecutionRole
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Action:
-          - logs:CreateLogGroup
-          - logs:CreateLogStream
-          - logs:PutLogEvents
-          - cloudwatch:PutMetricData
-          Resource:
-          - "*"
-
-  MetricsFunction:
-    Type: AWS::Lambda::Function
-    Condition: UseNativeAutoscaling
-    Properties:
-      Code:
-        S3Bucket: { 'Fn::FindInMap': [LambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-agent-metrics/v4.1.2/handler.zip"
-      Role: !GetAtt MetricsLambdaExecutionRole.Arn
-      Timeout: 120
-      Handler: handler
-      Runtime: go1.x
-      MemorySize: 128
-      Environment:
-        Variables:
-          BUILDKITE_AGENT_TOKEN: !Ref BuildkiteAgentToken
-          BUILDKITE_QUEUE: !Ref BuildkiteQueue
-
-  MetricsLambdaScheduledRule:
-    Type: "AWS::Events::Rule"
-    Condition: UseNativeAutoscaling
-    Properties:
-      Description: "BuildkiteMetricsScheduledRule"
-      ScheduleExpression: "rate(1 minute)"
-      State: "ENABLED"
-      Targets:
-        - Arn: !GetAtt MetricsFunction.Arn
-          Id: "TargetMetricsFunction"
-
-  PermissionForEventsToInvokeMetricsLambda:
-    Type: "AWS::Lambda::Permission"
-    Condition: UseNativeAutoscaling
-    Properties:
-      FunctionName: !Ref MetricsFunction
-      Action: "lambda:InvokeFunction"
-      Principal: "events.amazonaws.com"
-      SourceArn: !GetAtt MetricsLambdaScheduledRule.Arn
 
   AutoscalingLambdaExecutionRole:
     Type: AWS::IAM::Role

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1081,8 +1081,8 @@ Resources:
           ASG_NAME:              !Ref AgentAutoScaleGroup
           MIN_SIZE:              !Ref MinSize
           MAX_SIZE:              !Ref MaxSize
-          LAMBDA_TIMEOUT:        "1m"
-          LAMBDA_INTERVAL:       "8s"
+          LAMBDA_TIMEOUT:        "50s"
+          LAMBDA_INTERVAL:       "10s"
 
   AutoscalingLambdaScheduledRule:
     Type: "AWS::Events::Rule"


### PR DESCRIPTION
This removes the old alarm-based autoscaling in favour of lambda-based scale-out and per-host based idle scale-in.

It's radically faster. I'm seeing 50-75s from the time a job is queued to the time an agent is available on a new host! 

This will likely need to be released in v5.0.0. 

Closes #93, #322 and #436. 