### PR TITLE
Add support for loading BuildkiteAgentTokenPath from Parameter Store

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -102,7 +102,7 @@ fi
 
 # If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
 if [[ -z "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
-    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value"
+    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value)"
 fi
 
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -102,7 +102,7 @@ fi
 
 # If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
 if [[ -z "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
-    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name ${BUILDKITE_AGENT_TOKEN_PATH} --with-decryption | jq -r .Parameter.Value)"
+    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value"
 fi
 
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -101,7 +101,7 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
 fi
 
 # If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
-if [[ -z "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
+if [[ -n "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
     BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value)"
 fi
 

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -100,6 +100,11 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
   fi
 fi
 
+# If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
+if [[ -z "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
+    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name ${BUILDKITE_AGENT_TOKEN_PATH} --with-decryption | jq -r .Parameter.Value)"
+fi
+
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -73,11 +73,6 @@ If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
   }
 }
 
-# If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
-If (![string]::IsNullOrEmpty($Env:BUILDKITE_AGENT_TOKEN_PATH)) {
-    $Env:BUILDKITE_AGENT_TOKEN = aws ssm get-parameter --name ${Env:BUILDKITE_AGENT_TOKEN_PATH} --with-decryption | jq -r .Parameter.Value
-}
-
 $OFS=","
 Set-Content -Path C:\buildkite-agent\buildkite-agent.cfg -Value @"
 name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%n"

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -73,6 +73,11 @@ If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
   }
 }
 
+# If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
+If (![string]::IsNullOrEmpty($Env:BUILDKITE_AGENT_TOKEN_PATH)) {
+    $Env:BUILDKITE_AGENT_TOKEN = aws ssm get-parameter --name ${Env:BUILDKITE_AGENT_TOKEN_PATH} --with-decryption | jq -r .Parameter.Value
+}
+
 $OFS=","
 Set-Content -Path C:\buildkite-agent\buildkite-agent.cfg -Value @"
 name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%n"

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -110,6 +110,11 @@ Parameters:
     Type: String
     Default: ""
 
+  BuildkiteAgentTokenParameterStoreKMSKey:
+    Description: AWS KMS key ID used to encrypt the SSM parameter (if encrypted)
+    Type: String
+    Default: ""
+
   BuildkiteAgentTags:
     Description: Additional tags seperated by commas to provide to the agent. E.g os=linux,llamas=always
     Type: String
@@ -272,11 +277,6 @@ Parameters:
     Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
     Default: ""
 
-  LambdaManagedPolicyARN:
-    Type: CommaDelimitedList
-    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the autoscaling lambda
-    Default: ""
-
   InstanceRoleName:
     Type: String
     Description: Optional - A name for the IAM Role attached to the Instance Profile
@@ -426,14 +426,14 @@ Conditions:
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
 
-    UseLambdaManagedPolicyARN:
-      !Not [ !Equals [ !Join [ "", !Ref LambdaManagedPolicyARN ], "" ] ]
-
     UseECR:
       !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
 
     UseSSMAgentToken:
       !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
+
+    AgentTokenEncrypted:
+      !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ] ]
 
     HasVariableSize:
       !Not [ !Equals [ !Ref MaxSize, !Ref MinSize ] ]
@@ -916,15 +916,7 @@ Resources:
           Action:
           - sts:AssumeRole
       ManagedPolicyArns: !Split
-        - ','
-        - !Join
-          - ','
-          - - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-            - !If
-              - UseLambdaManagedPolicyARN
-              - !Ref 'AWS::NoValue'
-              - !Join [ ',', !Ref LambdaManagedPolicyARN ] ]
-          - !Ref 'AWS::NoValue'
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
         - PolicyName: AutoScalingGroups
           PolicyDocument:
@@ -935,6 +927,25 @@ Resources:
                 - autoscaling:DescribeAutoScalingGroups
                 - autoscaling:SetDesiredCapacity
               Resource: '*'
