### PR TITLE
Get SSM parameter as raw text

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -102,7 +102,7 @@ fi
 
 # If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
 if [[ -n "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
-    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value)"
+    BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value --output text)"
 fi
 
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg


### PR DESCRIPTION
This is a carry on from #624 to fix the newly introduced support for SSM parameter for the agent token.

Without the change, the get-parameter command returns the value as it appeared in the default json output which includes quotes.
Eg: `"token is here"`.

This was then double quoted by the script and when the EC2 instance boots up it sends the token to the API as `""token is here""` which is invalid.

With this change the quotes are removed from the get-parameter command so there is only one level of quotes