### PR TITLE
Pin git-for-windows to v2.22.0

### DIFF
--- a/packer/windows/scripts/install-utils.ps1
+++ b/packer/windows/scripts/install-utils.ps1
@@ -9,7 +9,7 @@ Write-Output "Installing awscli"
 choco install -y awscli
 
 Write-Output "Installing Git for Windows"
-choco install -y git
+choco install -y git --version 2.22.0
 
 Write-Output "Installing nssm"
 choco install -y nssm


### PR DESCRIPTION
git-for-windows v2.23.0 has a bug preventing bash process substitution from working which breaks the docker-login plugin so we'll pin to v2.22.0 until a git-for-windows releases the fix.

Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/631