### PR TITLE
windows: pin awscli to v1; v2 breaks 'aws ecr get-login'

### DIFF
--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC1117
 set -eu
 
 os="${1:-linux}"

--- a/packer/windows/scripts/install-utils.ps1
+++ b/packer/windows/scripts/install-utils.ps1
@@ -6,7 +6,9 @@ Set-ExecutionPolicy Bypass -Scope Process -Force
 Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 Write-Output "Installing awscli"
-choco install -y awscli
+# pinned because awscli v2 drops 'aws ecr get-login'
+# https://github.com/buildkite-plugins/ecr-buildkite-plugin/issues/37
+choco install -y awscli --version=1.18.11
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing Git for Windows"


### PR DESCRIPTION
Windows AMI pinned to awscli v1

See https://github.com/buildkite-plugins/ecr-buildkite-plugin/issues/37

This patch pins `choco install awscli` to the currently-latest `1.18.11`; see https://chocolatey.org/packages/awscli/1.18.11#versionhistory (Chocolatey doesn't make it possible to pin to a major version.)

This should be reverted after the ECR plugin supports awscli v2.