### PR TITLE
Use a LaunchTemplate instead of a LaunchConfiguration

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -693,102 +693,134 @@ Resources:
       Roles:
         - !Ref IAMRole
 
-  AgentLaunchConfiguration:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  AgentLaunchTemplate:
+    Type: "AWS::EC2::LaunchTemplate"
     Properties:
-      AssociatePublicIpAddress: !Ref AssociatePublicIpAddress
-      SecurityGroups: [ !If [ "CreateSecurityGroup", !Ref SecurityGroup, !Ref SecurityGroupId ] ]
-      KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
-      IamInstanceProfile: !Ref IAMInstanceProfile
-      InstanceType: !Ref InstanceType
-      SpotPrice: !If [ "UseSpotInstances", !Ref SpotPrice, !Ref 'AWS::NoValue' ]
-      ImageId: !If [ UseDefaultAMI, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ], !Ref ImageId ]
-      BlockDeviceMappings:
-        - DeviceName: !Ref RootVolumeName
-          Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }
-      UserData:
-        Fn::Base64: !If
-          - UseWindowsAgents
-          - !Sub
-            - |
-              <powershell>
-              $Env:DOCKER_USERNS_REMAP="${EnableDockerUserNamespaceRemap}"
-              $Env:DOCKER_EXPERIMENTAL="${EnableDockerExperimental}"
-              powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
+      LaunchTemplateData:
+	        NetworkInterfaces:
+	          - DeviceIndex: 0
+	            AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
+	            Groups:
+	            - !If [ "CreateSecurityGroup", !Ref SecurityGroup, !Ref SecurityGroupId ]
+	        KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
+	        IamInstanceProfile:
+	          Arn: !GetAtt "IAMInstanceProfile.Arn"
+	        InstanceType: !Ref InstanceType
+          MarketType: !If [ "UseSpotInstances", "spot", !Ref 'AWS::NoValue' ]
+          SpotOptions: !If
+            - UseSpotInstances
+            - SpotOptions:
+                MaxPrice: !Ref SpotPrice
+            - !Ref "AWS::NoValue"
+	        ImageId : !If [ UseDefaultAMI, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ], !Ref ImageId ]
+	        BlockDeviceMappings:
+	          - DeviceName: /dev/xvda
+	            Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }
+	        TagSpecifications:
+	          - ResourceType: instance
+	            Tags:
+                - Key: Role
+                  Value: buildkite-agent
+                  PropagateAtLaunch: true
+                - Key: Name
+                  Value: buildkite-agent
+                  PropagateAtLaunch: true
+                - Key: BuildkiteAgentRelease
+                  Value: !Ref BuildkiteAgentRelease
+                  PropagateAtLaunch: true
+                - Key: BuildkiteQueue
+                  Value: !Ref BuildkiteQueue
+                  PropagateAtLaunch: true
+                - !If
+                  - UseCostAllocationTags
+                  - Key: !Ref CostAllocationTagName
+                    Value: !Ref CostAllocationTagValue
+                  - !Ref "AWS::NoValue"
+          UserData:
+            Fn::Base64: !If
+              - UseWindowsAgents
+              - !Sub
+                - |
+                  <powershell>
+                  $Env:DOCKER_USERNS_REMAP="${EnableDockerUserNamespaceRemap}"
+                  $Env:DOCKER_EXPERIMENTAL="${EnableDockerExperimental}"
+                  powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
 
