### PR TITLE
Add default InstanceCreationTimeout value for windows instances

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -233,7 +233,7 @@ Parameters:
   InstanceCreationTimeout:
     Description: Timeout period for Autoscaling Group Creation Policy
     Type: String
-    Default: "PT5M"
+    Default: ""
 
   RootVolumeSize:
     Description: Size of each instance's root EBS volume (in GB)
@@ -405,6 +405,9 @@ Conditions:
 
     UseDefaultAMI:
       !Equals [ !Ref ImageId, "" ]
+
+    UseDefaultInstanceCreationTimeout:
+      !Equals [ !Ref InstanceCreationTimeout, "" ]
 
     UseDefaultRootVolumeName:
       !Equals [ !Ref RootVolumeName, "" ]
@@ -836,7 +839,7 @@ Resources:
         - ClosestToNextInstanceHour
     CreationPolicy:
       ResourceSignal:
-        Timeout: !Ref InstanceCreationTimeout
+        Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, PT5M ], !Ref InstanceCreationTimeout ]
         Count: !Ref MinSize
     UpdatePolicy:
       AutoScalingReplacingUpdate:


### PR DESCRIPTION
In my testing the stack's Windows Server 2019 instances take approximately 6 minutes to fully come online so we should make sure the `InstanceCreationTimeout` value is sufficiently large enough to accommodate the longer startup time.