### PR TITLE
FOR DISCUSSION: Copy and encrypt buildkite agent AMI

### DIFF
--- a/temp-ami-copy/ami-copy/cfn-response.js
+++ b/temp-ami-copy/ami-copy/cfn-response.js
@@ -1,0 +1,54 @@
+/* Copyright 2015 Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
+   This file is licensed to you under the AWS Customer Agreement (the "License").
+   You may not use this file except in compliance with the License.
+   A copy of the License is located at http://aws.amazon.com/agreement/ .
+   This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied.
+   See the License for the specific language governing permissions and limitations under the License. */
+
+exports.SUCCESS = "SUCCESS";
+exports.FAILED = "FAILED";
+
+exports.send = function (event, context, responseStatus, responseData, physicalResourceId, noEcho) {
+
+    var responseBody = JSON.stringify({
+        Status: responseStatus,
+        Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
+        PhysicalResourceId: physicalResourceId || context.logStreamName,
+        StackId: event.StackId,
+        RequestId: event.RequestId,
+        LogicalResourceId: event.LogicalResourceId,
+        NoEcho: noEcho || false,
+        Data: responseData
+    });
+
+    console.log("Response body:\n", responseBody);
+
+    var https = require("https");
+    var url = require("url");
+
+    var parsedUrl = url.parse(event.ResponseURL);
+    var options = {
+        hostname: parsedUrl.hostname,
+        port: 443,
+        path: parsedUrl.path,
+        method: "PUT",
+        headers: {
+            "content-type": "",
+            "content-length": responseBody.length
+        }
+    };
+
+    var request = https.request(options, function (response) {
+        console.log("Status code: " + response.statusCode);
+        console.log("Status message: " + response.statusMessage);
+        context.done();
+    });
+
+    request.on("error", function (error) {
+        console.log("send(..) failed executing https.request(..): " + error);
+        context.done();
+    });
+
+    request.write(responseBody);
+    request.end();
+}

