### PR TITLE
Support multiple instance types by switching to a Mixed Instance ASG

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -221,7 +221,7 @@ Parameters:
     Default: 0
 
   OnDemandPercentage:
-    Description: Percentage of total instances that should launch as OnDemand. Reduce this to use some Spot Instances when they're available.
+    Description: Percentage of total instances that should launch as OnDemand. Default is 100% OnDemand - reduce this to use some Spot Instances when they're available and cheaper than the OnDemand price.
     Type: Number
     Default: 100
     MinValue: 0

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -39,9 +39,11 @@ Metadata:
         - ImageId
         - ImageIdParameter
         - InstanceType
+        - InstanceType2
+        - InstanceType3
+        - InstanceType4
         - AgentsPerInstance
         - KeyName
-        - SpotPrice
         - SecretsBucket
         - ArtifactsBucket
         - AuthorizedUsersUrl
@@ -57,13 +59,7 @@ Metadata:
         Parameters:
         - MinSize
         - MaxSize
-        - SpotAllocationStrategy
-        - OnDemandBaseCapacity
-        - OnDemandPercentageAboveBaseCapacity
-        - InstanceType1
-        - InstanceType2
-        - InstanceType3
-        - InstanceType4
+        - OnDemandPercentage
         - ScaleOutFactor
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
@@ -216,11 +212,6 @@ Parameters:
     Default: t3.large
     MinLength: 1
 
-  SpotPrice:
-    Description: Maximum Spot bid price to use for the instances. 0 allows you to specify mixed instances (a combination of On-Demand and Spot Instances across multiple instances types)
-    Type: String
-    Default: 0
-
   MaxSize:
     Description: Maximum number of instances
     Type: Number
@@ -231,11 +222,6 @@ Parameters:
     Description: Minimum number of instances
     Type: Number
     Default: 0
-
-  InstanceType1:
-    Description: The primary instance type to use when requesting mixed instance types.
-    Type: String
-    Default: ""
 
   InstanceType2:
     Description: The secondary instance type to use when requesting mixed instances. Omit this parmameter to only request 1 instance type.
@@ -252,23 +238,12 @@ Parameters:
     Type: String
     Default: ""
 
-  SpotAllocationStrategy:
-    Description: Indicates how to allocate Spot capacity across Spot pools.
-    AllowedValues:
-    - capacity-optimized
-    - lowest-price
-    Type: String
-    Default: capacity-optimized
-
-  OnDemandBaseCapacity:
-    Description: Minimum number of instances in the ASG's initial capacity that must be fulfilled by On-Demand instances.
+  OnDemandPercentage:
+    Description: Percentage of total instances that should launch as OnDemand. Reduce this to use some Spot Instances when they're available.
     Type: Number
-    Default: 0
-
-  OnDemandPercentageAboveBaseCapacity:
-    Description: Percentage of On-Demand Instances for additional capacity beyond the optional On-Demand base amount.
-    Type: Number
-    Default: 40
+    Default: 100
+    MinValue: 0
+    MaxValue: 100
 
   ScaleOutFactor:
     Description: A decimal factor to apply to scale out changes to speed up or slow down scale-out
@@ -456,8 +431,6 @@ Outputs:
       Name: !Sub '${AWS::StackName}-InstanceRoleName'
 
 Conditions:
-    UseSpotInstances:
-      !Not [ !Equals [ !Ref SpotPrice, 0 ] ]
 
     CreateVpcResources:
       !Equals [ !Ref VpcId, "" ]
@@ -490,9 +463,6 @@ Conditions:
 
     UseDefaultRootVolumeName:
       !Equals [ !Ref RootVolumeName, "" ]
-
-    UseInstanceType1:
-      !Not [ !Equals [ !Ref InstanceType1, ""] ]
 
     UseInstanceType2:
       !Not [ !Equals [ !Ref InstanceType2, ""] ]
