### PR TITLE
Fix ECR hook; environment, not pre-command

### DIFF
--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -63,6 +63,18 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" &&  "${SECRETS_PLUGIN_ENABLED:-}" == "1
   source /usr/local/buildkite-aws-stack/plugins/secrets/hooks/environment
 fi
 
+if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" ]] ; then
+  export BUILDKITE_PLUGIN_ECR_LOGIN=1
+
+  # map AWS_ECR_LOGIN_REGISTRY_IDS into the plugin list format
+  if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
+    export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
+  fi
+
+  # shellcheck source=/dev/null
+  source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/environment
+fi
+
 if [[ "${DOCKER_USERNS_REMAP:-false}" == "false" ]] ; then
   # We need to scope the next bit to only the currently running agent dir and
   # pipeline, but we also need to control security and make sure arbitrary folders

--- a/packer/linux/conf/buildkite-agent/hooks/pre-command
+++ b/packer/linux/conf/buildkite-agent/hooks/pre-command
@@ -1,18 +1,5 @@
 #!/bin/bash
-
 set -eu -o pipefail
-
-if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" ]] ; then
-  export BUILDKITE_PLUGIN_ECR_LOGIN=1
-
-  # map AWS_ECR_LOGIN_REGISTRY_IDS into the plugin list format
-  if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
-    export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
-  fi
-
-  # shellcheck source=/dev/null
-  source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/pre-command
-fi
 
 if [[ -n "${DOCKER_LOGIN_USER:-}" && "${DOCKER_LOGIN_PLUGIN_ENABLED:-}" == "1" ]] ; then
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="$DOCKER_LOGIN_USER"

--- a/packer/windows/conf/buildkite-agent/hooks/environment
+++ b/packer/windows/conf/buildkite-agent/hooks/environment
@@ -40,3 +40,15 @@ if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" &&  "${SECRETS_PLUGIN_ENABLED:-}" == "1
   # shellcheck source=/dev/null
   source /usr/local/buildkite-aws-stack/plugins/secrets/hooks/environment
 fi
+
+if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" ]] ; then
+  export BUILDKITE_PLUGIN_ECR_LOGIN=1
+
+  # map AWS_ECR_LOGIN_REGISTRY_IDS into the plugin list format
+  if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
+    export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
+  fi
+
+  # shellcheck source=/dev/null
+  source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/environment
+fi

--- a/packer/windows/conf/buildkite-agent/hooks/pre-command
+++ b/packer/windows/conf/buildkite-agent/hooks/pre-command
@@ -1,18 +1,5 @@
 #!/bin/bash
-
 set -eu -o pipefail
-
-if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" ]] ; then
-  export BUILDKITE_PLUGIN_ECR_LOGIN=1
-
-  # map AWS_ECR_LOGIN_REGISTRY_IDS into the plugin list format
-  if [[ -n "${AWS_ECR_LOGIN_REGISTRY_IDS:-}" ]] ; then
-    export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
-  fi
-
-  # shellcheck source=/dev/null
-  source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/pre-command
-fi
 
 if [[ -n "${DOCKER_LOGIN_USER:-}" && "${DOCKER_LOGIN_PLUGIN_ENABLED:-}" == "1" ]] ; then
   export BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME="$DOCKER_LOGIN_USER"


### PR DESCRIPTION
ECR plugin-ish hook is now an `environment`, not a `pre-command` hook.

Changed as of this ECR plugin commit:
https://github.com/buildkite-plugins/ecr-buildkite-plugin/commit/18295819f568c099ab7056d41621768e62462167
Which was part of this PR:
https://github.com/buildkite-plugins/ecr-buildkite-plugin/pull/26

Brought into this repo by:
https://github.com/buildkite/elastic-ci-stack-for-aws/commit/9bec0c348f840ccf1db1008e7f9b70d1256bd600