### PR TITLE
POC: Add nvidia-docker

### DIFF
--- a/packer/buildkite-ami.json
+++ b/packer/buildkite-ami.json
@@ -15,13 +15,21 @@
         "owners": ["amazon"],
         "most_recent": true
       },
-      "instance_type": "m5.xlarge",
+      "instance_type": "p2.xlarge",
       "spot_price": "auto",
       "spot_price_auto_product": "Linux/UNIX (Amazon VPC)",
       "ssh_username": "ec2-user",
-      "ami_name": "buildkite-stack-{{isotime | clean_ami_name}}",
-      "ami_description": "Buildkite Elastic Stack (Amazon Linux 2 LTS w/ docker)",
-      "ami_groups": ["all"]
+      "ami_name": "buildkite-stack-dl-{{isotime | clean_ami_name}}",
+      "ami_description": "Buildkite Elastic Stack (Amazon Linux 2 LTS w/ nvidia-docker)",
+      "ami_groups": ["all"],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/xvda",
+          "volume_size": 20,
+          "volume_type": "gp2",
+          "delete_on_termination": true
+        }
+      ]
     }
   ],
   "provisioners": [
@@ -37,7 +45,12 @@
     },
     {
       "type": "shell",
-      "script": "scripts/install-utils.sh"
+      "script": "scripts/update-packages.sh"
+    },
+    {
+      "type": "shell",
+      "script": "scripts/install-utils.sh",
+      "pause_before": "10s"
     },
     {
       "type": "shell",
@@ -50,6 +63,10 @@
     {
       "type": "shell",
       "script": "scripts/install-docker.sh"
+    },
+    {
+      "type": "shell",
+      "script": "scripts/install-nvidia-docker.sh"
     },
     {
       "type": "shell",

--- a/packer/conf/docker/daemon.json
+++ b/packer/conf/docker/daemon.json
@@ -1,3 +1,10 @@
 {
-  "storage-driver": "overlay2"
+  "storage-driver": "overlay2",
+  "runtimes": {
+    "nvidia": {
+      "path": "nvidia-container-runtime",
+      "runtimeArgs": []
+    }
+  },
+  "default-runtime": "nvidia"
 }

--- a/packer/scripts/install-nvidia-docker.sh
+++ b/packer/scripts/install-nvidia-docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# nvidia driver
+sudo yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r) dkms
+
+curl -Lsf -o cuda_toolkit.run http://us.download.nvidia.com/tesla/440.33.01/NVIDIA-Linux-x86_64-440.33.01.run
+sudo sh cuda_toolkit.run --silent --dkms
+rm cuda_toolkit.run
+
+# nvidia-docker
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.repo | sudo tee /etc/yum.repos.d/nvidia-docker.repo
+sudo yum install -y nvidia-container-toolkit nvidia-container-runtime

--- a/packer/scripts/install-utils.sh
+++ b/packer/scripts/install-utils.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -eu -o pipefail
 
-echo "Updating core packages"
-sudo yum update -y
-
 echo "Updating awscli..."
 sudo yum install -y python2-pip
 sudo yum install -y python3-pip python3 python3-setuptools

--- a/packer/scripts/update-packages.sh
+++ b/packer/scripts/update-packages.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eu -o pipefail
+
+echo "Updating core packages"
+sudo yum update -y
+
+echo "Reboot"
+sudo reboot


### PR DESCRIPTION
Just a Proof of Concept. 

Things to improve:
- Probably it's better to create separate AMI with nvidia-docker. 
- Make configurable default runtime (current PR makes `nvidia` as default runtime)