### PR TITLE
yml templates/aws-stack: Add Mixed Instance support to the ASG

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -56,6 +56,13 @@ Metadata:
         Parameters:
         - MinSize
         - MaxSize
+        - SpotAllocationStrategy
+        - OnDemandBaseCapacity
+        - OnDemandPercentageAboveBaseCapacity
+        - InstanceType1
+        - InstanceType2
+        - InstanceType3
+        - InstanceType4
         - ScaleOutFactor
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
@@ -209,7 +216,7 @@ Parameters:
     MinLength: 1
 
   SpotPrice:
-    Description: Spot bid price to use for the instances. 0 means normal (non-spot) instances
+    Description: Maximum Spot bid price to use for the instances. 0 allows you to specify mixed instances (a combination of On-Demand and Spot Instances across multiple instances types)
     Type: String
     Default: 0
 
@@ -223,6 +230,44 @@ Parameters:
     Description: Minimum number of instances
     Type: Number
     Default: 0
+
+  InstanceType1:
+    Description: The primary instance type to use when requesting mixed instance types.
+    Type: String
+    Default: ""
+
+  InstanceType2:
+    Description: The secondary instance type to use when requesting mixed instances. Omit this parmameter to only request 1 instance type.
+    Type: String
+    Default: ""
+
+  InstanceType3:
+    Description: The tertiary instance type to use when requesting mixed instances. Omit this parmameter to only request 2 instance types.
+    Type: String
+    Default: ""
+
+  InstanceType4:
+    Description: The quaternary instance type to use when requesting mixed instances. Omit this parmameter to only request 3 instance types.
+    Type: String
+    Default: ""
+
+  SpotAllocationStrategy:
+    Description: Indicates how to allocate Spot capacity across Spot pools.
+    AllowedValues:
+    - capacity-optimized
+    - lowest-price
+    Type: String
+    Default: capacity-optimized
+
+  OnDemandBaseCapacity:
+    Description: Minimum number of instances in the ASG's initial capacity that must be fulfilled by On-Demand instances.
+    Type: Number
+    Default: 0
+
+  OnDemandPercentageAboveBaseCapacity:
+    Description: Percentage of On-Demand Instances for additional capacity beyond the optional On-Demand base amount.
+    Type: Number
+    Default: 40
 
   ScaleOutFactor:
     Description: A decimal factor to apply to scale out changes to speed up or slow down scale-out
@@ -437,6 +482,18 @@ Conditions:
 
     UseDefaultRootVolumeName:
       !Equals [ !Ref RootVolumeName, "" ]
+
+    UseInstanceType1:
+      !Not [ !Equals [ !Ref InstanceType1, ""] ]
+
+    UseInstanceType2:
+      !Not [ !Equals [ !Ref InstanceType2, ""] ]
+
+    UseInstanceType3:
+      !Not [ !Equals [ !Ref InstanceType3, ""] ]
+
+    UseInstanceType4:
+      !Not [ !Equals [ !Ref InstanceType4, ""] ]
 
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
@@ -872,9 +929,39 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
-      LaunchTemplate:
-        LaunchTemplateId: !Ref AgentLaunchTemplate
-        Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+      MixedInstancesPolicy: !If
+        - UseSpotInstances
+        - !Ref "AWS::NoValue"
+        - InstancesDistribution:
+            OnDemandBaseCapacity: !Ref OnDemandBaseCapacity
+            OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentageAboveBaseCapacity
+            SpotAllocationStrategy: !Ref SpotAllocationStrategy
+          LaunchTemplate:
+            LaunchTemplateSpecification:
+              LaunchTemplateId: !Ref AgentLaunchTemplate
+              Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+            Overrides:
+            - InstanceType: !If
+              - UseInstanceType1
+              - !Ref InstanceType1
+              - !Ref InstanceType
+            - InstanceType: !If
+              - UseInstanceType2
+              - !Ref InstanceType2
+              - !Ref "AWS::NoValue"
+            - InstanceType: !If
+              - UseInstanceType3
+              - !Ref InstanceType3
+              - !Ref "AWS::NoValue"
+            - InstanceType: !If
+              - UseInstanceType4
+              - !Ref InstanceType4
+              - !Ref "AWS::NoValue"
+      LaunchTemplate: !If
+        - UseSpotInstances
+        - LaunchTemplateId: !Ref AgentLaunchTemplate
+          Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+        - !Ref "AWS::NoValue"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 0


### PR DESCRIPTION
Playing off of https://github.com/buildkite/elastic-ci-stack-for-aws/pull/635
This is one approach for adding mixed instance support while allowing the instance types to be configurable.

The obvious drawback, is that this only supports 1-4 instance types.
However, it lays down an example for how users can modify the template for more instance type support.

[AWS announcement on Mixed Instance types](https://aws.amazon.com/blogs/aws/new-ec2-auto-scaling-groups-with-multiple-instance-types-purchase-options/)

[Detailed description of the various parameters](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-purchase-options.html)