+        - !If
+            - AgentTokenEncrypted
+            - - PolicyName: DecryptAgentToken
+                PolicyDocument:
+                  Version: '2012-10-17'
+                  Statement:
+                  - Effect: Allow
+                    Action:
+                      - kms:Decrypt
+                    Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
+              - PolicyName: ReadAgentToken
+                PolicyDocument:
+                  Version: '2012-10-17'
+                  Statement:
+                  - Effect: Allow
+                    Action:
+                      - ssm:GetParameter
+                    Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${BuildkiteAgentTokenParameterStorePath}
+            - !Ref 'AWS::NoValue'
         - PolicyName: WriteCloudwatchMetrics
           PolicyDocument:
             Version: '2012-10-17'

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -778,7 +778,8 @@ Resources:
                   $Env:BUILDKITE_STACK_VERSION=%v
                   $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
                   $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
-                  $Env:BUILDKITE_AGENT_TOKEN="${AgentTokenResolver}"
+                  $Env:BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}"
+                  $Env:BUILDKITE_AGENT_TOKEN_PATH="${BuildkiteAgentTokenPath}"
                   $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
                   $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
                   $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
@@ -801,7 +802,6 @@ Resources:
                   </powershell>
                 - {
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    AgentTokenResolver: !If [ UseSSMAgentToken, !Sub "$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)", !Ref BuildkiteAgentToken ],
                   }
               - !Sub
                 - |
@@ -819,7 +819,8 @@ Resources:
                   BUILDKITE_STACK_VERSION=%v \
                   BUILDKITE_SCALE_IN_IDLE_PERIOD=${ScaleInIdlePeriod} \
                   BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
-                  BUILDKITE_AGENT_TOKEN="${AgentTokenResolver}" \
+                  BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
+                  BUILDKITE_AGENT_TOKEN_PATH="${BuildkiteAgentTokenPath}" \
                   BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
                   BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
                   BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
@@ -841,7 +842,6 @@ Resources:
                   --==BOUNDARY==--
                 - {
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    AgentTokenResolver: !If [ UseSSMAgentToken, !Sub "$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)", !Ref BuildkiteAgentToken ],
                   }
 
   AgentAutoScaleGroup:
@@ -951,7 +951,7 @@ Resources:
       MemorySize: 128
       Environment:
         Variables:
-          BUILDKITE_AGENT_TOKEN: !Ref BuildkiteAgentToken
+          BUILDKITE_AGENT_TOKEN: !If [ UseSSMAgentToken, !Ref 'AWS::NoValue', !Ref BuildkiteAgentToken ]
           BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenPath
           BUILDKITE_QUEUE:       !Ref BuildkiteQueue
           AGENTS_PER_INSTANCE:   !Ref AgentsPerInstance

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -433,7 +433,7 @@ Conditions:
     UseSSMAgentToken:
       !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
 
-    AgentTokenEncrypted:
+    UseCustomerManagedKeyForParameterStore:
       !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ] ]
 
     HasVariableSize:
@@ -929,7 +929,7 @@ Resources:
                 - autoscaling:SetDesiredCapacity
               Resource: '*'
         - !If
-            - AgentTokenEncrypted
+            - UseCustomerManagedKeyForParameterStore
             - - PolicyName: DecryptAgentToken
                 PolicyDocument:
                   Version: '2012-10-17'

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -9,7 +9,7 @@ Metadata:
           default: Buildkite Configuration
         Parameters:
         - BuildkiteAgentToken
-        - BuildkiteAgentTokenPath
+        - BuildkiteAgentTokenParameterStorePath
         - BuildkiteQueue
 
       - Label:
@@ -105,7 +105,7 @@ Parameters:
     NoEcho: true
     Default: ""
 
-  BuildkiteAgentTokenPath:
+  BuildkiteAgentTokenParameterStorePath:
     Description: AWS SSM path to the Buildkite agent registration token (this takes precedence over BuildkiteAgentToken)
     Type: String
     Default: ""
@@ -433,7 +433,7 @@ Conditions:
       !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
 
     UseSSMAgentToken:
-      !Not [ !Equals [ !Ref BuildkiteAgentTokenPath, "" ] ]
+      !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
 
     HasVariableSize:
       !Not [ !Equals [ !Ref MaxSize, !Ref MinSize ] ]
@@ -787,7 +787,7 @@ Resources:
                   $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
                   $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
                   $Env:BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}"
-                  $Env:BUILDKITE_AGENT_TOKEN_PATH="${BuildkiteAgentTokenPath}"
+                  $Env:BUILDKITE_AGENT_TOKEN_PATH="${BuildkiteAgentTokenParameterStorePath}"
                   $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
                   $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
                   $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
