### PR TITLE
Add python3 and future lib to allow prepping for Python2 EOL

### DIFF
--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -6,7 +6,10 @@ sudo yum update -y
 
 echo "Updating awscli..."
 sudo yum install -y python2-pip
+sudo yum install -y python3-pip python3 python3-setuptools
 sudo pip install --upgrade awscli
+sudo pip install future
+sudo pip3 install future
 
 echo "Installing zip utils..."
 sudo yum update -y -q


### PR DESCRIPTION
With Python2 aiming to EOL on Jan 1, 2020 (https://github.com/python/devguide/pull/344), we need to start prepping for Python3 conversion.

The [future module](https://python-future.org/) allows uplifting Python2 code to be mostly compatible with Python3, allowing for incremental conversions.