### PR TITLE
Bump agent version to 3.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 ## What’s On Each Machine?
 
 * [Amazon Linux 2 LTS](https://aws.amazon.com/amazon-linux-2/)
-* [Buildkite Agent v3.16.0](https://buildkite.com/docs/agent)
+* [Buildkite Agent v3.21.1](https://buildkite.com/docs/agent)
 * [Docker 19.03.5](https://www.docker.com)
 * [Docker Compose 1.25.1](https://docs.docker.com/compose/)
 * [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.20.0
+AGENT_VERSION=3.21.1
 
 echo "Installing dependencies..."
 sudo yum update -y -q

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.20.0"
+$AGENT_VERSION = "3.21.1"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
This change updates the version of `buildkite-agent` that's bundled into the AMI to 3.21.1.