### PR TITLE
Set content-type on YML Files

### DIFF
--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -12,8 +12,8 @@ is_release_candidate_tag() {
 s3_upload_templates() {
   local bucket_prefix="${1:-}"
 
-  aws s3 cp --acl public-read build/mappings.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}mappings.yml"
-  aws s3 cp --acl public-read build/aws-stack.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.yml"
+  aws s3 cp --content-type 'text/yaml' --acl public-read build/mappings.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}mappings.yml"
+  aws s3 cp --content-type 'text/yaml' --acl public-read build/aws-stack.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.yml"
 }
 
 if [[ -z "${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}" ]] ; then


### PR DESCRIPTION
I recently ran into an issue when attempting to download one of the CloudFormation YAML templates provided in the release via Terraform which is caused by not setting the `content-type` to `text/yaml` on the files stored in S3.

Currently the files return `application/octet-stream` which causes the [http datasource](https://www.terraform.io/docs/providers/http/data_source.html) in Terraform to report failure as it only allows `text/*` and `application/json`.

This PR sets the content type to `text/yaml` during the upload of the file which happens in a Buildkite step. 