### PR TITLE
Bug with SSM permissions 

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -934,58 +934,45 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Policies:
-        !If
+        - PolicyName: AutoScalingGroups
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - autoscaling:DescribeAutoScalingGroups
+                - autoscaling:SetDesiredCapacity
+              Resource: '*'
+        - PolicyName: WriteCloudwatchMetrics
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+            - Effect: Allow
+              Action:
+                - cloudwatch:PutMetricData
+              Resource: '*'
+        - !If
           - UseCustomerManagedKeyForParameterStore
-          - - PolicyName: AutoScalingGroups
-              PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                - Effect: Allow
-                  Action:
-                    - autoscaling:DescribeAutoScalingGroups
-                    - autoscaling:SetDesiredCapacity
-                  Resource: '*'
-            - PolicyName: DecryptAgentToken
-              PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                - Effect: Allow
-                  Action:
-                    - kms:Decrypt
-                  Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
-            - PolicyName: ReadAgentToken
-              PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                - Effect: Allow
-                  Action:
-                    - ssm:GetParameter
-                  Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BuildkiteAgentTokenParameterStorePath}
-            - PolicyName: WriteCloudwatchMetrics
-              PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                - Effect: Allow
-                  Action:
-                    - cloudwatch:PutMetricData
-                  Resource: '*'
-          - - PolicyName: AutoScalingGroups
-              PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                - Effect: Allow
-                  Action:
-                    - autoscaling:DescribeAutoScalingGroups
-                    - autoscaling:SetDesiredCapacity
-                  Resource: '*'
-            - PolicyName: WriteCloudwatchMetrics
-              PolicyDocument:
-                Version: '2012-10-17'
-                Statement:
-                - Effect: Allow
-                  Action:
-                    - cloudwatch:PutMetricData
-                  Resource: '*'
+          - PolicyName: DecryptAgentToken
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
+          - !Ref 'AWS::NoValue'
+        - !If
+          - UseSSMAgentToken
+          - PolicyName: ReadAgentToken
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BuildkiteAgentTokenParameterStorePath}
+          - !Ref 'AWS::NoValue'
 
   # This mirrors the group that would be created by the lambda, but enforces
   # a retention period and also ensures it's removed when the stack is removed

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -622,6 +622,29 @@ Resources:
                  - !Join [ ',', !Ref ManagedPolicyARN ]
                  - !Ref 'AWS::NoValue'
           - !Ref 'AWS::NoValue'
+      Policies:
+        - !If
+          - UseCustomerManagedKeyForParameterStore
+          - PolicyName: DecryptAgentToken
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
+          - !Ref 'AWS::NoValue'
+        - !If
+          - UseSSMAgentToken
+          - PolicyName: ReadAgentToken
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${BuildkiteAgentTokenParameterStorePath}
+          - !Ref 'AWS::NoValue'
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
## Issue
Currently the default ec2 instance role created does not have permissions to access the SSM parameter specified by the user. This also fixes a potential bug where the lambda would not have the correct set of permissions if an SSM path was provided but not a KMS key id.

## Changes
* Split the KMS and SSM logic in the policy for the existing Lambda role
* Add the KMS and SSM permissions to the ec2 instance role

## Testing
* Tested via using this template and using all permutations of specifying and not specifying `BuildkiteAgentToken`, `BuildkiteAgentTokenParameterStorePath` and `BuildkiteAgentTokenParameterStoreKMSKey`