### PR TITLE
Add back us-east-1 to regions

### DIFF
--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -54,6 +54,7 @@ if [[ -z "${BUILDKITE_AWS_STACK_BUCKET}" ]] ; then
 fi
 
 ALL_REGIONS=(
+  us-east-1
   us-east-2
   us-west-1
   us-west-2


### PR DESCRIPTION
us-east-1 was accidentally removed from `copy.sh` file https://github.com/buildkite/elastic-ci-stack-for-aws/commit/e0ef99968d2be086b4734890aad34ccd1a3e9721