### PR TITLE
Fix cloudformation ImageId regression

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -410,6 +410,9 @@ Conditions:
     UseArtifactsBucket:
       !Not [ !Equals [ !Ref ArtifactsBucket, "" ] ]
 
+    UseDefaultAMI:
+      !Equals [ !Ref ImageId, "" ]
+
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
 
@@ -706,10 +709,7 @@ Resources:
       IamInstanceProfile: !Ref IAMInstanceProfile
       InstanceType: !Ref InstanceType
       SpotPrice: !If [ "UseSpotInstances", !Ref SpotPrice, !Ref 'AWS::NoValue' ]
-      ImageId: !If
-        - UseWindowsAgents
-        - !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'windows' ]
-        - !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'linux' ]
+      ImageId: !If [ UseDefaultAMI, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ], !Ref ImageId ]
       BlockDeviceMappings:
         - DeviceName: !Ref RootVolumeName
           Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }


### PR DESCRIPTION
The following commit removed the ability to use the
value set by the ImageId parameter.

https://github.com/buildkite/elastic-ci-stack-for-aws/commit/7d2ec14d1dc87ae32b98e7b75905e3d1fe6c8d51

Signed-off-by: Jeremiah Snapp <jeremiah@chef.io>