### PR TITLE
Isolate docker configuration per step

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -49,6 +49,8 @@ PLUGINS_ENABLED=()
 [[ $ECR_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("ecr")
 [[ $DOCKER_LOGIN_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("docker-login")
 
+[[ $ISOLATE_DOCKER_CONFIG == "true" ]] && DOCKER_CONFIG="export DOCKER_CONFIG=\$(mktemp -d)"
+
 # cfn-env is sourced by the environment hook in builds
 cat << EOF > /var/lib/buildkite-agent/cfn-env
 export DOCKER_VERSION=$DOCKER_VERSION
@@ -60,6 +62,7 @@ export AWS_DEFAULT_REGION=$AWS_REGION
 export AWS_REGION=$AWS_REGION
 export PLUGINS_ENABLED="${PLUGINS_ENABLED[*]-}"
 export BUILDKITE_ECR_POLICY=${BUILDKITE_ECR_POLICY:-none}
+${DOCKER_CONFIG:-""}
 EOF
 
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -73,6 +73,7 @@ Metadata:
         Parameters:
         - EnableDockerUserNamespaceRemap
         - EnableDockerExperimental
+        - IsolateDockerConfig
 
       - Label:
           default: Docker Registry Configuration
@@ -344,6 +345,14 @@ Parameters:
   EnableDockerExperimental:
     Type: String
     Description: Enables Docker experimental features
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
+  IsolateDockerConfig:
+    Type: String
+    Description: Isolates Docker Configuration per step
     AllowedValues:
       - "true"
       - "false"
@@ -845,6 +854,7 @@ Resources:
                   $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
                   $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
                   $Env:AWS_REGION="${AWS::Region}"
+                  $Env:ISOLATE_DOCKER_CONFIG="${IsolateDockerConfig}"
                   powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
                   </powershell>
                 - {


### PR DESCRIPTION
This avoids a couple of issues:

### Allow steps to use credentials from other steps
People may forget to configure their pipelines with ECR login and wonder why the build sometimes fails with "No basic auth credentials", when in fact their pipeline was never configured correctly.
By isolating credentials we make this behaviour more predictable, incorrectly configured pipelines will never work (rather than sometimes not working).

### Causes steps to use incorrect credentials
If they are over-written by another step running concurrently on the same agent. If Step A has read/write credentials and Step B has only read credentials, if Step A logs in first, then Step B logs in immediately after, future commands run by Step A have only read credentials.