### PR TITLE
Only set git-mirrors-path when EnableAgentGitMirrorsExperiment

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -91,13 +91,16 @@ if [[ -n "${BUILDKITE_AGENT_TAGS:-}" ]] ; then
 	agent_metadata=("${agent_metadata[@]}" "${extra_agent_metadata[@]}")
 fi
 
-# Enable git mirrors
+# Enable git-mirrors
 if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
   if [[ -z "$BUILDKITE_AGENT_EXPERIMENTS" ]] ; then
     BUILDKITE_AGENT_EXPERIMENTS="git-mirrors"
   else
     BUILDKITE_AGENT_EXPERIMENTS+=",git-mirrors"
   fi
+  BUILDKITE_AGENT_GIT_MIRRORS_PATH="/var/lib/buildkite-agent/git-mirrors"
+else
+  BUILDKITE_AGENT_GIT_MIRRORS_PATH=""
 fi
 
 # If the agent token path is set, use that instead of BUILDKITE_AGENT_TOKEN
@@ -114,7 +117,7 @@ timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds
 plugins-path=/var/lib/buildkite-agent/plugins
-git-mirrors-path=/var/lib/buildkite-agent/git-mirrors
+git-mirrors-path="${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
 experiment="${BUILDKITE_AGENT_EXPERIMENTS}"
 priority=%n
 spawn=${BUILDKITE_AGENTS_PER_INSTANCE}

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -43,7 +43,7 @@ echo "Creating builds dir..."
 sudo mkdir -p /var/lib/buildkite-agent/builds
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/builds
 
-echo "Creating git mirrors dir..."
+echo "Creating git-mirrors dir..."
 sudo mkdir -p /var/lib/buildkite-agent/git-mirrors
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/git-mirrors
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -66,7 +66,7 @@ If (Test-Path Env:BUILDKITE_AGENT_TAGS) {
   $agent_metadata += $Env:BUILDKITE_AGENT_TAGS.split(",")
 }
 
-# Enable git mirrors
+# Enable git-mirrors
 If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
   If ([string]::IsNullOrEmpty($Env:BUILDKITE_AGENT_EXPERIMENTS)) {
     $Env:BUILDKITE_AGENT_EXPERIMENTS = "git-mirrors"
@@ -74,6 +74,7 @@ If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
   Else {
     $Env:BUILDKITE_AGENT_EXPERIMENTS += ",git-mirrors"
   }
+  $Env:BUILDKITE_AGENT_GIT_MIRRORS_PATH = "C:\buildkite-agent\git-mirrors"
 }
 
 $OFS=","
@@ -86,7 +87,7 @@ timestamp-lines=${Env:BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path="C:\buildkite-agent\hooks"
 build-path="C:\buildkite-agent\builds"
 plugins-path="C:\buildkite-agent\plugins"
-git-mirrors-path="C:\buildkite-agent\git-mirrors"
+git-mirrors-path="${Env:BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
 experiment="${Env:BUILDKITE_AGENT_EXPERIMENTS}"
 priority=%n
 spawn=${Env:BUILDKITE_AGENTS_PER_INSTANCE}

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -29,7 +29,7 @@ Copy-Item -Path C:\packer-temp\conf\buildkite-agent\hooks\* -Destination C:\buil
 Write-Output "Creating builds dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\builds
 
-Write-Output "Creating git mirrors dir..."
+Write-Output "Creating git-mirrors dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\git-mirrors
 
 Write-Output "Creating plugins dir..."


### PR DESCRIPTION
We currently set `git-mirrors-path` even when [`EnableAgentGitMirrorsExperiment`](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/555) is `false`. That would lead to unexpected activation of the feature if a newer version of https://github.com/buildkite/agent promotes `git-mirrors` from experiment status.

This patch configures `git-mirrors-path` as an empty string unless `EnableAgentGitMirrorsExperiment` is `true`.