@@ -861,12 +831,6 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Ref InstanceType
-          InstanceMarketOptions: !If
-            - UseSpotInstances
-            - MarketType: spot
-              SpotOptions:
-                MaxPrice: !Ref SpotPrice
-            - !Ref "AWS::NoValue"
           ImageId: !If [ HasImageId, !Ref ImageId, !If [ HasImageIdParameter, !GetAtt ImageIdParameterStack.Outputs.ImageId, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ] ] ]
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
@@ -971,39 +935,28 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
-      MixedInstancesPolicy: !If
-        - UseSpotInstances
-        - !Ref "AWS::NoValue"
-        - InstancesDistribution:
-            OnDemandBaseCapacity: !Ref OnDemandBaseCapacity
-            OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentageAboveBaseCapacity
-            SpotAllocationStrategy: !Ref SpotAllocationStrategy
-          LaunchTemplate:
-            LaunchTemplateSpecification:
-              LaunchTemplateId: !Ref AgentLaunchTemplate
-              Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
-            Overrides:
-            - InstanceType: !If
-              - UseInstanceType1
-              - !Ref InstanceType1
-              - !Ref InstanceType
-            - InstanceType: !If
-              - UseInstanceType2
-              - !Ref InstanceType2
-              - !Ref "AWS::NoValue"
-            - InstanceType: !If
-              - UseInstanceType3
-              - !Ref InstanceType3
-              - !Ref "AWS::NoValue"
-            - InstanceType: !If
-              - UseInstanceType4
-              - !Ref InstanceType4
-              - !Ref "AWS::NoValue"
-      LaunchTemplate: !If
-        - UseSpotInstances
-        - LaunchTemplateId: !Ref AgentLaunchTemplate
-          Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
-        - !Ref "AWS::NoValue"
+      MixedInstancesPolicy:
+        InstancesDistribution:
+          OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
+          SpotAllocationStrategy: capacity-optimized
+        LaunchTemplate:
+          LaunchTemplateSpecification:
+            LaunchTemplateId: !Ref AgentLaunchTemplate
+            Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+          Overrides:
+          - InstanceType: !Ref InstanceType
+          - InstanceType: !If
+            - UseInstanceType2
+            - !Ref InstanceType2
+            - !Ref "AWS::NoValue"
+          - InstanceType: !If
+            - UseInstanceType3
+            - !Ref InstanceType3
+            - !Ref "AWS::NoValue"
+          - InstanceType: !If
+            - UseInstanceType4
+            - !Ref InstanceType4
+            - !Ref "AWS::NoValue"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 0

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -204,12 +204,12 @@ Parameters:
     Default: ""
 
   InstanceType:
-    Description: Instance type. Comma separated list with 1-4 instance types. The order is a prioritised preference for launching OnDemand instances, and an non-prioritised list of types to consider for Spot Instances (where used).
+    Description: Instance type. Comma-separated list with 1-4 instance types. The order is a prioritized preference for launching OnDemand instances, and a non-prioritized list of types to consider for Spot Instances (where used).
     Type: String
     Default: t3.large
     MinLength: 1
     AllowedPattern: "^[^,]+(,[^,]*){0,3}$"
-    ConstraintDescription: "must contain 1-4 instance types separated by commas"
+    ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
 
   MaxSize:
     Description: Maximum number of instances

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -208,6 +208,8 @@ Parameters:
     Type: String
     Default: t3.large
     MinLength: 1
+    AllowedPattern: "^[^,]+(,[^,]*){0,3}$"
+    ConstraintDescription: "must contain 1-4 instance types separated by commas"
 
   MaxSize:
     Description: Maximum number of instances

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -39,9 +39,6 @@ Metadata:
         - ImageId
         - ImageIdParameter
         - InstanceType
-        - InstanceType2
-        - InstanceType3
-        - InstanceType4
         - AgentsPerInstance
         - KeyName
         - SecretsBucket
@@ -207,7 +204,7 @@ Parameters:
     Default: ""
 
   InstanceType:
-    Description: Instance type
+    Description: Instance type. Comma separated list with 1-4 instance types. The order is a prioritised preference for launching OnDemand instances, and an non-prioritised list of types to consider for Spot Instances (where used).
     Type: String
     Default: t3.large
     MinLength: 1
@@ -222,21 +219,6 @@ Parameters:
     Description: Minimum number of instances
     Type: Number
     Default: 0
-
-  InstanceType2:
-    Description: The secondary instance type to use when requesting mixed instances. Omit this parmameter to only request 1 instance type.
-    Type: String
-    Default: ""
-
-  InstanceType3:
-    Description: The tertiary instance type to use when requesting mixed instances. Omit this parmameter to only request 2 instance types.
-    Type: String
-    Default: ""
-
-  InstanceType4:
-    Description: The quaternary instance type to use when requesting mixed instances. Omit this parmameter to only request 3 instance types.
-    Type: String
-    Default: ""
 
   OnDemandPercentage:
     Description: Percentage of total instances that should launch as OnDemand. Reduce this to use some Spot Instances when they're available.
@@ -465,13 +447,13 @@ Conditions:
       !Equals [ !Ref RootVolumeName, "" ]
 
     UseInstanceType2:
