### PR TITLE
Send SIGQUIT before spot termination time

### DIFF
--- a/packer/linux/conf/buildkite-agent/scripts/stop-agent-gracefully
+++ b/packer/linux/conf/buildkite-agent/scripts/stop-agent-gracefully
@@ -4,13 +4,44 @@ set -eu -o pipefail
 # Import BUILDKITE_AGENTS_PER_INSTANCE
 eval "$(cat /var/lib/buildkite-agent/cfn-env)"
 
-echo "Stopping buildkite-agent gracefully"
-systemctl stop "buildkite-agent"
+LIFECYCLE_TRANSITION=${1:-}
 
-# Need to ensure it's the buildkite-agent user, so it doesn't match this lifecycled handler script
-while pgrep -u buildkite-agent buildkite-agent > /dev/null; do
-  echo "Waiting for all buildkite-agent processes to have stopped..."
-  sleep 5
-done
+echo "Stopping buildkite-agent gracefully due to the lifecycle transition: ${LIFECYCLE_TRANSITION}"
 
-echo "All buildkite-agent processes have stopped"
+if [ $LIFECYCLE_TRANSITION = "ec2:SPOT_INSTANCE_TERMINATION" ]; then
+  # Send SIGTERM to the main buildkite-agent process in a non-blocking manner
+  # to start a graceful shutdown
+  systemctl kill --kill-who=main --signal=SIGTERM buildkite-agent
+
+  SPOT_TERMINATION_TIME=$(curl http://169.254.169.254/latest/meta-data/spot/termination-time 2>/dev/null)
+  # Convert the RFC3339 spot termination time to a unix timestamp
+  SPOT_TERMINATION_UNIX=$(date '+%s' -d ${SPOT_TERMINATION_TIME})
+  # Subtracts 20 seconds from the published spot termination time to give the
+  # agent a little time to forcefully quit running jobs. If the agent doesn't
+  # gracefully quit before this time we will send SIGQUIT.
+  STOP_BY_UNIX=$(expr ${SPOT_TERMINATION_UNIX} - 20)
+
+  echo "Waiting for agents to quit gracefully until 20 seconds before the spot termination time: ${SPOT_TERMINATION_TIME}"
+  while [ $(date '+%s') -lt $STOP_BY_UNIX ]; do
+    if ! pgrep -u buildkite-agent buildkite-agent > /dev/null; then
+      echo "All buildkite agents have stopped gracefully"
+      exit 0
+    fi
+    sleep 1
+  done
+
+  # Agents are still running and we're close to time, so send SIGQUIT. We can let
+  # this script exit as spot will hard terminate in a matter of seconds.
+  echo "Agents are still running. Sending SIGQUIT ahead of forced spot termination at ${SPOT_TERMINATION_TIME}"
+  systemctl kill --kill-who=main --signal=SIGQUIT buildkite-agent
+else
+  systemctl stop "buildkite-agent"
+
+  # Need to ensure it's the buildkite-agent user, so it doesn't match this lifecycled handler script
+  while pgrep -u buildkite-agent buildkite-agent > /dev/null; do
+    echo "Waiting for all buildkite-agent processes to have stopped..."
+    sleep 5
+  done
+
+  echo "All buildkite-agent processes have stopped"
+fi

--- a/packer/linux/conf/buildkite-agent/scripts/stop-agent-gracefully
+++ b/packer/linux/conf/buildkite-agent/scripts/stop-agent-gracefully
@@ -8,21 +8,23 @@ LIFECYCLE_TRANSITION=${1:-}
 
 echo "Stopping buildkite-agent gracefully due to the lifecycle transition: ${LIFECYCLE_TRANSITION}"
 
-if [ $LIFECYCLE_TRANSITION = "ec2:SPOT_INSTANCE_TERMINATION" ]; then
+if [[ $LIFECYCLE_TRANSITION = "ec2:SPOT_INSTANCE_TERMINATION" ]]; then
   # Send SIGTERM to the main buildkite-agent process in a non-blocking manner
   # to start a graceful shutdown
   systemctl kill --kill-who=main --signal=SIGTERM buildkite-agent
 
-  SPOT_TERMINATION_TIME=$(curl http://169.254.169.254/latest/meta-data/spot/termination-time 2>/dev/null)
-  # Convert the RFC3339 spot termination time to a unix timestamp
-  SPOT_TERMINATION_UNIX=$(date '+%s' -d ${SPOT_TERMINATION_TIME})
+
+  # Spot termination time is provided as the third argument in RFC3339 format,
+  # i.e. 2020-10-09T01:33:10Z
+  SPOT_TERMINATION_TIME=$3
+  SPOT_TERMINATION_TIME_UNIX=$(date '+%s' -d ${SPOT_TERMINATION_TIME})
   # Subtracts 20 seconds from the published spot termination time to give the
   # agent a little time to forcefully quit running jobs. If the agent doesn't
   # gracefully quit before this time we will send SIGQUIT.
-  STOP_BY_UNIX=$(expr ${SPOT_TERMINATION_UNIX} - 20)
+  STOP_BY_TIME_UNIX=$(expr ${SPOT_TERMINATION_TIME_UNIX} - 20)
 
   echo "Waiting for agents to quit gracefully until 20 seconds before the spot termination time: ${SPOT_TERMINATION_TIME}"
-  while [ $(date '+%s') -lt $STOP_BY_UNIX ]; do
+  while [[ $(date '+%s') -lt $STOP_BY_TIME_UNIX ]]; do
     if ! pgrep -u buildkite-agent buildkite-agent > /dev/null; then
       echo "All buildkite agents have stopped gracefully"
       exit 0


### PR DESCRIPTION
This addresses #733 by capturing the lifecycle transition from the first script argument. If we're not terminating due to spot the script should behave as it did before. If we are terminating due to spot, we do the following:

1. Send SIGTERM to the master agent process in a non-blocking fashion
1. Calculate the unix timestamp 20 seconds before the spot termination time and consider this our STOP_TIME
1. Check to see if the agents stop gracefully before our STOP_TIME
1.  If the agents stop on their own, exit 0. If they don't, send `SIGQUIT` and let this script exit, you only have 20 seconds before termination anyway.

## Testing

I tested this by booting up a stack and manually destroying the scaling lambda as to not have anything provision agents outside this test. I then create a spot fleet requesting a single instance using the launch template from the stack, setting the networking and other settings to what the ASG would do. This should boot up a single spot instance. You can then jump onto the instance and tail the lifecycled logs `journalctl -f -t lifecycled`. Now decrement the spot flee to 0 while your test long running job is still running on the agent. This will trigger the normal spot termination process. AWS doesn't do a great job of documenting this method, but you can find it here - https://ec2spotworkshops.com/running_spark_apps_with_emr_on_spot_instances/tracking_spot_interruptions.html#verifying-that-the-notification-works.

You should see the long running job eventually forcefully killed by `SIGQUIT` 20 seconds before the spot termination will ultimately terminate the instance. You can also repeat this test, manually cancelling the long running job to test the script detecting the graceful shutdown of the agent.

