### PR TITLE
Revert "Prevent the agent from terminating immediately on stop"

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -18,7 +18,7 @@ RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
-TimeoutStopSec=infinity
+TimeoutStopSec=0
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Reverts buildkite/elastic-ci-stack-for-aws#622

Fixes #629 