### PR TITLE
Ensure unhealthy Windows instances get marked correctly

### DIFF
--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -9,8 +9,10 @@ function on_error {
   $errorLine=$_.InvocationInfo.ScriptLineNumber
   $errorMessage=$_.Exception
 
+  $instance_id=(Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
+
   aws autoscaling set-instance-health `
-    --instance-id "(Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content" `
+    --instance-id "$instance_id" `
     --health-status Unhealthy
 
   cfn-signal `

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -785,7 +785,7 @@ Resources:
                   powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
 
                   $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
-                  $Env:BUILDKITE_STACK_VERSION=%v
+                  $Env:BUILDKITE_STACK_VERSION="%v"
                   $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
                   $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
                   $Env:BUILDKITE_AGENT_TOKEN="${BuildkiteAgentToken}"


### PR DESCRIPTION
Sometimes Windows instances fail to come up completely but are not marked unhealthy. It turns out sometimes the generated randomized password for the buildkite-user doesn't meet the password policy requirements and causes a failure of the `bk-install-elastic-stack.ps1` script. Normally that would trigger the `on_error` trap which would mark the instance unhealthy and it would be replaced but unfortunately there is a bug in the `on_error` trap that was preventing it from getting the instance ID. This leaves the instance running indefinitely but without a running buildkite-agent service which means jobs can wait indefinitely for an instance because the scaler lambda believes a healthy instance already exists.

This PR fixes the bug in the `on_error` trap so a failure of the `bk-install-elastic-stack.ps1` script can mark the instance unhealthy. It also adds a retry loop for randomizing the buildkite-agent user's password giving it a few extra chances to get a good password before failing.

The PR also fixes the cloudformation by putting quotes around `%v` for a windows environment variable.