### PR TITLE
Add EnableAgentGitMirrorsExperiment parameter

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -64,6 +64,10 @@ cat << EOF > config.json
   {
     "ParameterKey": "EnableDockerUserNamespaceRemap",
     "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "EnableAgentGitMirrorsExperiment",
+    "ParameterValue": "true"
   }
 ]
 EOF

--- a/packer/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/conf/bin/bk-install-elastic-stack.sh
@@ -91,6 +91,15 @@ if [[ -n "${BUILDKITE_AGENT_TAGS:-}" ]] ; then
 	agent_metadata=("${agent_metadata[@]}" "${extra_agent_metadata[@]}")
 fi
 
+# Enable git mirrors
+if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
+  if [[ -z "$BUILDKITE_AGENT_EXPERIMENTS" ]] ; then
+    BUILDKITE_AGENT_EXPERIMENTS="git-mirrors"
+  else
+    BUILDKITE_AGENT_EXPERIMENTS+=",git-mirrors"
+  fi
+fi
+
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
@@ -100,6 +109,7 @@ timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins
+git-mirrors-path=/var/lib/buildkite-agent/git-mirrors
 experiment="${BUILDKITE_AGENT_EXPERIMENTS}"
 priority=%n
 spawn=${BUILDKITE_AGENTS_PER_INSTANCE}

--- a/packer/scripts/install-buildkite-agent.sh
+++ b/packer/scripts/install-buildkite-agent.sh
@@ -43,6 +43,10 @@ echo "Creating builds dir..."
 sudo mkdir -p /var/lib/buildkite-agent/builds
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/builds
 
+echo "Creating git mirrors dir..."
+sudo mkdir -p /var/lib/buildkite-agent/git-mirrors
+sudo chown -R buildkite-agent: /var/lib/buildkite-agent/git-mirrors
+
 echo "Creating plugins dir..."
 sudo mkdir -p /var/lib/buildkite-agent/plugins
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/plugins

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -331,6 +331,14 @@ Parameters:
     Description: The value of the Cost Allocation Tag used for billing purposes
     Default: "buildkite-elastic-ci-stack-for-aws"
 
+   EnableAgentGitMirrorsExperiment:
+    Type: String
+    Description: Enables the git-mirrors experiment in the agent
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
 Outputs:
   ManagedSecretsBucket:
     Value:
@@ -700,6 +708,7 @@ Resources:
             BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
             BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
             BUILDKITE_QUEUE="${BuildkiteQueue}" \
+            BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT=${EnableAgentGitMirrorsExperiment} \
             BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
             BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
             BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -331,7 +331,7 @@ Parameters:
     Description: The value of the Cost Allocation Tag used for billing purposes
     Default: "buildkite-elastic-ci-stack-for-aws"
 
-   EnableAgentGitMirrorsExperiment:
+  EnableAgentGitMirrorsExperiment:
     Type: String
     Description: Enables the git-mirrors experiment in the agent
     AllowedValues:


### PR DESCRIPTION
Supports the new git mirrors functionality in the latest Agent releases:

https://github.com/buildkite/agent/pull/936