### PR TITLE
Wrap exit handler with exit code check to resolve #720

### DIFF
--- a/packer/linux/conf/buildkite-agent/scripts/service-exit-handler
+++ b/packer/linux/conf/buildkite-agent/scripts/service-exit-handler
@@ -12,4 +12,3 @@ fi
 
 echo "Service exited normally, attempting to shut down EC2 instance" | logger
 ./terminate-instance
-/bin/sudo poweroff

--- a/packer/linux/conf/buildkite-agent/scripts/service-exit-handler
+++ b/packer/linux/conf/buildkite-agent/scripts/service-exit-handler
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 echo "Buildkite agent service stopped, entered service-exit-handler" | logger

--- a/packer/linux/conf/buildkite-agent/scripts/service-exit-handler
+++ b/packer/linux/conf/buildkite-agent/scripts/service-exit-handler
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -euo pipefail
+
+echo "Buildkite agent service stopped, entered service-exit-handler" | logger
+systemctl is-failed buildkite-agent.service | logger
+echo "Service result: $SERVICE_RESULT Exit code: $EXIT_CODE Exit status: $EXIT_STATUS" | logger
+
+if [[ $EXIT_CODE != 0 ]]; then
+  echo "Service exited abnormally, systemd will try to restart it in 5 seconds" | logger
+  exit 0
+fi
+
+echo "Service exited normally, attempting to shut down EC2 instance" | logger
+./terminate-instance
+/bin/sudo poweroff

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -12,8 +12,7 @@ Environment="HOME=/var/lib/buildkite-agent"
 Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 Environment="USER=buildkite-agent"
 ExecStart=/usr/bin/buildkite-agent start
-ExecStopPost=/usr/local/bin/terminate-instance
-ExecStopPost=/bin/sudo poweroff
+ExecStopPost=/usr/local/bin/service-exit-handler
 RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -60,6 +60,7 @@ sudo cp /tmp/conf/buildkite-agent/systemd/cloud-final.service.d/10-power-off-on-
 
 echo "Adding termination scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/stop-agent-gracefully /usr/local/bin/stop-agent-gracefully
+sudo cp /tmp/conf/buildkite-agent/scripts/service-exit-handler /usr/local/bin/service-exit-handler
 sudo cp /tmp/conf/buildkite-agent/scripts/terminate-instance /usr/local/bin/terminate-instance
 
 echo "Copying built-in plugins..."


### PR DESCRIPTION
**Problem**: systemd's [`ExecStopPost`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStopPost=) gets run in all cases, including where the service exited unexpectedly (non-zero exit code) as it is intended for cleanup behaviour.

This PR implements a script to wrap `terminate-instance` (which I did not want to modify) in a script to gracefully handle the branching logic between standard agent `exit 0` (which should terminate the instance) and non-zero exit codes (which should restart the agent and leave the instance as-is).

This is a change we should consider backporting to v4.5.