### PR TITLE
Ensure powershell scripts fail when executable fails

### DIFF
--- a/packer/windows/conf/bin/bk-fetch.ps1
+++ b/packer/windows/conf/bin/bk-fetch.ps1
@@ -5,6 +5,7 @@ $ErrorActionPreference = "Stop"
 
 If ($From -Like "s3://*") {
   aws s3 cp $From $To
+  If ($lastexitcode -ne 0) { Exit $lastexitcode }
 }
 Else {
   Invoke-WebRequest -Uri $From -OutFile $To

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -50,6 +50,7 @@ If ($Env:BUILDKITE_AGENT_RELEASE -eq "edge") {
   Write-Output "Downloading buildkite-agent edge..."
   Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-edge.exe -Uri "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-windows-amd64.exe"
   buildkite-agent-edge.exe --version
+  If ($lastexitcode -ne 0) { Exit $lastexitcode }
 }
 
 Copy-Item -Path C:\buildkite-agent\bin\buildkite-agent-${Env:BUILDKITE_AGENT_RELEASE}.exe -Destination C:\buildkite-agent\bin\buildkite-agent.exe
@@ -110,7 +111,7 @@ do {
 
 docker ps
 if (! $?) {
-  echo "Failed to contact docker"
+  Write-Output "Failed to contact docker"
   exit 1
 }
 
@@ -157,12 +158,19 @@ If (![string]::IsNullOrEmpty($Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT)) {
 Write-Output "Starting the Buildkite Agent"
 
 nssm install buildkite-agent C:\buildkite-agent\bin\buildkite-agent.exe start
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent ObjectName .\$UserName $Password
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppStdout C:\buildkite-agent\buildkite-agent.log
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppStderr C:\buildkite-agent\buildkite-agent.log
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppEnvironmentExtra :HOME=C:\buildkite-agent
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppExit Default Exit
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Restart-Service buildkite-agent
 
@@ -177,7 +185,7 @@ cfn-signal `
   --exit-code 0 ; if (-not $?) {
     # This will fail if the stack has already completed, for instance if there is a min size
     # of 1 and this is the 2nd instance. This is ok, so we just ignore the erro
-    echo "Signal failed"
+    Write-Output "Signal failed"
   }
 
 Set-PSDebug -Off

--- a/packer/windows/scripts/ec2-userdata.ps1
+++ b/packer/windows/scripts/ec2-userdata.ps1
@@ -20,9 +20,13 @@ write-output "Setting up WinRM"
 write-host "(host) setting up WinRM"
 
 winrm set "winrm/config" '@{MaxTimeoutms="1800000"}'
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 winrm set "winrm/config/winrs" '@{MaxMemoryPerShellMB="1024"}'
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 winrm set "winrm/config/service/auth" '@{Basic="true"}'
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 netsh advfirewall firewall add rule name="Port 5986" protocol=TCP dir=in localport=5986 action=allow
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Stop-Transcript
 </powershell>

--- a/packer/windows/scripts/install-awslogs.ps1
+++ b/packer/windows/scripts/install-awslogs.ps1
@@ -9,6 +9,7 @@ Start-Process C:\packer-temp\amazon-cloudwatch-agent.msi -Wait
 
 Write-Output "Setting amazon cloudwatch agent start type to delayed-auto..."
 sc.exe config AmazonCloudWatchAgent start= delayed-auto
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Copying amazon cloudwatch agent config..."
 Copy-Item -Path C:\packer-temp\conf\awslogs\amazon-cloudwatch-agent.json -Destination C:\ProgramData\Amazon\AmazonCloudWatchAgent

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -13,10 +13,12 @@ $env:PATH = "C:\buildkite-agent\bin;" + $env:PATH
 Write-Output "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-stable.exe -Uri "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-windows-amd64.exe"
 buildkite-agent-stable.exe --version
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Downloading buildkite-agent beta..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-beta.exe -Uri "https://download.buildkite.com/agent/unstable/latest/buildkite-agent-windows-amd64.exe"
 buildkite-agent-beta.exe --version
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Creating hooks dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\hooks

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -13,6 +13,8 @@ Start-Service docker
 
 Write-Output "Installing docker-compose"
 choco install -y docker-compose
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing jq"
 choco install -y jq
+If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/packer/windows/scripts/install-lifecycled.ps1
+++ b/packer/windows/scripts/install-lifecycled.ps1
@@ -12,5 +12,8 @@ Invoke-WebRequest -OutFile C:\lifecycled\bin\lifecycled.exe https://github.com/b
 
 Write-Output "Configure lifecycled to run on startup..."
 nssm install lifecycled C:\lifecycled\bin\lifecycled.exe
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set lifecycled AppStdout C:\lifecycled\lifecycled.log
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set lifecycled AppStderr C:\lifecycled\lifecycled.log
+If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/packer/windows/scripts/install-utils.ps1
+++ b/packer/windows/scripts/install-utils.ps1
@@ -3,16 +3,19 @@ $ErrorActionPreference = "Stop"
 
 Write-Output "Installing chocolatey package manager"
 Set-ExecutionPolicy Bypass -Scope Process -Force
-iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 Write-Output "Installing awscli"
 choco install -y awscli
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing Git for Windows"
 choco install -y git --version 2.22.0
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing nssm"
 choco install -y nssm
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 # Make `Update-SessionEnvironment` available
 Write-Output "Importing the Chocolatey profile module"
@@ -34,13 +37,16 @@ Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Co
 
 # Set autocrlf to false so we don't end up with mismatched line endings
 git config --system core.autocrlf false
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 # disable Git Credential Manager for Windows so it doesn't interfere with buildkite's secrets plugin
 git config --system --unset credential.helper
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Configuring awscli to use v4 signatures..."
 $Env:AWS_CONFIG_FILE = "C:\buildkite-agent\.aws\config"
 $Env:AWS_SHARED_CREDENTIALS_FILE = "C:\buildkite-agent\.aws\credentials"
 aws configure set s3.signature_version s3v4
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 Remove-Item -Path Env:AWS_CONFIG_FILE
 Remove-Item -Path Env:AWS_SHARED_CREDENTIALS_FILE


### PR DESCRIPTION
We have to explicitly test the exit status after running executables because powershell doesn't automatically fail when an executable's exit status is non-zero.

We've deployed these changes to our own Windows Buildkite packer template and it really increases the confidence that the powershell scripts haven't silently failed.