-              $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
-              $Env:BUILDKITE_STACK_VERSION=%v
-              $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
-              $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
-              $Env:BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}"
-              $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
-              $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
-              $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
-              $Env:BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}"
-              $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
-              $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
-              $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT="${EnableAgentGitMirrorsExperiment}"
-              $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
-              $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
-              $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
-              $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
-              $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
-              $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
-              $Env:AWS_DEFAULT_REGION="${AWS::Region}"
-              $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
-              $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
-              $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
-              $Env:AWS_REGION="${AWS::Region}"
-              powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
-              </powershell>
-            - {
-                LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-              }
-          - !Sub
-            - |
-              Content-Type: multipart/mixed; boundary="==BOUNDARY=="
-              MIME-Version: 1.0
-              --==BOUNDARY==
-              Content-Type: text/cloud-boothook; charset="us-ascii"
-              DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
-              DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
-                /usr/local/bin/bk-configure-docker.sh
-              --==BOUNDARY==
-              Content-Type: text/x-shellscript; charset="us-ascii"
-              #!/bin/bash -xv
-              BUILDKITE_STACK_NAME="${AWS::StackName}" \
-              BUILDKITE_STACK_VERSION=%v \
-              BUILDKITE_SCALE_IN_IDLE_PERIOD=${ScaleInIdlePeriod} \
-              BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
-              BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
-              BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
-              BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
-              BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
-              BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
-              BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
-              BUILDKITE_QUEUE="${BuildkiteQueue}" \
-              BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT=${EnableAgentGitMirrorsExperiment} \
-              BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
-              BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
-              BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
-              BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \
-              BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${BuildkiteAdditionalSudoPermissions} \
-              AWS_DEFAULT_REGION=${AWS::Region} \
-              SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
-              ECR_PLUGIN_ENABLED=${EnableECRPlugin} \
-              DOCKER_LOGIN_PLUGIN_ENABLED=${EnableDockerLoginPlugin} \
-              AWS_REGION=${AWS::Region} \
-                /usr/local/bin/bk-install-elastic-stack.sh
-              --==BOUNDARY==--
-            - {
-                LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-              }
+                  $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
+                  $Env:BUILDKITE_STACK_VERSION=%v
+                  $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
+                  $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
+                  $Env:BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}"
+                  $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
+                  $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
+                  $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
+                  $Env:BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}"
+                  $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
+                  $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
+                  $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT="${EnableAgentGitMirrorsExperiment}"
+                  $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
+                  $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
+                  $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
+                  $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
+                  $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
+                  $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
+                  $Env:AWS_DEFAULT_REGION="${AWS::Region}"
+                  $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
+                  $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
+                  $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
+                  $Env:AWS_REGION="${AWS::Region}"
+                  powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
+                  </powershell>
+                - {
+                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
+                  }
+              - !Sub
+                - |
+                  Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+                  MIME-Version: 1.0
+                  --==BOUNDARY==
+                  Content-Type: text/cloud-boothook; charset="us-ascii"
+                  DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+                  DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
+                    /usr/local/bin/bk-configure-docker.sh
+                  --==BOUNDARY==
+                  Content-Type: text/x-shellscript; charset="us-ascii"
+                  #!/bin/bash -xv
+                  BUILDKITE_STACK_NAME="${AWS::StackName}" \
+                  BUILDKITE_STACK_VERSION=%v \
+                  BUILDKITE_SCALE_IN_IDLE_PERIOD=${ScaleInIdlePeriod} \
+                  BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
+                  BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
+                  BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
+                  BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
+                  BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
+                  BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
+                  BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
+                  BUILDKITE_QUEUE="${BuildkiteQueue}" \
+                  BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT=${EnableAgentGitMirrorsExperiment} \
+                  BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
+                  BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
+                  BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
+                  BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \
+                  BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${BuildkiteAdditionalSudoPermissions} \
+                  AWS_DEFAULT_REGION=${AWS::Region} \
+                  SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
+                  ECR_PLUGIN_ENABLED=${EnableECRPlugin} \
+                  DOCKER_LOGIN_PLUGIN_ENABLED=${EnableDockerLoginPlugin} \
+                  AWS_REGION=${AWS::Region} \
+                    /usr/local/bin/bk-install-elastic-stack.sh
+                  --==BOUNDARY==--
+                - {
+                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
+                  }
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
-      LaunchConfigurationName: !Ref AgentLaunchConfiguration
+      LaunchTemplate:
+	      LaunchTemplateId: !Ref AgentLaunchTemplate
+	      Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 0
@@ -803,25 +835,6 @@ Resources:
       TerminationPolicies:
         - OldestLaunchConfiguration
         - ClosestToNextInstanceHour
