### PR TITLE
Update ArtifactBucketPolicy to match docs

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -702,9 +702,14 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - s3:Put*
-              - s3:List*
-              - s3:Get*
+              - s3:GetObject
+              - s3:GetObjectAcl
+              - s3:GetObjectVersion
+              - s3:GetObjectVersionAcl
+              - s3:ListBucket
+              - s3:PutObject
+              - s3:PutObjectAcl
+              - s3:PutObjectVersionAcl
             Resource:
               - !Sub "arn:aws:s3:::${ArtifactsBucket}/*"
               - !Sub "arn:aws:s3:::${ArtifactsBucket}"


### PR DESCRIPTION
This pull request updates the policy to match what is suggested in the documentation (linked below). 

In our testing, the default policy also did not allow uploading of artifacts despite what the policy seemed to allow. However, this could be due to another issue in our configuration.

https://buildkite.com/docs/agent/v3/cli-artifact#using-your-own-private-aws-s3-bucket