--- a/temp-ami-copy/ami-copy/index.js
+++ b/temp-ami-copy/ami-copy/index.js
@@ -1,0 +1,167 @@
+var AWS = require('aws-sdk')
+var response = require('./cfn-response.js')
+exports.handler = function(event, context, callback) {
+  console.log('Request received:\n', JSON.stringify(event))
+  var resProps = event.ResourceProperties,
+    sourceImageId = resProps.SourceImageId,
+    sourceRegion = resProps.SourceRegion,
+    kmsKeyId = resProps.KmsKeyId,
+    physicalId = event.PhysicalResourceId
+
+  function success(data) {
+    return response.send(
+      event,
+      context,
+      response.SUCCESS,
+      { Id: physicalId },
+      physicalId
+    )
+  }
+  function failed(e) {
+    return response.send(event, context, response.FAILED, e, physicalId)
+  }
+
+  // Call ec2.waitFor, continuing if not finished before Lambda function timeout.
+  function wait(waiter) {
+    console.log('Waiting: ', JSON.stringify(waiter))
+    event.waiter = waiter
+    event.PhysicalResourceId = physicalId
+    var request = ec2.waitFor(waiter.state, waiter.params)
+    setTimeout(() => {
+      request.abort()
+      console.log(
+        'Timeout reached, continuing function. Params:\n',
+        JSON.stringify(event)
+      )
+      var lambda = new AWS.Lambda()
+      lambda
+        .invoke({
+          FunctionName: context.invokedFunctionArn,
+          InvocationType: 'Event',
+          Payload: JSON.stringify(event),
+        })
+        .promise()
+        .then(data => context.done())
+        .catch(err => context.fail(err))
+    }, context.getRemainingTimeInMillis() - 5000)
+    return request.promise().catch(err => {
+      console.log('Error on waitFor: ', JSON.stringify(err))
+      if (err.code == 'RequestAbortedError') {
+        return new Promise(() => context.done())
+      } else {
+        return Promise.reject(err)
+      }
+    })
+  }
+
+  var ec2 = new AWS.EC2(),
+    kms = new AWS.KMS()
+
+  if (event.waiter) {
+    wait(event.waiter)
+      .then(data => success({}))
+      .catch(err => failed(err))
+  } else if (event.RequestType == 'Create' || event.RequestType == 'Update') {
+    var Operations = [
+      'Decrypt',
+      'Encrypt',
+      'GenerateDataKey',
+      'GenerateDataKeyWithoutPlaintext',
+      'CreateGrant',
+      'DescribeKey',
+      'ReEncryptFrom',
+      'ReEncryptTo',
+    ]
+    var listGrantsParams = { KeyId: kmsKeyId }
+    var checkGrantOperations = function(grant) {
+      var hasAllOperations = true
+      for (var i = 0; i < Operations.length; i++) {
+        var op = Operations[i]
+        if (grant.Operations.indexOf(op) === -1) {
+          console.log('Grant found but does not have operation: ', op)
+          hasAllOperations = false
+        }
+      }
+      return hasAllOperations
+    }
+    var createGrantParams = {
+      GranteePrincipal:
+        'arn:aws:iam::775966183015:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot',
+      KeyId: kmsKeyId,
+      Operations,
+    }
+    var copyParams = {
+      Name: 'buildkite-stack-encrypted',
+      SourceImageId: sourceImageId,
+      SourceRegion: sourceRegion,
+      Description: 'Encrypted version of the buildkite agent AMI',
+      Encrypted: true,
+      KmsKeyId: kmsKeyId,
+    }
+    var hasGrant
+    kms
+      .listGrants(listGrantsParams)
+      .promise()
+      .then(({ Grants }) => {
+        var grant
+        for (var i = 0; i < Grants.length; i++) {
+          grant = Grants[i]
+          if (
+            grant.GranteePrincipal.indexOf('AWSServiceRoleForEC2Spot') !== -1 &&
+            checkGrantOperations(grant)
+          ) {
+            hasGrant = true
+            console.log('Grant exists!')
+            break
+          }
+        }
+        if (hasGrant) Promise.resolve(grant)
+        else return kms.createGrant(createGrantParams).promise()
+      })
+      .then(data => {
+        console.log('Grant created or already existed: ', JSON.stringify(data))
+        return ec2.copyImage(copyParams).promise()
+      })
+      .then(data =>
+        wait({
+          state: 'imageAvailable',
+          params: { ImageIds: [(physicalId = data.ImageId)] },
+        })
+      )
+      .then(data => success({}))
+      .catch(err => failed(err))
+  } else if (event.RequestType == 'Delete') {
+    if (physicalId.indexOf('ami-') !== 0) {
+      return success({})
+    }
+    ec2
+      .describeImages({ ImageIds: [physicalId] })
+      .promise()
+      .then(data =>
+        data.Images.length == 0
+          ? success({})
+          : ec2.deregisterImage({ ImageId: physicalId }).promise()
+      )
+      .then(data =>
+        ec2
+          .describeSnapshots({
+            Filters: [
+              {
+                Name: 'description',
+                Values: ['*' + physicalId + '*'],
+              },
+            ],
+          })
+          .promise()
+      )
+      .then(data =>
+        data.Snapshots.length === 0
+          ? success({})
+          : ec2
+              .deleteSnapshot({ SnapshotId: data.Snapshots[0].SnapshotId })
+              .promise()
+      )
+      .then(data => success({}))
+      .catch(err => failed(err))
+  }
+}

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -48,6 +48,7 @@ Metadata:
         - RootVolumeSize
         - RootVolumeName
         - RootVolumeType
+        - RootVolumeKmsKeyId
         - ManagedPolicyARN
         - InstanceRoleName
 
@@ -274,6 +275,11 @@ Parameters:
     Type: String
     Description: Optional - Security group id to assign to instances
     Default: ""
+  
+  RootVolumeKmsKeyId:
+    Description: Optional - ARN of the AWS Key Management Service CMK used to use encryption (This will cause the Buildkite AMI to be copied to your account!)
+    Type: String
+    Default: ""
 
   ImageId:
     Type: String
