### PR TITLE
Permit custom git-mirrors-path with provisioning script

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -105,6 +105,8 @@ if [[ -n "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
     BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value --output text)"
 fi
 
+BUILDKITE_GIT_MIRRORS_PATH="${BUILDKITE_GIT_MIRRORS_PATH:-/var/lib/buildkite-agent/git-mirrors}"
+
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
@@ -114,7 +116,7 @@ timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins
-git-mirrors-path=/var/lib/buildkite-agent/git-mirrors
+git-mirrors-path=${BUILDKITE_GIT_MIRRORS_PATH}
 experiment="${BUILDKITE_AGENT_EXPERIMENTS}"
 priority=%n
 spawn=${BUILDKITE_AGENTS_PER_INSTANCE}

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -76,6 +76,11 @@ If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
   }
 }
 
+If (!Test-Path Env:BUILDKITE_GIT_MIRRORS_PATH) {
+  $Env:BUILDKITE_GIT_MIRRORS_PATH = "C:\buildkite-agent\git-mirrors"
+}
+
+
 $OFS=","
 Set-Content -Path C:\buildkite-agent\buildkite-agent.cfg -Value @"
 name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%n"
@@ -86,7 +91,7 @@ timestamp-lines=${Env:BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path="C:\buildkite-agent\hooks"
 build-path="C:\buildkite-agent\builds"
 plugins-path="C:\buildkite-agent\plugins"
-git-mirrors-path="C:\buildkite-agent\git-mirrors"
+git-mirrors-path="${Env:BUILDKITE_GIT_MIRRORS_PATH}"
 experiment="${Env:BUILDKITE_AGENT_EXPERIMENTS}"
 priority=%n
 spawn=${Env:BUILDKITE_AGENTS_PER_INSTANCE}


### PR DESCRIPTION
Hello!

This change adds the ability to customise the provisioned agent's `git-mirrors-path` by setting the `BUILDKITE_GIT_MIRRORS_PATH` environment variable. This is the same environment variable respected by the `buildkite-agent` itself.

If `BUILDKITE_GIT_MIRRORS_PATH` is unset, the script behaves the same way it currently does.

This is beneficial to users who run multiple agent workers on one host (i.e., `spawn > 1`). If multiple agents attempt to update the same repository on-disk concurrently, they can experience lock contention from concurrent operations. This depends on https://github.com/buildkite/agent/pull/1153, which adds support for %n interpolation in `git-mirrors-path`.

Let me know if you have any questions or concerns.

Cheers,
Denbeigh

---

Confirming variable substitution in a bash script:


```
$ echo "$BUILDKITE_GIT_MIRRORS_PATH"

$ BUILDKITE_GIT_MIRRORS_PATH="${BUILDKITE_GIT_MIRRORS_PATH:-/var/lib/buildkite-agent/git-mirrors}"
$ echo "$BUILDKITE_GIT_MIRRORS_PATH"
/var/lib/buildkite-agent/git-mirrors
```