### PR TITLE
Add cloudformation output exports

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -376,19 +376,32 @@ Parameters:
     Default: "false"
 
 Outputs:
+  VpcId:
+    Value: !Ref Vpc
+    Export:
+      Name: !Sub '${AWS::StackName}-VpcId'
+
   ManagedSecretsBucket:
     Value:
       !If [CreateSecretsBucket, !Ref ManagedSecretsBucket, "" ]
+    Export:
+      Name: !Sub '${AWS::StackName}-ManagedSecretsBucket'
 
   ManagedSecretsLoggingBucket:
     Value:
       !If [CreateSecretsBucket, !Ref ManagedSecretsLoggingBucket, "" ]
+    Export:
+      Name: !Sub '${AWS::StackName}-ManagedSecretsLoggingBucket'
 
   AutoScalingGroupName:
     Value: !Ref AgentAutoScaleGroup
+    Export:
+      Name: !Sub '${AWS::StackName}-AutoScalingGroupName'
 
   InstanceRoleName:
     Value: !Ref IAMRole
+    Export:
+      Name: !Sub '${AWS::StackName}-InstanceRoleName'
 
 Conditions:
     UseSpotInstances:


### PR DESCRIPTION
This resolves #615

I've only added the VPC and export names for the existing ones so they can be referenced in other places. Let me know if this is okay or any changes.

To clarify the exact use-case; we would like to run 2 of these stacks with different sized instances but want to share a VPC and role created by one, with the other without having to create that role externally and pass it into both.