### PR TITLE
Set up git credentials helper to use .git-credentials file as source

### DIFF
--- a/packer/linux/scripts/install-git-lfs.sh
+++ b/packer/linux/scripts/install-git-lfs.sh
@@ -9,3 +9,6 @@ tar -xvzf git-lfs.tgz -C git-lfs
 sudo chmod 755 git-lfs/git-lfs
 sudo ./git-lfs/install.sh
 rm -rf git-lfs.tgz git-lfs/
+
+echo "Setting Git credential helper to use ~/.git-credentials as source if clone via https"
+git config --global credential.helper 'store --file ~/.git-credentials'

--- a/packer/linux/scripts/install-git-lfs.sh
+++ b/packer/linux/scripts/install-git-lfs.sh
@@ -11,4 +11,4 @@ sudo ./git-lfs/install.sh
 rm -rf git-lfs.tgz git-lfs/
 
 echo "Setting Git credential helper to use ~/.git-credentials as source if clone via https"
-git config --global credential.helper 'store --file ~/.git-credentials'
+sudo git config --global credential.helper 'store --file ~/.git-credentials'


### PR DESCRIPTION
Now if I upload git credentials to S3 bucket Git via https doesn't work directly. Setting git credential helper to pick up ~/.git-credentials is necessary and doable via env hooks but it's better to set up this step at an early stage and won't hurt anybody.