### PR TITLE
Fix lambda role

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -960,7 +960,7 @@ Resources:
                 - Effect: Allow
                   Action:
                     - ssm:GetParameter
-                  Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${BuildkiteAgentTokenParameterStorePath}
+                  Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BuildkiteAgentTokenParameterStorePath}
             - PolicyName: WriteCloudwatchMetrics
               PolicyDocument:
                 Version: '2012-10-17'

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -934,42 +934,58 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        - PolicyName: AutoScalingGroups
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Effect: Allow
-              Action:
-                - autoscaling:DescribeAutoScalingGroups
-                - autoscaling:SetDesiredCapacity
-              Resource: '*'
-        - !If
-            - UseCustomerManagedKeyForParameterStore
-            - - PolicyName: DecryptAgentToken
-                PolicyDocument:
-                  Version: '2012-10-17'
-                  Statement:
-                  - Effect: Allow
-                    Action:
-                      - kms:Decrypt
-                    Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
-              - PolicyName: ReadAgentToken
-                PolicyDocument:
-                  Version: '2012-10-17'
-                  Statement:
-                  - Effect: Allow
-                    Action:
-                      - ssm:GetParameter
-                    Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${BuildkiteAgentTokenParameterStorePath}
-            - !Ref 'AWS::NoValue'
-        - PolicyName: WriteCloudwatchMetrics
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-            - Effect: Allow
-              Action:
-                - cloudwatch:PutMetricData
-              Resource: '*'
+        !If
+          - UseCustomerManagedKeyForParameterStore
+          - - PolicyName: AutoScalingGroups
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                - Effect: Allow
+                  Action:
+                    - autoscaling:DescribeAutoScalingGroups
+                    - autoscaling:SetDesiredCapacity
+                  Resource: '*'
+            - PolicyName: DecryptAgentToken
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                - Effect: Allow
+                  Action:
+                    - kms:Decrypt
+                  Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
+            - PolicyName: ReadAgentToken
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                - Effect: Allow
+                  Action:
+                    - ssm:GetParameter
+                  Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${BuildkiteAgentTokenParameterStorePath}
+            - PolicyName: WriteCloudwatchMetrics
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                - Effect: Allow
+                  Action:
+                    - cloudwatch:PutMetricData
+                  Resource: '*'
+          - - PolicyName: AutoScalingGroups
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                - Effect: Allow
+                  Action:
+                    - autoscaling:DescribeAutoScalingGroups
+                    - autoscaling:SetDesiredCapacity
+                  Resource: '*'
+            - PolicyName: WriteCloudwatchMetrics
+              PolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                - Effect: Allow
+                  Action:
+                    - cloudwatch:PutMetricData
+                  Resource: '*'
 
   # This mirrors the group that would be created by the lambda, but enforces
   # a retention period and also ensures it's removed when the stack is removed


### PR DESCRIPTION
Trying to use the CloudFormation template from the HEAD of master yields this error: `Error: ROLLBACK_COMPLETE: ["The following resource(s) failed to create: [AutoscalingLambdaExecutionRole]. . Rollback requested by user." "Value of property Policies must be a list of objects"]` (Note we are running the stack through terraform but I don't think that is necessarily related).

This PR fixes that issue.