### PR TITLE
Decrease capacity after terminating instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,16 +144,9 @@ Metrics are collected with a Lambda function, polling every minute.
 
 ## Terminating the instance after job is complete
 
-You may set `BuildkiteTerminateInstanceAfterJob` to `true` to force the instance to terminate after it completes a job. Setting this value to `true` tells the stack to apply the following configurations:
-
-1. Sets `disconnect-after-job` and `disconnect-after-job-timeout` in the `buildkite-agent.cfg` file.
-2. Adds `ExecStopPost` steps to the agent's systemd service to mark the instance as unhealthy and to stop the instance.
+You may set `BuildkiteTerminateInstanceAfterJob` to `true` to force the instance to terminate after it completes a job. Setting this value to `true` tells the stack to enable `disconnect-after-job` in the `buildkite-agent.cfg` file.
 
 While not enforced, it is highly recommended you also set your `AgentsPerInstance` value to `1`.
-
-You may configure `BuildkiteTerminateInstanceAfterJobTimeout` to control how long an instance will wait for a job before terminating itself. You can use this setting to tune your ASG to optimize the queue for availability based on your tolerance for scaling events. The default value is 30 minutes (1800 seconds).
-
-Additionally you can set `BuildkiteTerminateInstanceAfterJobDecreaseDesiredCapacity` to `true` to decrease the desired capacity of the autoscaling group by 1 when terminating an instance after the job completes. Use this option if you don't wish the terminated instance to be replaced by another in the autoscaling group.
 
 We strongly encourage you to find an alternative to this setting if at all possible. The turn around time for replacing these instances is currently slow (5-10 minutes depending on other stack configuration settings). If you need single use jobs, we suggest looking at our container plugins like `docker`, `docker-compose`, and `ecs`, all which can be found [here](https://buildkite.com/plugins).
 

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -114,35 +114,9 @@ experiment="${BUILDKITE_AGENT_EXPERIMENTS}"
 priority=%n
 spawn=${BUILDKITE_AGENTS_PER_INSTANCE}
 no-color=true
-EOF
-
-terminate_instance_on_agent_stop() {
-  mkdir -p /etc/systemd/system/buildkite-agent.service.d/
-  cat << EOF > /etc/systemd/system/buildkite-agent.service.d/10-power-off-stop.conf
-[Service]
-ExecStopPost=/usr/local/bin/terminate-instance
-ExecStopPost=/bin/sudo poweroff
-EOF
-
-  # If we modify the systemd, we need to rebuild the dependency tree
-  systemctl daemon-reload
-}
-
-# Add conditional config to the agent config
-if [[ "${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB:-false}" == "true" ]] ; then
-  cat << EOF >> /etc/buildkite-agent/buildkite-agent.cfg
-disconnect-after-job=true
-disconnect-after-job-timeout=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_TIMEOUT}
-EOF
-  terminate_instance_on_agent_stop
-fi
-
-if [[ "${BUILDKITE_LAMBDA_AUTOSCALING}" == "true" ]] ; then
-  cat << EOF >> /etc/buildkite-agent/buildkite-agent.cfg
 disconnect-after-idle-timeout=${BUILDKITE_SCALE_IN_IDLE_PERIOD}
+disconnect-after-job=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
 EOF
-  terminate_instance_on_agent_stop
-fi
 
 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -2,13 +2,7 @@
 
 set -euo pipefail
 
-if [[ "${1:-false}" == "true" ]] ; then
-  should_decrement="should"
-else
-  should_decrement="no-should"
-fi
-
 instance_id=$(curl -fsSL http://169.254.169.254/latest/meta-data/instance-id)
 region=$(curl -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--${should_decrement}-decrement-desired-capacity"
+aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity"

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -12,6 +12,8 @@ Environment="HOME=/var/lib/buildkite-agent"
 Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 Environment="USER=buildkite-agent"
 ExecStart=/usr/bin/buildkite-agent start
+ExecStopPost=/usr/local/bin/terminate-instance
+ExecStopPost=/bin/sudo poweroff
 RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.11.3
+AGENT_VERSION=3.11.5
 
 echo "Installing dependencies..."
 sudo yum update -y -q

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,18 +1,9 @@
-param ([string]$should_decrement = "false")
-
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
-
-If ($should_decrement -eq "true") {
-  $should_decrement = "should"
-}
-Else {
-  $should_decrement = "no-should"
-}
 
 $InstanceId = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
 $Region = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--${should_decrement}-decrement-desired-capacity"
+aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity"
 
 Stop-Computer $env:computername -Force

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.11.3"
+$AGENT_VERSION = "3.11.5"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -19,7 +19,6 @@ Metadata:
         - BuildkiteAgentTimestampLines
         - BuildkiteAgentExperiments
         - BuildkiteTerminateInstanceAfterJob
-        - BuildkiteTerminateInstanceAfterJobTimeout
         - BuildkiteAdditionalSudoPermissions
         - BuildkiteWindowsAdministrator
 
@@ -130,12 +129,6 @@ Parameters:
       - "true"
       - "false"
     Default: "false"
-
-  BuildkiteTerminateInstanceAfterJobTimeout:
-    Description: When BuildkiteTerminateInstanceAfterJob is "true", how many seconds to wait for a job before terminating the instance.
-    Type: Number
-    Default: 1800
-    MinValue: 1
 
   BuildkiteAdditionalSudoPermissions:
     Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo.
@@ -740,7 +733,6 @@ Resources:
               $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
               $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
               $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
-              $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_TIMEOUT="${BuildkiteTerminateInstanceAfterJobTimeout}"
               $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
               $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
               $Env:AWS_DEFAULT_REGION="${AWS::Region}"
@@ -783,7 +775,6 @@ Resources:
               BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
               BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
               BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \
-              BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_TIMEOUT=${BuildkiteTerminateInstanceAfterJobTimeout} \
               BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${BuildkiteAdditionalSudoPermissions} \
               AWS_DEFAULT_REGION=${AWS::Region} \
               SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \


### PR DESCRIPTION
* Bumps buildkite-agent to version 3.11.5.
* Makes terminate-instance script always decrease capacity.
* Removes `BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB_TIMEOUT` parameter since this is best handled by `ScaleInIdlePeriod`.
* Using the new scaler by default allows the bk-install-elastic-stack scripts to be refactored to have a cleaner way of defining `buildkite-agent.cfg` and also allows the buildkite-agent service to run `post stop` commands by default.
* Updates README.md