### PR TITLE
bump docker and docker-compose

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=19.03.5
+DOCKER_VERSION=19.03.13
 DOCKER_RELEASE="stable"
-DOCKER_COMPOSE_VERSION=1.25.1
+DOCKER_COMPOSE_VERSION=1.27.4
 
 # This performs a manual install of Docker.
 

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -1,10 +1,13 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$docker_version="19.03.5"
+$docker_version="19.03.12"
 
 Write-Output "Upgrading DockerMsftProvider module"
 Update-Module -Name DockerMsftProvider -Force
+
+Write-Output "Printing available docker versions"
+Find-Package -providerName DockerMsftProvider -AllVersions
 
 Write-Output "Installing docker enterprise edition"
 Stop-Service docker


### PR DESCRIPTION
* docker to 19.03.13 (linux) and 19.03.12 (windows)
* docker-compose to 1.27.4 (linux)
* docker-compose on windows is installed via chocolatey, and at the time of this commit is version 1.27.2
    
v4.5.0 of the elastic stack was released with docker 19.03.12 and docker-compose 1.25.1 - the upcoming release should use at least the same versions.
    
I've bumped them a little higher that what was in v4.5.0, but only to versions I consider relatively low risk.