@@ -828,7 +828,7 @@ Resources:
                   BUILDKITE_SCALE_IN_IDLE_PERIOD=${ScaleInIdlePeriod} \
                   BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
                   BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
-                  BUILDKITE_AGENT_TOKEN_PATH="${BuildkiteAgentTokenPath}" \
+                  BUILDKITE_AGENT_TOKEN_PATH="${BuildkiteAgentTokenParameterStorePath}" \
                   BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
                   BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
                   BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
@@ -968,7 +968,7 @@ Resources:
       Environment:
         Variables:
           BUILDKITE_AGENT_TOKEN: !If [ UseSSMAgentToken, !Ref 'AWS::NoValue', !Ref BuildkiteAgentToken ]
-          BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenPath
+          BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenParameterStorePath
           BUILDKITE_QUEUE:       !Ref BuildkiteQueue
           AGENTS_PER_INSTANCE:   !Ref AgentsPerInstance
           CLOUDWATCH_METRICS:    "1"

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -272,6 +272,11 @@ Parameters:
     Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
     Default: ""
 
+  LambdaManagedPolicyARN:
+    Type: CommaDelimitedList
+    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the autoscaling lambda
+    Default: ""
+
   InstanceRoleName:
     Type: String
     Description: Optional - A name for the IAM Role attached to the Instance Profile
@@ -420,6 +425,9 @@ Conditions:
 
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
+
+    UseLambdaManagedPolicyARN:
+      !Not [ !Equals [ !Join [ "", !Ref LambdaManagedPolicyARN ], "" ] ]
 
     UseECR:
       !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
@@ -907,8 +915,16 @@ Resources:
             - lambda.amazonaws.com
           Action:
           - sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      ManagedPolicyArns: !Split
+        - ','
+        - !Join
+          - ','
+          - - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+            - !If
+              - UseLambdaManagedPolicyARN
+              - !Ref 'AWS::NoValue'
+              - !Join [ ',', !Ref LambdaManagedPolicyARN ] ]
+          - !Ref 'AWS::NoValue'
       Policies:
         - PolicyName: AutoScalingGroups
           PolicyDocument:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -8,6 +8,7 @@ Metadata:
       - Label:
           default: Buildkite Configuration
         Parameters:
+        - BuildkiteAgentToken
         - BuildkiteAgentTokenPath
         - BuildkiteQueue
 
@@ -98,10 +99,16 @@ Parameters:
       - edge
     Default: "stable"
 
-  BuildkiteAgentTokenPath:
+  BuildkiteAgentToken:
     Description: Buildkite agent registration token
     Type: String
-    MinLength: 1
+    NoEcho: true
+    Default: ""
+
+  BuildkiteAgentTokenPath:
+    Description: AWS SSM path to the Buildkite agent registration token (this takes precedence over BuildkiteAgentToken)
+    Type: String
+    Default: ""
 
   BuildkiteAgentTags:
     Description: Additional tags seperated by commas to provide to the agent. E.g os=linux,llamas=always
@@ -416,6 +423,9 @@ Conditions:
 
     UseECR:
       !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
+
+    UseSSMAgentToken:
+      !Not [ !Equals [ !Ref BuildkiteAgentTokenPath, "" ] ]
 
     HasVariableSize:
       !Not [ !Equals [ !Ref MaxSize, !Ref MinSize ] ]
@@ -768,7 +778,7 @@ Resources:
                   $Env:BUILDKITE_STACK_VERSION=%v
                   $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
                   $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
-                  $Env:BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)"
+                  $Env:BUILDKITE_AGENT_TOKEN="${AgentTokenResolver}"
                   $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
                   $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
                   $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
@@ -791,6 +801,7 @@ Resources:
                   </powershell>
                 - {
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
+                    AgentTokenResolver: !If [ UseSSMAgentToken, !Sub "$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)", !Ref BuildkiteAgentToken ],
                   }
               - !Sub
                 - |
@@ -808,7 +819,7 @@ Resources:
                   BUILDKITE_STACK_VERSION=%v \
                   BUILDKITE_SCALE_IN_IDLE_PERIOD=${ScaleInIdlePeriod} \
                   BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
