### PR TITLE
Propagate terminate-instance failure up to systemd again

### DIFF
--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -11,4 +11,4 @@ region=$(curl -fsSL http://169.254.169.254/latest/meta-data/placement/availabili
 
 echo "requesting instance termination..."
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity" || true
+aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity"


### PR DESCRIPTION
Revert #707, because we've now removed the `poweroff` call in #728 (because it wasn't working correctly anyway).

If we allow `terminate-instance` to fail silently, _and_ we don't have another `ExecStopPost` to ~shut down the instance~ _also exit non-zero_, the instance is left dead in the water: still consuming a slot in the ASG, but with no agent running, and nothing to get it out of that state.

We (re-)considered some other changes (e.g. make the `poweroff` actually work), but this seems like the best option available: if we fail to terminate the instance, then we pass the failure to systemd, which will in turn restart the agent (which, if necessary, might try to stop itself again sometime later). 

Most notably, `terminate-instance` will fail if stopping the instance would drop the ASG below its configured MinSize. This change will restore the previous behaviour (present up until #728), where the agent will reach its idle time, briefly remove itself from the agent pool by disconnecting from Buildkite, attempt `terminate-instance` [but fail], then restart the agent process and return to the pool (and then again wait out its idle timer before the cycle repeats).