### PR TITLE
Ensure terminate instance exits gracefully

### DIFF
--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -5,4 +5,4 @@ set -euo pipefail
 instance_id=$(curl -fsSL http://169.254.169.254/latest/meta-data/instance-id)
 region=$(curl -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity"
+aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity" || true


### PR DESCRIPTION
We run a slightly modified version of this stack, in which it doesn't have permission to call `terminate-instance-in-auto-scaling-group`.

I will change that, but for robustness I don't think a failure here should cause the box to stay up (and the buildkite-agent to get restarted by systemd).
Just falling through to `sudo poweroff` will be sufficient.

This causes issues with scaling down, as the non-zero exit code from `aws autoscaling terminate-instance-in-auto-scaling-group` results in systemd restarting buildkite-agent, which means it takes jobs even though we're trying to drain it ready for scale down.