### PR TITLE
stop trying to call poweroff after the agent shuts down

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -13,7 +13,6 @@ Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
 Environment="USER=buildkite-agent"
 ExecStart=/usr/bin/buildkite-agent start
 ExecStopPost=/usr/local/bin/terminate-instance
-ExecStopPost=/bin/sudo poweroff
 RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE


### PR DESCRIPTION
When the agent process exits cleanly, our goal is to shut the instance down and reduce the autoscaling group size by 1.

Currently, we do that by running two commands in sequence:

1. terminate-instance
2. sudo poweroff

I'm proposing we remove the poweroff call, for two reasons:

1. It's redundant. The terminate-instance script instructs the ASG to terminate this instance, and this often happens within 2-3 seconds.
2. If the ASG is a bit slow action the termination, the poweroff doesn't work anyway. The buildkite-user doesn't have the required permissions in /etc/sudoers to call poweroff, so we get the following in the system logs

> Oct 01 11:22:55 sudo[5090]: We trust you have received the usual lecture from the local System
> Oct 01 11:22:55 sudo[5090]: Administrator. It usually boils down to these three things:
> Oct 01 11:22:55 sudo[5090]: #1) Respect the privacy of others.
> Oct 01 11:22:55 sudo[5090]: #2) Think before you type.
> Oct 01 11:22:55 sudo[5090]: #3) With great power comes great responsibility.
> Oct 01 11:22:55 sudo[5090]: pam_unix(sudo:auth): conversation failed
> Oct 01 11:22:55 systemd[1]: buildkite-agent.service: control process exited, code=exited status=1
> Oct 01 11:22:55 sudo[5090]: sudo: no tty present and no askpass program specified
> Oct 01 11:22:55 sudo[5090]: pam_unix(sudo:auth): auth could not identify password for [buildkite-agent]
> Oct 01 11:22:55 systemd[1]: Unit buildkite-agent.service entered failed state.

When the ASG termination is slow and the above error happens, systemd considers the agent to have failed (even though the agent exited with status 0) and `Restart=on-failure` means the agent restarts. If the customer is unlucky, the restarted agent might even accept a new job just before the ASG terminates the instance.

Race conditions are fun!