### PR TITLE
Update with clarification about how scaling works

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you have configured `MinSize` < `MaxSize`, the stack will automatically scale
 
 This means you can scale down to zero when idle, which means you can use larger instances for the same cost.
 
-Metrics are collected with a Lambda function, polling every minute.
+Metrics are collected with a Lambda function, polling every minute based on the queue the stack is configured with. The autoscaler monitors only one queue.
 
 ## Terminating the instance after job is complete
 


### PR DESCRIPTION
A customer encountered some difficulties when their stack was configured on more than one queue. This helps clarify the docs around this behavior.