### PR TITLE
Prune the docker build cache too

### DIFF
--- a/packer/linux/conf/docker/cron.hourly/docker-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-gc
@@ -12,3 +12,4 @@ DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-4h}
 
 docker network prune --force --filter "until=${DOCKER_PRUNE_UNTIL}"
 docker container prune --force --filter "until=${DOCKER_PRUNE_UNTIL}"
+docker builder prune --force --filter "until=${DOCKER_PRUNE_UNTIL}"


### PR DESCRIPTION
Does what it says. At the moment we just let the build cache grow forever.