### PR TITLE
add a 10sec pause before we request instance termination

### DIFF
--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -2,7 +2,13 @@
 
 set -euo pipefail
 
+echo "sleeping for 10 seconds before terminating instance to allow agent logs to drain to cloudwatch..."
+
+sleep 10
+
 instance_id=$(curl -fsSL http://169.254.169.254/latest/meta-data/instance-id)
 region=$(curl -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
+
+echo "requesting instance termination..."
 
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity" || true


### PR DESCRIPTION
When the buildkite-agent exits cleanly (generally after an idle timeout), we ask the ASG to terminate the instance. The termination can happen *very* quickly, oftern within 2-3 seconds.

We use the legacy awslogs tool[1] to send logs to cloudwatch, and it buffers new logs for 5 seconds (or 32Kb, whichever comes first).

This results in a race condition - often the final logs from the agent as it shutdown may not make it to cloudwatch before the instance shuts down.

Long term we assume migrating from awslogs to the new cloudwatch agent might improve this situation. However, we don't plan to attempt that migration vor the v5 release and we'd like to improve the chances customers will have access to a full agent log in clouddwatch. Adding a 10 sec sleep before requesting termination is slightly-sad, but pragmatic option.

Note that this (sadly) won't resolve the race condition that prevents other useful logs from making it to cloudwatch, like the result of calling `aws autoscaling terminate-instance-in-auto-scaling-group` and systemd during shutdown