### PR TITLE
update agent config: tags-from-ec2 -> tags-from-ec2-meta-data

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -112,7 +112,7 @@ cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
 token="${BUILDKITE_AGENT_TOKEN}"
 tags=$(IFS=, ; echo "${agent_metadata[*]}")
-tags-from-ec2=true
+tags-from-ec2-meta-data=true
 timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path=/etc/buildkite-agent/hooks
 build-path=/var/lib/buildkite-agent/builds

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -82,7 +82,7 @@ Set-Content -Path C:\buildkite-agent\buildkite-agent.cfg -Value @"
 name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%n"
 token="${Env:BUILDKITE_AGENT_TOKEN}"
 tags=$agent_metadata
-tags-from-ec2=true
+tags-from-ec2-meta-data=true
 timestamp-lines=${Env:BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path="C:\buildkite-agent\hooks"
 build-path="C:\buildkite-agent\builds"


### PR DESCRIPTION
I've noticed the following warning in log output of various stacks:

> The config option `tags-from-ec2` has been renamed to `tags-from-ec2-meta-data`. Please update your configuration.

The deprecation happened in agent 3.17.0 ([august 2019](https://github.com/buildkite/agent/pull/1067)) [1]. The stack ships with a more recent version and it seems unlikely anyone will jump through hoops to downgrade, so I think it's safe to use the newer flag.