### PR TITLE
README create-stack example fixed; quote command expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ aws cloudformation create-stack \
   --stack-name buildkite \
   --template-url "https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml" \
   --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
-  --parameters $(cat config.json)
+  --parameters "$(cat config.json)"
 ```
 
 ## Build Secrets


### PR DESCRIPTION
This PR adds missing quotes around the `$(cat config.json)` command substitution in the `README.md` example. Without them, each space-separated chunk of JSON in that file was being treated as a separate argument to the `aws create-stack` command, and only the first interpreted as (broken) JSON;

> Error parsing parameter '--parameters': Invalid JSON: [

This quoting issue was the only complaint [shellcheck](https://www.shellcheck.net/) made about that particular shell snippet:

```
Line 7:
  --parameters $(cat config.json)
               ^-- SC2046: Quote this to prevent word splitting.
```