### PR TITLE
Install pigz for parallel decompression in docker pull

### DIFF
--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -10,7 +10,7 @@ sudo pip install --upgrade awscli
 
 echo "Installing zip utils..."
 sudo yum update -y -q
-sudo yum install -y zip unzip git
+sudo yum install -y zip unzip git pigz
 
 echo "Installing bk elastic stack bin files..."
 sudo chmod +x /tmp/conf/bin/bk-*


### PR DESCRIPTION
Docker added some support for slightly improving `docker pull` performance if `unpigz` is available, see the notes here: https://github.com/moby/moby/issues/37957#issuecomment-426633293