### PR TITLE
make build: render the mappings.yml file before aws-stack.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ env-%:
 
 # -----------------------------------------
 
-build: packer build/aws-stack.yml
+build: packer build/mappings.yml build/aws-stack.yml
 
 # Build a mapping file for a single region and image id pair
 mappings-for-linux-image: env-AWS_REGION env-IMAGE_ID

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ mappings-for-windows-image: env-AWS_REGION env-IMAGE_ID
 
 # Takes the mappings files and copies them into a generated stack template
 .PHONY: build/aws-stack.yml
-build/aws-stack.yml: build/mappings.yml
+build/aws-stack.yml:
 	test -f build/mappings.yml
 	awk '{ \
 		if ($$0 ~ /AWSRegion2AMI:/ && system("test -f build/mappings.yml") == 0) { \


### PR DESCRIPTION
Rendering `aws-stack.yml` depends on the `mappings.yml` file existing. I previously setup that dependency directly (see PR #706), however that broke CI where we want to manually manage the mappings.yml file.

This seems like it might be a way to ensure `make build` works in our development environment (as documented in the README) while also keeping the CI pipeline working.
