### PR TITLE
Power off immediately if cloud-init fails

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/cloud-final.service.d/10-power-off-on-failure.conf
+++ b/packer/linux/conf/buildkite-agent/systemd/cloud-final.service.d/10-power-off-on-failure.conf
@@ -1,0 +1,3 @@
+[Unit]
+OnFailure=poweroff.target
+OnFailureJobMode=replace-irreversibly

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -54,6 +54,9 @@ sudo chown -R buildkite-agent: /var/lib/buildkite-agent/plugins
 echo "Adding systemd service template..."
 sudo cp /tmp/conf/buildkite-agent/systemd/buildkite-agent.service /etc/systemd/system/buildkite-agent.service
 
+echo "Adding cloud-init failure safety check..."
+sudo cp /tmp/conf/buildkite-agent/systemd/system/cloud-final.service.d/10-power-off-on-failure.conf /etc/systemd/system/cloud-final.service.d/10-power-off-on-failure.conf
+
 echo "Adding termination scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/stop-agent-gracefully /usr/local/bin/stop-agent-gracefully
 sudo cp /tmp/conf/buildkite-agent/scripts/terminate-instance /usr/local/bin/terminate-instance


### PR DESCRIPTION
This appears to fix #572 for us.

We see occasional failures from `cloud-init` failing to communicate with the EC2 metadata endpoint. These appear in systemd as a failure of the `cloud-final` service. By adding `OnFailure=poweroff.target`, the instance will power itself off when this occurs and allow the ASG to replace it instead of hanging around in a hung state forever.