-      !Not [ !Equals [ !Ref InstanceType2, ""] ]
+      !Not [ !Equals [ !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ], ""] ]
 
     UseInstanceType3:
-      !Not [ !Equals [ !Ref InstanceType3, ""] ]
+      !Not [ !Equals [ !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ], ""] ]
 
     UseInstanceType4:
-      !Not [ !Equals [ !Ref InstanceType4, ""] ]
+      !Not [ !Equals [ !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ], ""] ]
 
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
@@ -830,7 +812,7 @@ Resources:
           KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
-          InstanceType: !Ref InstanceType
+          InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
           ImageId: !If [ HasImageId, !Ref ImageId, !If [ HasImageIdParameter, !GetAtt ImageIdParameterStack.Outputs.ImageId, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ] ] ]
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
@@ -944,18 +926,18 @@ Resources:
             LaunchTemplateId: !Ref AgentLaunchTemplate
             Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
           Overrides:
-          - InstanceType: !Ref InstanceType
+          - InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
           - InstanceType: !If
             - UseInstanceType2
-            - !Ref InstanceType2
+            - !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
             - !Ref "AWS::NoValue"
           - InstanceType: !If
             - UseInstanceType3
-            - !Ref InstanceType3
+            - !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
             - !Ref "AWS::NoValue"
           - InstanceType: !If
             - UseInstanceType4
-            - !Ref InstanceType4
+            - !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
             - !Ref "AWS::NoValue"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -223,7 +223,7 @@ Parameters:
     Default: 0
 
   OnDemandPercentage:
-    Description: Percentage of total instances that should launch as OnDemand. Default is 100% OnDemand - reduce this to use some Spot Instances when they're available and cheaper than the OnDemand price.
+    Description: Percentage of total instances that should launch as OnDemand. Default is 100% OnDemand - reduce this to use some Spot Instances when they're available and cheaper than the OnDemand price. A value of 70 means 70% OnDemand and 30% Spot Instances.
     Type: Number
     Default: 100
     MinValue: 0

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -208,7 +208,7 @@ Parameters:
     Type: String
     Default: t3.large
     MinLength: 1
-    AllowedPattern: "^[^,]+(,[^,]*){0,3}$"
+    AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
 
   MaxSize:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -57,6 +57,13 @@ Metadata:
         Parameters:
         - MinSize
         - MaxSize
+        - SpotAllocationStrategy
+        - OnDemandBaseCapacity
+        - OnDemandPercentageAboveBaseCapacity
+        - InstanceType1
+        - InstanceType2
+        - InstanceType3
+        - InstanceType4
         - ScaleOutFactor
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
@@ -210,7 +217,7 @@ Parameters:
     MinLength: 1
 
   SpotPrice:
-    Description: Spot bid price to use for the instances. 0 means normal (non-spot) instances
+    Description: Maximum Spot bid price to use for the instances. 0 allows you to specify mixed instances (a combination of On-Demand and Spot Instances across multiple instances types)
     Type: String
     Default: 0
 
@@ -224,6 +231,44 @@ Parameters:
     Description: Minimum number of instances
     Type: Number
     Default: 0
+
+  InstanceType1:
+    Description: The primary instance type to use when requesting mixed instance types.
+    Type: String
+    Default: ""
+
+  InstanceType2:
+    Description: The secondary instance type to use when requesting mixed instances. Omit this parmameter to only request 1 instance type.
+    Type: String
+    Default: ""
+
+  InstanceType3:
+    Description: The tertiary instance type to use when requesting mixed instances. Omit this parmameter to only request 2 instance types.
+    Type: String
+    Default: ""
+
+  InstanceType4:
+    Description: The quaternary instance type to use when requesting mixed instances. Omit this parmameter to only request 3 instance types.
+    Type: String
+    Default: ""
+
+  SpotAllocationStrategy:
+    Description: Indicates how to allocate Spot capacity across Spot pools.
+    AllowedValues:
+    - capacity-optimized
+    - lowest-price
+    Type: String
+    Default: capacity-optimized
+
+  OnDemandBaseCapacity:
+    Description: Minimum number of instances in the ASG's initial capacity that must be fulfilled by On-Demand instances.
+    Type: Number
+    Default: 0
+
+  OnDemandPercentageAboveBaseCapacity:
+    Description: Percentage of On-Demand Instances for additional capacity beyond the optional On-Demand base amount.
+    Type: Number
+    Default: 40
 
   ScaleOutFactor:
     Description: A decimal factor to apply to scale out changes to speed up or slow down scale-out
@@ -445,6 +490,18 @@ Conditions:
 
     UseDefaultRootVolumeName:
       !Equals [ !Ref RootVolumeName, "" ]