@@ -466,6 +472,9 @@ Conditions:
     # Whether or not there's any managed polices to attach
     HasManagedPolicies:
       !Or [ { Condition: UseManagedPolicyARN }, { Condition: UseECR } ]
+
+    CreateEncryptedAMI:
+      !Not [ !Equals [ !Ref RootVolumeKmsKeyId, "" ] ]
 
 Mappings:
   ECRManagedPolicy:
@@ -732,7 +741,15 @@ Resources:
       IamInstanceProfile: !Ref IAMInstanceProfile
       InstanceType: !Ref InstanceType
       SpotPrice: !If [ "UseSpotInstances", !Ref SpotPrice, !Ref 'AWS::NoValue' ]
-      ImageId: !If [ "UseDefaultAMI", !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'AMI'], !Ref ImageId ]
+      ImageId: 
+        !If
+          - "UseDefaultAMI"
+          - 
+            !If
+              - "CreateEncryptedAMI"
+              - !GetAtt EncryptedAMI.Id
+              - !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'AMI']
+          - !Ref ImageId
       BlockDeviceMappings:
         - DeviceName: !Ref RootVolumeName
           Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }
@@ -1114,3 +1131,88 @@ Resources:
       Action: "lambda:InvokeFunction"
       Principal: "events.amazonaws.com"
       SourceArn: !GetAtt AutoscalingLambdaScheduledRule.Arn
+
+  EncryptedAMI:
+    Type: Custom::AMI
+    Properties:
+      ServiceToken: !GetAtt CopyImageLambda.Arn
+      SourceImageId: !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'AMI']
+      SourceRegion: !Ref 'AWS::Region'
+      KmsKeyId: !Ref RootVolumeKmsKeyId      
+
+  CopyImageLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Role: !GetAtt CopyImageLambdaExecutionRole.Arn
+      Timeout: 900
+      Handler: aws-copy/index.handler
+      Runtime: nodejs10.x
+      Code:
+        S3Bucket: { 'Fn::FindInMap': [LambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
+        S3Key: "buildkite-copy-ami/v0.0.1/handler.zip"
+
+  CopyImageLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: "/"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - lambda:InvokeFunction
+              Resource: '*'
+        - PolicyName: KMSPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - kms:CreateGrant
+                - kms:Decrypt
+                - kms:DescribeKey*
+                - kms:Encrypt
+                - kms:GenerateDataKey*
+                - kms:ListGrants
+                - kms:ReEncrypt*
+              Resource: !Ref RootVolumeKmsKeyId
+        - PolicyName: EC2Policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - ec2:CopyImage
+                - ec2:CopySnapshot
+                - ec2:CreateImage
+                - ec2:CreateSnapshot
+                - ec2:DeleteSnapshot
+                - ec2:DeregisterImage
+                - ec2:Describe*
+                - ec2:ImportImage
+                - ec2:ImportSnapshot
+                - ec2:ModifyImageAttribute
+                - ec2:ModifySnapshotAttribute
+                - ec2:RegisterImage
+              Resource: '*'   
+        - PolicyName: WriteCloudwatchLogs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+              Resource: '*'


### PR DESCRIPTION
These changes update the aws stack to allow copying the buildkite agent AMI using a lambda and encrypting it on the consumer's AWS account using a provided KMS key.

This PR includes the JS code (in `temp-ami-copy`) for a lambda that would likely need to be made into its own repository (according to existing patterns) if you decide to integrate this change into the stack. The `cfn-response.js` module is provided by Amazon and is being included in the lambda per their suggestion to help handle responses https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html

With this change, the priority for which AMI to use will be:
1. AMI from `ImageId` parameter if provided
2. Copied/encrypted version of default AMI if a `RootVolumeKmsKeyId` parameter is provided
3. Default AMI

As part of the copying process, the lambda will also create a grant on the KMS key for `AWSServiceRoleForEC2Spot` to allow spot instances to decrypt the encrypted volume.

The permission set on the `CopyImageLambdaExecutionRole` resource should be the least access privilege required to execute the AMI copy/encrypt process (based on much trial and error).

Very much open to feedback/changes on this, but wanted to open up the PR and see what people think.