### PR TITLE
Configure Windows service exit like the unix service

### DIFF
--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -170,7 +170,7 @@ nssm set buildkite-agent AppEnvironmentExtra :HOME=C:\buildkite-agent
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppExit Default Restart
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
-nssm set buildkite-agent AppRestartDelay 5000
+nssm set buildkite-agent AppRestartDelay 10000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -168,7 +168,9 @@ nssm set buildkite-agent AppStderr C:\buildkite-agent\buildkite-agent.log
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppEnvironmentExtra :HOME=C:\buildkite-agent
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
-nssm set buildkite-agent AppExit Default Exit
+nssm set buildkite-agent AppExit Default Restart
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+nssm set buildkite-agent AppRestartDelay 5000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -172,7 +172,7 @@ nssm set buildkite-agent AppExit Default Restart
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppRestartDelay 5000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
-nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1 3>&1 2>&1 > C:\buildkite-agent\buildkite-agent.log"
+nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Restart-Service buildkite-agent

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -172,7 +172,7 @@ nssm set buildkite-agent AppExit Default Restart
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppRestartDelay 5000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
-nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
+nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1 3>&1 2>&1 > C:\buildkite-agent\buildkite-agent.log"
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Restart-Service buildkite-agent

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -9,3 +9,11 @@ $Region = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta
 
 Write-Output "terminate-instance: requesting instance termination..."
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity"
+
+if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will terminate
+  Write-Output "terminate-instance: disabling buildkite-agent service"
+  nssm stop buildkite-agent
+}
+else {
+  Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
+}

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,9 +1,11 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
+Write-Output "terminate-instance: waiting for 10 seconds to allow agent logs to drain to Cloudwatch..."
+Start-Sleep -Seconds 10
+
 $InstanceId = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
 $Region = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
 
+Write-Output "terminate-instance: requesting instance termination..."
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity"
-
-Stop-Computer $env:computername -Force

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -13,4 +13,5 @@ if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will term
 }
 else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
+  nssm start buildkite-agent
 }

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,6 +1,3 @@
-Write-Output "terminate-instance: waiting for 10 seconds to allow agent logs to drain to Cloudwatch..."
-Start-Sleep -Seconds 10
-
 $InstanceId = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
 $Region = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
 

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -5,7 +5,7 @@ $InstanceId = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/
 $Region = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
 
 Write-Output "terminate-instance: requesting instance termination..."
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity"
+aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity" 2> $null
 
 if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will terminate
   Write-Output "terminate-instance: disabling buildkite-agent service"
@@ -13,5 +13,4 @@ if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will term
 }
 else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
-  nssm start buildkite-agent
 }

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,6 +1,3 @@
-# Stop script execution when a non-terminating error occurs
-$ErrorActionPreference = "Stop"
-
 Write-Output "terminate-instance: waiting for 10 seconds to allow agent logs to drain to Cloudwatch..."
 Start-Sleep -Seconds 10
 


### PR DESCRIPTION
There's a known issue around the lambda scaling behaviour and when the stack's MinSize is greater than 0 (see #712). On unix, the Buildkite service will exit on idletimeout, but restart as configured in the `systemd` service configuration. On Windows, we never restart, so the instance will end and the ASG will provision us a fresh instance. This is way more disruptive and time consuming, and leads to a lot of resource churn in AWS. While we continue to investigate the underlying issue, we're hopeful that configuring the Windows service the same way as the unix one will reduce the severity of the problem.

Our Windows service is configured through `nssm` (the "non-sucking" service manager). This service manager features the following properties to help us resolve this:
- The action to take when exiting (includes to restart) https://nssm.cc/usage#exit
- The delay to wait before restarting (ms) https://nssm.cc/usage#delay

These options have straightforward command equivalents
```powershell
nssm set UT2003 AppExit Default Restart
nssm set UT2003 AppRestartDelay 0
```

I'll update this PR with results of Windows agent testing for this behaviour. I will focus only on on-demand agents for this test. This PR should resolve #712