-      Tags:
-        - Key: Role
-          Value: buildkite-agent
-          PropagateAtLaunch: true
-        - Key: Name
-          Value: buildkite-agent
-          PropagateAtLaunch: true
-        - Key: BuildkiteAgentRelease
-          Value: !Ref BuildkiteAgentRelease
-          PropagateAtLaunch: true
-        - Key: BuildkiteQueue
-          Value: !Ref BuildkiteQueue
-          PropagateAtLaunch: true
-        - !If
-          - UseCostAllocationTags
-          - Key: !Ref CostAllocationTagName
-            Value: !Ref CostAllocationTagValue
-            PropagateAtLaunch: true
-          - !Ref "AWS::NoValue"
     CreationPolicy:
       ResourceSignal:
         Timeout: !Ref InstanceCreationTimeout

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -697,28 +697,28 @@ Resources:
     Type: "AWS::EC2::LaunchTemplate"
     Properties:
       LaunchTemplateData:
-	        NetworkInterfaces:
-	          - DeviceIndex: 0
-	            AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
-	            Groups:
-	            - !If [ "CreateSecurityGroup", !Ref SecurityGroup, !Ref SecurityGroupId ]
-	        KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
-	        IamInstanceProfile:
-	          Arn: !GetAtt "IAMInstanceProfile.Arn"
-	        InstanceType: !Ref InstanceType
+          NetworkInterfaces:
+            - DeviceIndex: 0
+              AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
+              Groups:
+              - !If [ "CreateSecurityGroup", !Ref SecurityGroup, !Ref SecurityGroupId ]
+          KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
+          IamInstanceProfile:
+            Arn: !GetAtt "IAMInstanceProfile.Arn"
+          InstanceType: !Ref InstanceType
           MarketType: !If [ "UseSpotInstances", "spot", !Ref 'AWS::NoValue' ]
           SpotOptions: !If
             - UseSpotInstances
             - SpotOptions:
                 MaxPrice: !Ref SpotPrice
             - !Ref "AWS::NoValue"
-	        ImageId : !If [ UseDefaultAMI, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ], !Ref ImageId ]
-	        BlockDeviceMappings:
-	          - DeviceName: /dev/xvda
-	            Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }
-	        TagSpecifications:
-	          - ResourceType: instance
-	            Tags:
+          ImageId: !If [ UseDefaultAMI, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ], !Ref ImageId ]
+          BlockDeviceMappings:
+            - DeviceName: /dev/xvda
+              Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }
+          TagSpecifications:
+            - ResourceType: instance
+              Tags:
                 - Key: Role
                   Value: buildkite-agent
                   PropagateAtLaunch: true
@@ -819,8 +819,8 @@ Resources:
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       LaunchTemplate:
-	      LaunchTemplateId: !Ref AgentLaunchTemplate
-	      Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+        LaunchTemplateId: !Ref AgentLaunchTemplate
+        Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 0

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -721,16 +721,12 @@ Resources:
               Tags:
                 - Key: Role
                   Value: buildkite-agent
-                  PropagateAtLaunch: true
                 - Key: Name
                   Value: buildkite-agent
-                  PropagateAtLaunch: true
                 - Key: BuildkiteAgentRelease
                   Value: !Ref BuildkiteAgentRelease
-                  PropagateAtLaunch: true
                 - Key: BuildkiteQueue
                   Value: !Ref BuildkiteQueue
-                  PropagateAtLaunch: true
                 - !If
                   - UseCostAllocationTags
                   - Key: !Ref CostAllocationTagName


### PR DESCRIPTION
Apparently using LaunchTemplates solves the tag propagation problem that has resulted in the emails folks have been getting about IAM Authentication and Cross-stack Requests. 

It also opens up some nice possibilities for the easier introduction of Spot Fleet down the track. 

Tried this before in #424, but it wasn't possible then because there wasn't a way to specify a spot bid, but that now is possible in [InstanceMarketOptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-instancemarketoptions.html).