### PR TITLE
Add InstanceMetadataOptions

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -50,6 +50,9 @@ Metadata:
         - RootVolumeName
         - RootVolumeType
         - ManagedPolicyARN
+        - MetadataOptionsHttpEndpoint
+        - MetadataOptionsHttpPutResponseHopLimit
+        - MetadataOptionsHttpTokens
         - InstanceRoleName
 
       - Label:
@@ -281,6 +284,21 @@ Parameters:
 
   ManagedPolicyARN:
     Type: CommaDelimitedList
+    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
+    Default: ""
+  
+  MetadataOptionsHttpEndpoint:
+    Type: String
+    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
+    Default: ""
+  
+  MetadataOptionsHttpPutResponseHopLimit:
+    Type: String
+    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
+    Default: ""
+  
+  MetadataOptionsHttpTokens:
+    Type: String
     Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
     Default: ""
 
@@ -800,6 +818,10 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Ref InstanceType
+          MetadataOptions:
+            HttpEndpoint: String
+            HttpPutResponseHopLimit: Integer
+            HttpTokens: String
           InstanceMarketOptions: !If
             - UseSpotInstances
             - MarketType: spot

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -289,18 +289,18 @@ Parameters:
   
   MetadataOptionsHttpEndpoint:
     Type: String
-    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
-    Default: ""
+    Description: Optional - "enabled" | "disabled" Whether the Instance Metadata endpoint is enabled.
+    Default: "enabled"
   
   MetadataOptionsHttpPutResponseHopLimit:
-    Type: String
-    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
-    Default: ""
+    Type: Number
+    Description: Optional - Number of hops that the PUT request can jump.
+    Default: 1
   
   MetadataOptionsHttpTokens:
     Type: String
-    Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
-    Default: ""
+    Description: Optional - "optional" | "required" Whether to require tokens for using the Instance Metadata service.
+    Default: "optional"
 
   InstanceRoleName:
     Type: String
@@ -819,9 +819,9 @@ Resources:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Ref InstanceType
           MetadataOptions:
-            HttpEndpoint: String
-            HttpPutResponseHopLimit: Integer
-            HttpTokens: String
+            HttpEndpoint: !Ref MetadataOptionsHttpEndpoint
+            HttpPutResponseHopLimit: !Ref MetadataOptionsHttpPutResponseHopLimit
+            HttpTokens: !Ref MetadataOptionsHttpTokens
           InstanceMarketOptions: !If
             - UseSpotInstances
             - MarketType: spot


### PR DESCRIPTION
Allow modifying Instance options so that users can disable IMDSv1 for higher security. In reference to this issue: https://github.com/buildkite/elastic-ci-stack-for-aws/issues/647

More information about this below:
https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata-metadataoptions.html#cfn-ec2-launchtemplate-launchtemplatedata-metadataoptions-httpendpoint
