### PR TITLE
Prevent the agent from terminating immediately on stop

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -18,7 +18,7 @@ RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
-TimeoutStopSec=0
+TimeoutStopSec=infinity
 KillMode=process
 
 [Install]


### PR DESCRIPTION
This applies the patch that @james-portman-contino suggested in https://github.com/buildkite/agent/pull/1075.