### PR TITLE
InstanceType default t3.small, was t2.nano

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -206,7 +206,7 @@ Parameters:
   InstanceType:
     Description: Instance type
     Type: String
-    Default: t3.small
+    Default: t3.large
     MinLength: 1
 
   SpotPrice:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -206,7 +206,7 @@ Parameters:
   InstanceType:
     Description: Instance type
     Type: String
-    Default: t2.nano
+    Default: t3.small
     MinLength: 1
 
   SpotPrice:


### PR DESCRIPTION
The newer `t3` instance family is objectively better than `t2`.
The `large` size (8 GiB RAM) is more realistic than `nano` (0.5 GiB RAM) for actual workloads, and still very affordable with autoscaling.