### PR TITLE
Adds AllowedPattern to ImageId

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -266,6 +266,7 @@ Parameters:
   ImageId:
     Type: String
     Description: Optional - Custom AMI to use for instances (must be based on the stack's AMI)
+    AllowedPattern: "^ami\-\w+$"
     Default: ""
 
   ManagedPolicyARN:


### PR DESCRIPTION
Adds `AllowedPattern` regex to `ImageId`. I mistakenly passed the image name and had to wait for the stack to rollback to see that I had passed the wrong value. This would have given me an error more quickly.