### PR TITLE
Revert "bump docker and docker compose versions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 
 * [Amazon Linux 2 LTS](https://aws.amazon.com/amazon-linux-2/)
 * [Buildkite Agent v3.16.0](https://buildkite.com/docs/agent)
-* [Docker 19.03.2](https://www.docker.com)
+* [Docker 19.03.5](https://www.docker.com)
 * [Docker Compose 1.24.1](https://docs.docker.com/compose/)
 * [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks
 * [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from cli tools such as aws-cli or the Buildkite API

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 
 * [Amazon Linux 2 LTS](https://aws.amazon.com/amazon-linux-2/)
 * [Buildkite Agent v3.16.0](https://buildkite.com/docs/agent)
-* [Docker 19.03.5](https://www.docker.com)
-* [Docker Compose 1.25.0](https://docs.docker.com/compose/)
+* [Docker 19.03.2](https://www.docker.com)
+* [Docker Compose 1.24.1](https://docs.docker.com/compose/)
 * [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks
 * [jq](https://stedolan.github.io/jq/) - useful for manipulating JSON responses from cli tools such as aws-cli or the Buildkite API
 

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=19.03.5
+DOCKER_VERSION=19.03.2
 DOCKER_RELEASE="stable"
-DOCKER_COMPOSE_VERSION=1.25.0
+DOCKER_COMPOSE_VERSION=1.24.1
 
 # This performs a manual install of Docker.
 

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=19.03.2
+DOCKER_VERSION=19.03.5
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.24.1
 

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$docker_version="19.03.5"
+$docker_version="19.03.2"
 
 Write-Output "Upgrading DockerMsftProvider module"
 Update-Module -Name DockerMsftProvider -Force

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$docker_version="19.03.2"
+$docker_version="19.03.5"
 
 Write-Output "Upgrading DockerMsftProvider module"
 Update-Module -Name DockerMsftProvider -Force


### PR DESCRIPTION
Partially reverts buildkite/elastic-ci-stack-for-aws#654

docker-compose 1.25.0 has a regression preventing https://github.com/buildkite-plugins/docker-compose-buildkite-plugin from using an image pre-built in a previous build step. This would cause much longer build times, and in some cases build failures if the later step is unable to build the image itself (e.g. if the Dockerfile is BuildKit-specific but the step building it doesn't support that).

See: https://github.com/docker/compose/pull/7039 and other issues linked from there.