+
+    UseInstanceType1:
+      !Not [ !Equals [ !Ref InstanceType1, ""] ]
+
+    UseInstanceType2:
+      !Not [ !Equals [ !Ref InstanceType2, ""] ]
+
+    UseInstanceType3:
+      !Not [ !Equals [ !Ref InstanceType3, ""] ]
+
+    UseInstanceType4:
+      !Not [ !Equals [ !Ref InstanceType4, ""] ]
 
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
@@ -914,9 +971,39 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
-      LaunchTemplate:
-        LaunchTemplateId: !Ref AgentLaunchTemplate
-        Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+      MixedInstancesPolicy: !If
+        - UseSpotInstances
+        - !Ref "AWS::NoValue"
+        - InstancesDistribution:
+            OnDemandBaseCapacity: !Ref OnDemandBaseCapacity
+            OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentageAboveBaseCapacity
+            SpotAllocationStrategy: !Ref SpotAllocationStrategy
+          LaunchTemplate:
+            LaunchTemplateSpecification:
+              LaunchTemplateId: !Ref AgentLaunchTemplate
+              Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+            Overrides:
+            - InstanceType: !If
+              - UseInstanceType1
+              - !Ref InstanceType1
+              - !Ref InstanceType
+            - InstanceType: !If
+              - UseInstanceType2
+              - !Ref InstanceType2
+              - !Ref "AWS::NoValue"
+            - InstanceType: !If
+              - UseInstanceType3
+              - !Ref InstanceType3
+              - !Ref "AWS::NoValue"
+            - InstanceType: !If
+              - UseInstanceType4
+              - !Ref InstanceType4
+              - !Ref "AWS::NoValue"
+      LaunchTemplate: !If
+        - UseSpotInstances
+        - LaunchTemplateId: !Ref AgentLaunchTemplate
+          Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+        - !Ref "AWS::NoValue"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 0

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -41,6 +41,7 @@ Metadata:
         - InstanceType
         - AgentsPerInstance
         - KeyName
+        - SpotPrice
         - SecretsBucket
         - ArtifactsBucket
         - AuthorizedUsersUrl
@@ -210,6 +211,11 @@ Parameters:
     MinLength: 1
     AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
+
+  SpotPrice:
+    Description: Maximum spot price to use for the instances, in instance cost per hour. Values >0 will result in 100% of instances being spot. 0 means only use normal (non-spot) instances. This parameter is deprecated - we recommend setting to 0 and using OnDemandPercentage to opt into spot instances.
+    Type: String
+    Default: 0
 
   MaxSize:
     Description: Maximum number of instances
@@ -415,6 +421,8 @@ Outputs:
       Name: !Sub '${AWS::StackName}-InstanceRoleName'
 
 Conditions:
+    SpotPriceSet:
+      !Not [ !Equals [ !Ref SpotPrice, 0 ] ]
 
     CreateVpcResources:
       !Equals [ !Ref VpcId, "" ]
@@ -921,8 +929,9 @@ Resources:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
+          OnDemandPercentageAboveBaseCapacity: !If [ SpotPriceSet, 0, !Ref OnDemandPercentage ]
           SpotAllocationStrategy: capacity-optimized
+          SpotMaxPrice: !If [SpotPriceSet, !Ref SpotPrice, !Ref "AWS::NoValue"]
         LaunchTemplate:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref AgentLaunchTemplate


### PR DESCRIPTION
I started reviewing #651 as an excuse to improve my CloudFormation knowledge, and ended up extending it into an alternative approach that might be worth considering.

This makes the following changes to master:

1. Replaces the `SpotPrice` parameter with `OnDemandPercentage` that defaults to 100%. If this is reduced, the stack will potentially use Spot instances if they're available and cheaper than the standard OnDemand price
1. Allows the `InstanceType` parameter to be a CSV with 1- 4 types. When launching  OnDemand instances the types will be used in priority order, and when launching spot instances (if the config allows them) all types will be considered (AWS will pick the instances with the best capacity and least chanec of being terminated).

The internal implementation of the `InstanceType` CSV is pretty ugly, but at least the users of the stack don't see it. We append some extra commas before splitting it to ensure the CF `!Select` function is **always** passed a list with at least 4 items.

A nice side effect of this change is that a single stack can be configured to use Spot instances when they're available, but fall back to OnDemand instances when spot capacity is unavailable. I'm a little hazy on how Reserved Instances work, but I think the priority order can also be used to prefer instance types with reserved pricing, but then fallback to other types.