### PR TITLE
Increase the threshold for disk cleanup to 5GB free for 4.3

### DIFF
--- a/packer/conf/bin/bk-check-disk-space.sh
+++ b/packer/conf/bin/bk-check-disk-space.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-DISK_MIN_AVAILABLE=${DISK_MIN_AVAILABLE:-1048576} # 1GB
+DISK_MIN_AVAILABLE=${DISK_MIN_AVAILABLE:-5242880} # 5GB
 DISK_MIN_INODES=${DISK_MIN_INODES:-250000} # docker needs lots
 
 DOCKER_DIR="/var/lib/docker/"


### PR DESCRIPTION
e97921cc74e8a69fccbe98ebcc6ee0f50a9ccbcf on `master` increased the `DISK_MIN_AVAILABLE` threshold to 5GB a few months ago, but it doesn't seem to be in the 4.3.5 release that happened since then.

The 1GB threshold is causing us problems (https://github.com/buildkite/elastic-ci-stack-for-aws/issues/465#issuecomment-555846619) so this PR cherrypicks that existing commit onto the 4.3 series branch, as a temporary work-around while waiting for the stalled #623 and/or #639.