### PR TITLE
Add an optional ImageId SSM Parameter Path

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -37,6 +37,7 @@ Metadata:
           default: Instance Configuration
         Parameters:
         - ImageId
+        - ImageIdParameter
         - InstanceType
         - AgentsPerInstance
         - KeyName

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -280,6 +280,11 @@ Parameters:
     Description: Optional - Custom AMI to use for instances (must be based on the stack's AMI)
     Default: ""
 
+  ImageIdParameter:
+    Type: String
+    Description: Optional - Custom AMI SSM Parameter to use for instances (must be based on the stack's AMI)
+    Default: ""
+
   ManagedPolicyARN:
     Type: CommaDelimitedList
     Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
@@ -439,8 +444,10 @@ Conditions:
     UseArtifactsBucket:
       !Not [ !Equals [ !Ref ArtifactsBucket, "" ] ]
 
-    UseDefaultAMI:
-      !Equals [ !Ref ImageId, "" ]
+    HasImageId:
+      !Not [ !Equals [ !Ref ImageId, "" ] ]
+    HasImageIdParameter:
+      !Not [ !Equals [ !Ref ImageIdParameter, "" ] ]
 
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
@@ -743,6 +750,14 @@ Resources:
       Roles:
         - !Ref IAMRole
 
+  ImageIdParameterStack:
+    Type: AWS::CloudFormation::Stack
+    Condition: HasImageIdParameter
+    Properties:
+      TemplateURL: ssm-ami.yml
+      Parameters:
+        AmiParameterPath: !Ref ImageIdParameter
+
   AgentLaunchConfiguration:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -752,7 +767,7 @@ Resources:
       IamInstanceProfile: !Ref IAMInstanceProfile
       InstanceType: !Ref InstanceType
       SpotPrice: !If [ "UseSpotInstances", !Ref SpotPrice, !Ref 'AWS::NoValue' ]
-      ImageId: !If [ "UseDefaultAMI", !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'AMI'], !Ref ImageId ]
+      ImageId: !If [ HasImageId, !Ref ImageId, !If [ HasImageIdParameter, !GetAtt ImageIdParameterStack.Outputs.ImageId, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'AMI'] ] ]
       BlockDeviceMappings:
         - DeviceName: !Ref RootVolumeName
           Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -754,7 +754,7 @@ Resources:
     Type: AWS::CloudFormation::Stack
     Condition: HasImageIdParameter
     Properties:
-      TemplateURL: ssm-ami.yml
+      TemplateURL: https://s3.amazonaws.com/buildkite-aws-stack/ssm-ami/releases/0.1.0.yml
       Parameters:
         AmiParameterPath: !Ref ImageIdParameter
 

--- a/templates/ssm-ami.yml
+++ b/templates/ssm-ami.yml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+  AmiParameterPath:
+    Description: SSM Parameter Path for an aws:ec2:image Parameter.
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+
+Resources:
+  # This is a placeholder because a template must specify at least one resource
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/buildkite/${AWS::StackName}/placeholder"
+      RetentionInDays: 1
+
+Outputs:
+  ImageId:
+    Value: !Ref AmiParameterPath


### PR DESCRIPTION
This adds an optional String parameter to the elastic-ci stack parameter list. If given this is expected to be an SSM Parameter Path. This cannot be typed as an `AWS::SSM::Parameter` at the top level because that would make it mandatory. Instead, if given, a substack with a `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>` parameter is brought in whose output is the value we need.

Example error when using an `AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>` parameter with a `Default: ""`:

```
Error: Failed to create changeset for the stack: substack-laundry, An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameter AmiParameterPath should either have input value or default value
```

This change removes the `UseDefaultAMI` condition and replaces it with `HasImageId` and `HasImageIdParameter` conditions. Precedence is: the plain `ImageId` parameter, the SSM parameter path, then the default AMI mapping.

The given `TemplateURL` I’ve used here won’t work because it’s file system relative and we don’t use `aws cloudformation package` to preprocess the template. We’ll either need to add something to the build system to make this work, or pre-deploy the new template somewhere we can reference with an S3 url. I don’t anticipate this substack template changing often and would lean towards separately packaging and deploying the `ssm-ami.yml` template to S3, and using a static semver'd URL to this template in the main `aws-stack.yml` file. This would avoid any potentially complex additions to the current build system.