-                  BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)" \
+                  BUILDKITE_AGENT_TOKEN="${AgentTokenResolver}" \
                   BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
                   BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
                   BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
@@ -830,6 +841,7 @@ Resources:
                   --==BOUNDARY==--
                 - {
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
+                    AgentTokenResolver: !If [ UseSSMAgentToken, !Sub "$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)", !Ref BuildkiteAgentToken ],
                   }
 
   AgentAutoScaleGroup:
@@ -939,6 +951,7 @@ Resources:
       MemorySize: 128
       Environment:
         Variables:
+          BUILDKITE_AGENT_TOKEN: !Ref BuildkiteAgentToken
           BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenPath
           BUILDKITE_QUEUE:       !Ref BuildkiteQueue
           AGENTS_PER_INSTANCE:   !Ref AgentsPerInstance

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -8,7 +8,7 @@ Metadata:
       - Label:
           default: Buildkite Configuration
         Parameters:
-        - BuildkiteAgentToken
+        - BuildkiteAgentTokenPath
         - BuildkiteQueue
 
       - Label:
@@ -98,10 +98,9 @@ Parameters:
       - edge
     Default: "stable"
 
-  BuildkiteAgentToken:
+  BuildkiteAgentTokenPath:
     Description: Buildkite agent registration token
     Type: String
-    NoEcho: true
     MinLength: 1
 
   BuildkiteAgentTags:
@@ -769,7 +768,7 @@ Resources:
                   $Env:BUILDKITE_STACK_VERSION=%v
                   $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
                   $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
-                  $Env:BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}"
+                  $Env:BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)"
                   $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
                   $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
                   $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
@@ -809,7 +808,7 @@ Resources:
                   BUILDKITE_STACK_VERSION=%v \
                   BUILDKITE_SCALE_IN_IDLE_PERIOD=${ScaleInIdlePeriod} \
                   BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
-                  BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}" \
+                  BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name ${BuildkiteAgentTokenPath} --with-decryption | jq -r .Parameter.Value)" \
                   BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
                   BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
                   BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
@@ -940,7 +939,7 @@ Resources:
       MemorySize: 128
       Environment:
         Variables:
-          BUILDKITE_AGENT_TOKEN: !Ref BuildkiteAgentToken
+          BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenPath
           BUILDKITE_QUEUE:       !Ref BuildkiteQueue
           AGENTS_PER_INSTANCE:   !Ref AgentsPerInstance
           CLOUDWATCH_METRICS:    "1"
@@ -952,6 +951,8 @@ Resources:
           INCLUDE_WAITING:       !Ref ScaleOutForWaitingJobs
           LAMBDA_TIMEOUT:        "50s"
           LAMBDA_INTERVAL:       "10s"
+
+  # TODO: give lambda permission to decrypt chamber SSM key
 
   AutoscalingLambdaScheduledRule:
     Type: "AWS::Events::Rule"

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -981,8 +981,6 @@ Resources:
           LAMBDA_TIMEOUT:        "50s"
           LAMBDA_INTERVAL:       "10s"
 
-  # TODO: give lambda permission to decrypt chamber SSM key
-
   AutoscalingLambdaScheduledRule:
     Type: "AWS::Events::Rule"
     Condition: HasVariableSize

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -10,6 +10,7 @@ Metadata:
         Parameters:
         - BuildkiteAgentToken
         - BuildkiteAgentTokenParameterStorePath
+        - BuildkiteAgentTokenParameterStoreKMSKey
         - BuildkiteQueue
 
       - Label:


### PR DESCRIPTION
This provides changes to allow using a Buildkite agent token that is set in AWS SSM.

It should help with #422 and #597.

I'm assuming the lambda code is coming from [buildkite-agent-scaler](https://github.com/buildkite/buildkite-agent-scaler) since that's the name of the bucket the lambda binary is taken from. I've looked through that code and found that it already supports retrieving the token from SSM by setting `BUILDKITE_AGENT_TOKEN_SSM_KEY`. The only remaining thing I can think of is adding the IAM permissions to the lambda to allow it to read and/or decrypt the parameter in SSM.

Before proceeding with this further, can I get the maintainers (and community I suppose) opinion on this change? I could make further changes so that it's hopefully backwards compatible, but currently it is not.