### PR TITLE
Experimental support for running linux ARM instances

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -132,7 +132,7 @@ steps:
     depends_on: "linux-launch"
 
   - id: "packer-linux-arm64"
-    name: ":packer: :linux: :arm:"
+    name: ":packer: :linux: 💪"
     command: .buildkite/steps/packer.sh linux arm64
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
@@ -144,7 +144,7 @@ steps:
       - "s3secrets-helper-linux-arm64"
 
   - id: "linux-arm64-launch"
-    name: ":cloudformation: :linux: :arm: Launch"
+    name: ":cloudformation: :linux: 💪 Launch"
     command: .buildkite/steps/launch.sh linux arm64
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
@@ -152,7 +152,7 @@ steps:
     depends_on: "packer-linux-arm64"
 
   - id: "linux-arm64-test"
-    name: ":cloudformation: :linux: :arm: Test"
+    name: ":cloudformation: :linux: 💪 Test"
     command: "goss validate --format documentation"
     timeout_in_minutes: 5
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,7 +85,7 @@ steps:
       - "bats-tests"
       - "s3secrets-helper-windows-amd64"
 
-  - id: "windows-launch"
+  - id: "launch-windows"
     name: ":cloudformation: :windows: Launch"
     command: .buildkite/steps/launch.sh windows
     agents:
@@ -93,17 +93,17 @@ steps:
     artifact_paths: "build/aws-stack.yml"
     depends_on: "packer-windows"
 
-  - id: "windows-test"
+  - id: "test-windows"
     name: ":cloudformation: :windows: Test"
     command: "docker info"
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: "windows-launch"
+    depends_on: "launch-windows"
 
-  - id: "packer-linux"
-    name: ":packer: :linux:"
+  - id: "packer-linux-amd64"
+    name: ":packer: :linux: AMD64"
     command: .buildkite/steps/packer.sh linux
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
@@ -114,25 +114,25 @@ steps:
       - "bats-tests"
       - "s3secrets-helper-linux-amd64"
 
-  - id: "linux-launch"
-    name: ":cloudformation: :linux: Launch"
+  - id: "launch-linux-amd64"
+    name: ":cloudformation: :linux: AMD64 Launch"
     command: .buildkite/steps/launch.sh linux
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
-    depends_on: "packer-linux"
+    depends_on: "packer-linux-amd64"
 
-  - id: "linux-test"
-    name: ":cloudformation: :linux: Test"
+  - id: "test-linux-amd64"
+    name: ":cloudformation: :linux: AMD64 Test"
     command: "goss validate --format documentation"
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: "linux-launch"
+    depends_on: "launch-linux-amd64"
 
   - id: "packer-linux-arm64"
-    name: ":packer: :linux: 💪"
+    name: ":packer: :linux: ARM64"
     command: .buildkite/steps/packer.sh linux arm64
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
@@ -143,22 +143,22 @@ steps:
       - "bats-tests"
       - "s3secrets-helper-linux-arm64"
 
-  - id: "linux-arm64-launch"
-    name: ":cloudformation: :linux: 💪 Launch"
+  - id: "launch-linux-arm64"
+    name: ":cloudformation: :linux: ARM64 Launch"
     command: .buildkite/steps/launch.sh linux arm64
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
     depends_on: "packer-linux-arm64"
 
-  - id: "linux-arm64-test"
-    name: ":cloudformation: :linux: 💪 Test"
+  - id: "test-linux-arm64"
+    name: ":cloudformation: :linux: ARM64 Test"
     command: "goss validate --format documentation"
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: "linux-arm64-launch"
+    depends_on: "launch-linux-arm64"
 
   - id: "copy-ami"
     name: ":cloudformation: 🚚 🌎"
@@ -167,9 +167,9 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/mappings.yml"
     depends_on:
-      - "linux-test"
-      - "linux-arm64-test"
-      - "windows-test"
+      - "test-linux-amd64"
+      - "test-linux-arm64"
+      - "test-windows"
 
   - id: "publish"
     name: ":cloudformation: :rocket:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,6 +35,25 @@ steps:
     artifact_paths:
       - build/s3secrets-helper-linux-amd64
 
+  - id: "s3secrets-helper-linux-arm64"
+    name: ":golang: :linux: s3secrets-helper-linux-arm64"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    plugins:
+      docker#v3.7.0:
+        image: "golang:1.15"
+        mount-checkout: false
+        volumes:
+          - "./build:/build:rw"
+          - "./plugins/secrets/s3secrets-helper:/s3secrets-helper:ro"
+        workdir: /s3secrets-helper
+        environment:
+          - "GOOS=linux"
+          - "GOARCH=arm64"
+        command: ["go", "build", "-o", "/build/s3secrets-helper-linux-arm64"]
+    artifact_paths:
+      - build/s3secrets-helper-linux-arm64
+
   - id: "s3secrets-helper-windows-amd64"
     name: ":golang: :windows: s3secrets-helper-windows-amd64.exe"
     agents:
@@ -79,8 +98,8 @@ steps:
     command: "docker info"
     timeout_in_minutes: 5
     agents:
-      stack: "buildkite-aws-stack-test-windows-${BUILDKITE_BUILD_NUMBER}"
-      queue: "testqueue-windows-${BUILDKITE_BUILD_NUMBER}"
+      stack: "buildkite-aws-stack-test-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
+      queue: "testqueue-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
     depends_on: "windows-launch"
 
   - id: "packer-linux"
@@ -108,9 +127,38 @@ steps:
     command: "goss validate --format documentation"
     timeout_in_minutes: 5
     agents:
-      stack: "buildkite-aws-stack-test-linux-${BUILDKITE_BUILD_NUMBER}"
-      queue: "testqueue-linux-${BUILDKITE_BUILD_NUMBER}"
+      stack: "buildkite-aws-stack-test-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
+      queue: "testqueue-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
     depends_on: "linux-launch"
+
+  - id: "packer-linux-arm64"
+    name: ":packer: :linux: :arm:"
+    command: .buildkite/steps/packer.sh linux arm64
+    timeout_in_minutes: 60
+    retry: { automatic: { limit: 3 } }
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    depends_on:
+      - "lint"
+      - "bats-tests"
+      - "s3secrets-helper-linux-arm64"
+
+  - id: "linux-arm64-launch"
+    name: ":cloudformation: :linux: :arm: Launch"
+    command: .buildkite/steps/launch.sh linux arm64
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    artifact_paths: "build/aws-stack.yml"
+    depends_on: "packer-linux-arm64"
+
+  - id: "linux-arm64-test"
+    name: ":cloudformation: :linux: :arm: Test"
+    command: "goss validate --format documentation"
+    timeout_in_minutes: 5
+    agents:
+      stack: "buildkite-aws-stack-test-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
+      queue: "testqueue-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
+    depends_on: "linux-arm64-launch"
 
   - id: "copy-ami"
     name: ":cloudformation: 🚚 🌎"
@@ -120,6 +168,7 @@ steps:
     artifact_paths: "build/mappings.yml"
     depends_on:
       - "linux-test"
+      - "linux-arm64-test"
       - "windows-test"
 
   - id: "publish"

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -138,13 +138,13 @@ windows_amd64_source_image_name=$(get_image_name "$windows_amd64_source_image_id
 # Copy to all other regions
 for region in ${ALL_REGIONS[*]}; do
   if [[ $region != "$source_region" ]] ; then
-    echo "--- Copying :linux: $linux_amd64_source_image_id to $region" >&2
+    echo "--- :linux: Copying Linux AMD64 $linux_amd64_source_image_id to $region" >&2
     IMAGES+=("$(copy_ami_to_region "$linux_amd64_source_image_id" "$source_region" "$region" "${linux_amd64_source_image_name}-${region}")")
 
-    echo "--- Copying :linux: :arm: $linux_arm64_source_image_id to $region" >&2
+    echo "--- :linux: Copying Linux ARM64 $linux_arm64_source_image_id to $region" >&2
     IMAGES+=("$(copy_ami_to_region "$linux_arm64_source_image_id" "$source_region" "$region" "${linux_arm64_source_image_name}-${region}")")
 
-    echo "--- Copying :windows: $windows_amd64_source_image_id to $region" >&2
+    echo "--- :windows: Copying Windows AMD64 $windows_amd64_source_image_id to $region" >&2
     IMAGES+=("$(copy_ami_to_region "$windows_amd64_source_image_id" "$source_region" "$region" "${windows_amd64_source_image_name}-${region}")")
   else
     IMAGES+=("$linux_amd64_source_image_id" "$linux_arm64_source_image_id" "$windows_amd64_source_image_id")
@@ -169,7 +169,7 @@ for region in ${ALL_REGIONS[*]}; do
 
   # Make the linux AMI public if it's not the source image
   if [[ $linux_amd64_image_id != "$linux_amd64_source_image_id" ]] ; then
-    echo "Making :linux: ${linux_amd64_image_id} public" >&2
+    echo ":linux: Making Linux AMD64 ${linux_amd64_image_id} public" >&2
     make_ami_public "$linux_amd64_image_id" "$region"
   fi
 
@@ -177,7 +177,7 @@ for region in ${ALL_REGIONS[*]}; do
 
   # Make the linux ARM AMI public if it's not the source image
   if [[ $linux_arm64_image_id != "$linux_arm64_source_image_id" ]] ; then
-    echo "Making :linux: :arm: ${linux_arm64_image_id} public" >&2
+    echo ":linux: Making Linux ARM64 ${linux_arm64_image_id} public" >&2
     make_ami_public "$linux_arm64_image_id" "$region"
   fi
 
@@ -185,7 +185,7 @@ for region in ${ALL_REGIONS[*]}; do
 
   # Make the windows AMI public if it's not the source image
   if [[ $windows_amd64_image_id != "$windows_amd64_source_image_id" ]] ; then
-    echo "Making :windows: ${windows_amd64_image_id} public" >&2
+    echo ":windows: Making Windows AMD64 ${windows_amd64_image_id} public" >&2
     make_ami_public "$windows_amd64_image_id" "$region"
   fi
 

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -91,16 +91,18 @@ IMAGES=(
 )
 
 # Configuration
-linux_source_image_id="${1:-}"
-windows_source_image_id="${2:-}"
+linux_amd64_source_image_id="${1:-}"
+linux_arm64_source_image_id="${1:-}"
+windows_amd64_source_image_id="${2:-}"
 
 source_region="${AWS_REGION}"
 mapping_file="build/mappings.yml"
 
 # Read the source images from meta-data if no arguments are provided
 if [ $# -eq 0 ] ; then
-    linux_source_image_id=$(buildkite-agent meta-data get "linux_image_id")
-    windows_source_image_id=$(buildkite-agent meta-data get "windows_image_id")
+    linux_amd64_source_image_id=$(buildkite-agent meta-data get "linux_amd64_image_id")
+    linux_arm64_source_image_id=$(buildkite-agent meta-data get "linux_arm64_image_id")
+    windows_amd64_source_image_id=$(buildkite-agent meta-data get "windows_amd64_image_id")
 fi
 
 # If we're not on the master branch or a tag build skip the copy
@@ -110,15 +112,16 @@ if [[ $BUILDKITE_BRANCH != "master" ]] && [[ "$BUILDKITE_TAG" != "$BUILDKITE_BRA
   cat << EOF > "$mapping_file"
 Mappings:
   AWSRegion2AMI:
-    ${AWS_REGION} : { linux: $linux_source_image_id, windows: $windows_source_image_id }
+    ${AWS_REGION} : { linux: $linux_amd64_source_image_id, linuxarm: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id }
 EOF
   exit 0
 fi
 
-s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s.yml" \
+s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
   "${BUILDKITE_AWS_STACK_BUCKET}" \
-  "${linux_source_image_id}" \
-  "${windows_source_image_id}" \
+  "${linux_amd64_source_image_id}" \
+  "${linux_arm64_source_image_id}" \
+  "${windows_amd64_source_image_id}" \
   "${BUILDKITE_BRANCH}")
 
 # Check if there is a previously copy in the cache bucket
@@ -128,19 +131,23 @@ if aws s3 cp "${s3_mappings_cache}" "$mapping_file" ; then
 fi
 
 # Get the image names to copy to other regions
-linux_source_image_name=$(get_image_name "$linux_source_image_id" "$source_region")
-windows_source_image_name=$(get_image_name "$windows_source_image_id" "$source_region")
+linux_amd64_source_image_name=$(get_image_name "$linux_amd64_source_image_id" "$source_region")
+linux_arm64_source_image_name=$(get_image_name "$linux_arm64_source_image_id" "$source_region")
+windows_amd64_source_image_name=$(get_image_name "$windows_amd64_source_image_id" "$source_region")
 
 # Copy to all other regions
 for region in ${ALL_REGIONS[*]}; do
   if [[ $region != "$source_region" ]] ; then
-    echo "--- Copying :linux: $linux_source_image_id to $region" >&2
-    IMAGES+=("$(copy_ami_to_region "$linux_source_image_id" "$source_region" "$region" "${linux_source_image_name}-${region}")")
+    echo "--- Copying :linux: $linux_amd64_source_image_id to $region" >&2
+    IMAGES+=("$(copy_ami_to_region "$linux_amd64_source_image_id" "$source_region" "$region" "${linux_amd64_source_image_name}-${region}")")
 
-    echo "--- Copying :windows: $windows_source_image_id to $region" >&2
-    IMAGES+=("$(copy_ami_to_region "$windows_source_image_id" "$source_region" "$region" "${windows_source_image_name}-${region}")")
+    echo "--- Copying :linux: :arm: $linux_arm64_source_image_id to $region" >&2
+    IMAGES+=("$(copy_ami_to_region "$linux_arm64_source_image_id" "$source_region" "$region" "${linux_arm64_source_image_name}-${region}")")
+
+    echo "--- Copying :windows: $windows_amd64_source_image_id to $region" >&2
+    IMAGES+=("$(copy_ami_to_region "$windows_amd64_source_image_id" "$source_region" "$region" "${windows_amd64_source_image_name}-${region}")")
   else
-    IMAGES+=("$linux_source_image_id" "$windows_source_image_id")
+    IMAGES+=("$linux_amd64_source_image_id" "$linux_arm64_source_image_id" "$windows_amd64_source_image_id")
   fi
 done
 
@@ -154,30 +161,39 @@ EOF
 echo "--- Waiting for AMIs to become available"  >&2
 
 for region in ${ALL_REGIONS[*]}; do
-  linux_image_id="${IMAGES[0]}"
-  windows_image_id="${IMAGES[1]}"
+  linux_amd64_image_id="${IMAGES[0]}"
+  linux_arm64_image_id="${IMAGES[1]}"
+  windows_amd64_image_id="${IMAGES[2]}"
 
-  wait_for_ami_to_be_available "$linux_image_id" "$region" >&2
+  wait_for_ami_to_be_available "$linux_amd64_image_id" "$region" >&2
 
   # Make the linux AMI public if it's not the source image
-  if [[ $linux_image_id != "$linux_source_image_id" ]] ; then
-    echo "Making :linux: ${linux_image_id} public" >&2
-    make_ami_public "$linux_image_id" "$region"
+  if [[ $linux_amd64_image_id != "$linux_amd64_source_image_id" ]] ; then
+    echo "Making :linux: ${linux_amd64_image_id} public" >&2
+    make_ami_public "$linux_amd64_image_id" "$region"
   fi
 
-  wait_for_ami_to_be_available "$windows_image_id" "$region" >&2
+  wait_for_ami_to_be_available "$linux_arm64_image_id" "$region" >&2
+
+  # Make the linux ARM AMI public if it's not the source image
+  if [[ $linux_arm64_image_id != "$linux_arm64_source_image_id" ]] ; then
+    echo "Making :linux: :arm: ${linux_arm64_image_id} public" >&2
+    make_ami_public "$linux_arm64_image_id" "$region"
+  fi
+
+  wait_for_ami_to_be_available "$windows_amd64_image_id" "$region" >&2
 
   # Make the windows AMI public if it's not the source image
-  if [[ $windows_image_id != "$windows_source_image_id" ]] ; then
-    echo "Making :windows: ${windows_image_id} public" >&2
-    make_ami_public "$windows_image_id" "$region"
+  if [[ $windows_amd64_image_id != "$windows_amd64_source_image_id" ]] ; then
+    echo "Making :windows: ${windows_amd64_image_id} public" >&2
+    make_ami_public "$windows_amd64_image_id" "$region"
   fi
 
   # Write yaml to file
-  echo "    $region : { linux: $linux_image_id, windows: $windows_image_id }"  >> "$mapping_file"
+  echo "    $region : { linux: $linux_amd64_image_id, linuxarm: $linux_arm64_image_id, windows: $windows_amd64_image_id }"  >> "$mapping_file"
 
   # Shift off the processed images
-  IMAGES=("${IMAGES[@]:2}")
+  IMAGES=("${IMAGES[@]:3}")
 done
 
 echo "--- Uploading mapping to s3 cache"

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -112,7 +112,7 @@ if [[ $BUILDKITE_BRANCH != "master" ]] && [[ "$BUILDKITE_TAG" != "$BUILDKITE_BRA
   cat << EOF > "$mapping_file"
 Mappings:
   AWSRegion2AMI:
-    ${AWS_REGION} : { linux: $linux_amd64_source_image_id, linuxarm: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id }
+    ${AWS_REGION} : { linux_amd64: $linux_amd64_source_image_id, linux_arm64: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id }
 EOF
   exit 0
 fi
@@ -190,7 +190,7 @@ for region in ${ALL_REGIONS[*]}; do
   fi
 
   # Write yaml to file
-  echo "    $region : { linux: $linux_amd64_image_id, linuxarm: $linux_arm64_image_id, windows: $windows_amd64_image_id }"  >> "$mapping_file"
+  echo "    $region : { linux_amd64: $linux_amd64_image_id, linux_arm64: $linux_arm64_image_id, windows: $windows_amd64_image_id }"  >> "$mapping_file"
 
   # Shift off the processed images
   IMAGES=("${IMAGES[@]:3}")

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -7,8 +7,9 @@ if [[ -z "${BUILDKITE_AWS_STACK_BUCKET}" ]] ; then
 fi
 
 os="${1:-linux}"
-agent_binary="buildkite-agent-${os}-amd64"
-s3secrets_binary="s3secrets-helper-${os}-amd64"
+arch="${2:-amd64}"
+agent_binary="buildkite-agent-${os}-${arch}"
+s3secrets_binary="s3secrets-helper-${os}-${arch}"
 
 if [[ "$os" == "windows" ]] ; then
   agent_binary+=".exe"
@@ -23,16 +24,16 @@ buildkite-agent artifact download "build/$s3secrets_binary" .
 packer_files_sha=$(find Makefile "packer/${os}" plugins/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
 stable_agent_sha=$(curl -Lfs "https://download.buildkite.com/agent/stable/latest/${agent_binary}.sha256")
 unstable_agent_sha=$(curl -Lfs "https://download.buildkite.com/agent/unstable/latest/${agent_binary}.sha256")
-packer_hash=$(echo "$packer_files_sha" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
+packer_hash=$(echo "$packer_files_sha" "$arch" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
 
-echo "Packer image hash for ${os} is ${packer_hash}"
-packer_file="packer-${packer_hash}-${os}.output"
+echo "Packer image hash for ${os}/${arch} is ${packer_hash}"
+packer_file="packer-${packer_hash}-${os}-${arch}.output"
 
 # Only build packer image if one with the same hash doesn't exist, and we're not being forced
 if [[ -n "${PACKER_REBUILD:-}" ]] || ! aws s3 cp "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}" . ; then
-  make "packer-${os}.output"
-  aws s3 cp "packer-${os}.output" "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}"
-  mv "packer-${os}.output" "${packer_file}"
+  make "packer-${os}-${arch}.output"
+  aws s3 cp "packer-${os}-${arch}.output" "s3://${BUILDKITE_AWS_STACK_BUCKET}/${packer_file}"
+  mv "packer-${os}-${arch}.output" "${packer_file}"
 else
   echo "Skipping packer build, no changes"
 fi
@@ -41,4 +42,4 @@ fi
 image_id=$(grep -Eo "${AWS_REGION}: (ami-.+)$" "$packer_file" | awk '{print $2}')
 echo "AMI for ${AWS_REGION} is $image_id"
 
-buildkite-agent meta-data set "${os}_image_id" "$image_id"
+buildkite-agent meta-data set "${os}_${arch}_image_id" "$image_id"

--- a/Makefile
+++ b/Makefile
@@ -34,19 +34,19 @@ build: packer build/mappings.yml build/aws-stack.yml
 # Build a mapping file for a single region and image id pair
 mappings-for-linux-amd64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: %s, linuxarm: '', windows: '' }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: %s, linuxarm64: '', windows: '' }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Build a mapping file for a single region and image id pair
 mappings-for-linux-arm64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: '', linuxarm: %s, windows: '' }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: %s, windows: '' }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Build a windows mapping file for a single region and image id pair
 mappings-for-windows-amd64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: '', linuxarm: '', windows: %s }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: '', windows: %s }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Takes the mappings files and copies them into a generated stack template
@@ -68,7 +68,7 @@ packer: packer-linux-amd64.output packer-linux-arm64.output packer-windows-amd64
 
 build/mappings.yml: build/linux-amd64-ami.txt build/linux-arm64-ami.txt build/windows-amd64-ami.txt
 	mkdir -p build
-	printf "Mappings:\n  AWSRegion2AMI:\n    %q : { linux: %q, linuxarm: %q, windows: %q }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %q : { linuxamd64: %q, linuxarm64: %q, windows: %q }\n" \
 		"$(AWS_REGION)" $$(cat build/linux-amd64-ami.txt) $$(cat build/linux-arm64-ami.txt) $$(cat build/windows-amd64-ami.txt) > $@
 
 build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
@@ -96,7 +96,7 @@ build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
 	mkdir -p build
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
-# Build linuxarm packer image
+# Build linuxarm64 packer image
 packer-linux-arm64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-arm64
 	docker run \
 		-e AWS_DEFAULT_REGION  \

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,8 @@ PACKER_WINDOWS_FILES = $(exec find packer/windows)
 AWS_REGION ?= us-east-1
 AMZN_LINUX2_AMI ?= $(shell aws ec2 describe-images --region $(AWS_REGION) --owners amazon --filters 'Name=name,Values=amzn2-ami-hvm-2.0.????????-x86_64-gp2' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')
 
-ARCH ?= x86_64
-ifeq ($(ARCH), arm64)
-  INSTANCE_TYPE = m6g.xlarge
-else
-  INSTANCE_TYPE = c5.xlarge
-endif
+ARM64_INSTANCE_TYPE = m6g.xlarge
+X86_INSTANCE_TYPE = c5.xlarge
 
 all: packer build
 
@@ -36,15 +32,21 @@ env-%:
 build: packer build/mappings.yml build/aws-stack.yml
 
 # Build a mapping file for a single region and image id pair
-mappings-for-linux-image: env-AWS_REGION env-IMAGE_ID
+mappings-for-linux-amd64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: %s, windows: '' }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: %s, linuxarm: '', windows: '' }\n" \
+		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
+
+# Build a mapping file for a single region and image id pair
+mappings-for-linux-arm64-image: env-AWS_REGION env-IMAGE_ID
+	mkdir -p build/
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: '', linuxarm: %s, windows: '' }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Build a windows mapping file for a single region and image id pair
-mappings-for-windows-image: env-AWS_REGION env-IMAGE_ID
+mappings-for-windows-amd64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: '', windows: %s }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linux: '', linuxarm: '', windows: %s }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Takes the mappings files and copies them into a generated stack template
@@ -62,19 +64,19 @@ build/aws-stack.yml:
 # -----------------------------------------
 # AMI creation with Packer
 
-packer: packer-linux.output packer-windows.output
+packer: packer-linux-amd64.output packer-linux-arm64.output packer-windows-amd64.output
 
-build/mappings.yml: build/linux-ami.txt build/windows-ami.txt
+build/mappings.yml: build/linux-amd64-ami.txt build/linux-arm64-ami.txt build/windows-amd64-ami.txt
 	mkdir -p build
-	printf "Mappings:\n  AWSRegion2AMI:\n    %q : { linux: %q, windows: %q }\n" \
-		"$(AWS_REGION)" $$(cat build/linux-ami.txt) $$(cat build/windows-ami.txt) > $@
+	printf "Mappings:\n  AWSRegion2AMI:\n    %q : { linux: %q, linuxarm: %q, windows: %q }\n" \
+		"$(AWS_REGION)" $$(cat build/linux-amd64-ami.txt) $$(cat build/linux-arm64-ami.txt) $$(cat build/windows-amd64-ami.txt) > $@
 
-build/linux-ami.txt: packer-linux.output env-AWS_REGION
+build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
 	mkdir -p build
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linux packer image
-packer-linux.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-amd64
+packer-linux-amd64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-amd64
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -87,15 +89,36 @@ packer-linux.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-amd64
 		--rm \
 		-w /src/packer/linux \
 		hashicorp/packer:$(PACKER_VERSION) build -timestamp-ui -var 'ami=$(AMZN_LINUX2_AMI)' -var 'region=$(AWS_REGION)' \
-			-var 'arch=$(ARCH)' -var 'instance_type=$(INSTANCE_TYPE)' \
+			-var 'arch=x86_64' -var 'instance_type=$(X86_INSTANCE_TYPE)' \
 			buildkite-ami.json | tee $@
 
-build/windows-ami.txt: packer-windows.output env-AWS_REGION
+build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
+	mkdir -p build
+	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
+
+# Build linuxarm packer image
+packer-linux-arm64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-arm64
+	docker run \
+		-e AWS_DEFAULT_REGION  \
+		-e AWS_PROFILE \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e PACKER_LOG \
+		-v ${HOME}/.aws:/root/.aws \
+		-v "$(PWD):/src" \
+		--rm \
+		-w /src/packer/linux \
+		hashicorp/packer:$(PACKER_VERSION) build -timestamp-ui -var 'ami=$(AMZN_LINUX2_AMI)' -var 'region=$(AWS_REGION)' \
+			-var 'arch=arm64' -var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
+			buildkite-ami.json | tee $@
+
+build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
 	mkdir -p build
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build windows packer image
-packer-windows.output: $(PACKER_WINDOWS_FILES) build/s3secrets-helper-windows-amd64.exe
+packer-windows-amd64.output: $(PACKER_WINDOWS_FILES) build/s3secrets-helper-windows-amd64.exe
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ packer-linux-amd64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-am
 		--rm \
 		-w /src/packer/linux \
 		hashicorp/packer:$(PACKER_VERSION) build -timestamp-ui -var 'ami=$(AMZN_LINUX2_AMI)' -var 'region=$(AWS_REGION)' \
-			-var 'arch=x86_64' -var 'instance_type=$(X86_INSTANCE_TYPE)' \
+			-var 'arch=x86_64' -var 'goarch=amd64' -var 'instance_type=$(X86_INSTANCE_TYPE)' \
 			buildkite-ami.json | tee $@
 
 build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
@@ -110,7 +110,7 @@ packer-linux-arm64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-ar
 		--rm \
 		-w /src/packer/linux \
 		hashicorp/packer:$(PACKER_VERSION) build -timestamp-ui -var 'ami=$(AMZN_LINUX2_AMI)' -var 'region=$(AWS_REGION)' \
-			-var 'arch=arm64' -var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
+			-var 'arch=arm64' -var 'goarch=arm64' -var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
 			buildkite-ami.json | tee $@
 
 build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ AWS_REGION ?= us-east-1
 AMZN_LINUX2_AMI ?= $(shell aws ec2 describe-images --region $(AWS_REGION) --owners amazon --filters 'Name=name,Values=amzn2-ami-hvm-2.0.????????-x86_64-gp2' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')
 
 ARM64_INSTANCE_TYPE = m6g.xlarge
-X86_INSTANCE_TYPE = c5.xlarge
+AMD64_INSTANCE_TYPE = c5.xlarge
 
 all: packer build
 
@@ -89,7 +89,7 @@ packer-linux-amd64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-am
 		--rm \
 		-w /src/packer/linux \
 		hashicorp/packer:$(PACKER_VERSION) build -timestamp-ui -var 'ami=$(AMZN_LINUX2_AMI)' -var 'region=$(AWS_REGION)' \
-			-var 'arch=x86_64' -var 'goarch=amd64' -var 'instance_type=$(X86_INSTANCE_TYPE)' \
+			-var 'arch=x86_64' -var 'goarch=amd64' -var 'instance_type=$(AMD64_INSTANCE_TYPE)' \
 			buildkite-ami.json | tee $@
 
 build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION

--- a/Makefile
+++ b/Makefile
@@ -184,5 +184,8 @@ generate-toc:
 build/s3secrets-helper-linux-amd64:
 	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=amd64 go build -o ../../../$@
 
+build/s3secrets-helper-linux-arm64:
+	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=arm64 go build -o ../../../$@
+
 build/s3secrets-helper-windows-amd64.exe:
 	cd plugins/secrets/s3secrets-helper && GOOD=windows GOARCH=amd64 go build -o ../../../$@

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ PACKER_WINDOWS_FILES = $(exec find packer/windows)
 AWS_REGION ?= us-east-1
 AMZN_LINUX2_AMI ?= $(shell aws ec2 describe-images --region $(AWS_REGION) --owners amazon --filters 'Name=name,Values=amzn2-ami-hvm-2.0.????????-x86_64-gp2' 'Name=state,Values=available' --output json | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId')
 
+ARCH ?= x86_64
+ifeq ($(ARCH), arm64)
+  INSTANCE_TYPE = m6g.xlarge
+else
+  INSTANCE_TYPE = c5.xlarge
+endif
+
 all: packer build
 
 # Remove any built cloudformation templates and packer output
@@ -80,6 +87,7 @@ packer-linux.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-amd64
 		--rm \
 		-w /src/packer/linux \
 		hashicorp/packer:$(PACKER_VERSION) build -timestamp-ui -var 'ami=$(AMZN_LINUX2_AMI)' -var 'region=$(AWS_REGION)' \
+			-var 'arch=$(ARCH)' -var 'instance_type=$(INSTANCE_TYPE)' \
 			buildkite-ami.json | tee $@
 
 build/windows-ami.txt: packer-windows.output env-AWS_REGION

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -1,7 +1,10 @@
 {
   "variables": {
-    "region": "us-east-1"
+    "region": "us-east-1",
+    "arch": "x86_64",
+    "instance_type": "m5.xlarge"
   },
+
   "builders": [
     {
       "type": "amazon-ebs",
@@ -9,15 +12,15 @@
       "source_ami_filter": {
         "filters": {
           "name": "amzn2-ami-hvm-2.0.*-gp2",
-          "architecture": "x86_64",
+          "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },
         "owners": ["amazon"],
         "most_recent": true
       },
-      "instance_type": "m5.xlarge",
+      "instance_type": "{{user `instance_type`}}",
       "ssh_username": "ec2-user",
-      "ami_name": "buildkite-stack-linux-{{isotime | clean_resource_name}}",
+      "ami_name": "buildkite-stack-linux-{{user `arch`}}-{{isotime | clean_resource_name}}",
       "ami_description": "Buildkite Elastic Stack (Amazon Linux 2 LTS w/ docker)",
       "ami_groups": ["all"]
     }

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -2,6 +2,7 @@
   "variables": {
     "region": "us-east-1",
     "arch": "x86_64",
+    "goarch": "amd64",
     "instance_type": "m5.xlarge"
   },
 
@@ -38,7 +39,7 @@
     },
     {
       "type": "file",
-      "source": "../../build/s3secrets-helper-linux-amd64",
+      "source": "../../build/s3secrets-helper-linux-{{user `goarch`}}",
       "destination": "/tmp/s3secrets-helper"
     },
     {

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -62,13 +62,18 @@ export PLUGINS_ENABLED="${PLUGINS_ENABLED[*]-}"
 export BUILDKITE_ECR_POLICY=${BUILDKITE_ECR_POLICY:-none}
 EOF
 
-#if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
-#	echo "Downloading buildkite-agent edge..."
-#	curl -Lsf -o /usr/bin/buildkite-agent-edge \
-#		"https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64"
-#	chmod +x /usr/bin/buildkite-agent-edge
-#	buildkite-agent-edge --version
-#fi
+if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
+	if [[ "$(uname -m)" == "aarch64" ]] ; then
+	  AGENT_ARCH="arm64"
+	else
+	  AGENT_ARCH="amd64"
+	fi
+	echo "Downloading buildkite-agent edge..."
+	curl -Lsf -o /usr/bin/buildkite-agent-edge \
+		"https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-${AGENT_ARCH}"
+	chmod +x /usr/bin/buildkite-agent-edge
+	buildkite-agent-edge --version
+fi
 
 if [[ "${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" != "" ]] ; then
   echo "buildkite-agent ALL=NOPASSWD: ${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" > /etc/sudoers.d/buildkite-agent-additional

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -62,13 +62,13 @@ export PLUGINS_ENABLED="${PLUGINS_ENABLED[*]-}"
 export BUILDKITE_ECR_POLICY=${BUILDKITE_ECR_POLICY:-none}
 EOF
 
-if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
-	echo "Downloading buildkite-agent edge..."
-	curl -Lsf -o /usr/bin/buildkite-agent-edge \
-		"https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64"
-	chmod +x /usr/bin/buildkite-agent-edge
-	buildkite-agent-edge --version
-fi
+#if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
+#	echo "Downloading buildkite-agent edge..."
+#	curl -Lsf -o /usr/bin/buildkite-agent-edge \
+#		"https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-amd64"
+#	chmod +x /usr/bin/buildkite-agent-edge
+#	buildkite-agent-edge --version
+#fi
 
 if [[ "${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" != "" ]] ; then
   echo "buildkite-agent ALL=NOPASSWD: ${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" > /etc/sudoers.d/buildkite-agent-additional

--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -9,6 +9,11 @@ BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY=$(mktemp -d)
 export BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY
 export DOCKER_CONFIG="$BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY"
 
+# on linux/arm64 we have to install docker-compose via pip, which
+# has a dependency on the cryptography package, which requires some
+# convincing to run with the version of openssl distributed with Amazon Linux 2
+export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
+
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 

--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -9,11 +9,6 @@ BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY=$(mktemp -d)
 export BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY
 export DOCKER_CONFIG="$BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY"
 
-# on linux/arm64 we have to install docker-compose via pip, which
-# has a dependency on the cryptography package, which requires some
-# convincing to run with the version of openssl distributed with Amazon Linux 2
-export CRYPTOGRAPHY_ALLOW_OPENSSL_102=true
-
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
 

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -20,12 +20,9 @@ sudo useradd --base-dir /var/lib --uid 2000 buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
-mkdir -p buildkite-agent
-curl -Lsf -o buildkite-agent-linux.tar.gz \
-  "https://github.com/buildkite/agent/releases/download/v${AGENT_VERSION}/buildkite-agent-linux-${ARCH}-${AGENT_VERSION}.tar.gz"
-tar -C buildkite-agent -xvzf buildkite-agent-linux.tar.gz
-sudo cp buildkite-agent/buildkite-agent /usr/bin/buildkite-agent-stable
-rm -fr buildkite-agent buildkite-agent-linux.tar.gz
+sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
+  "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"
+sudo chmod +x /usr/bin/buildkite-agent-stable
 buildkite-agent-stable --version
 
 echo "Downloading buildkite-agent beta..."

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 AGENT_VERSION=3.25.0
 
-MACHINE=`uname -m`
+MACHINE="$(uname -m)"
 
 case "${MACHINE}" in
 	x86_64)    ARCH=amd64;;

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -28,11 +28,11 @@ sudo cp buildkite-agent/buildkite-agent /usr/bin/buildkite-agent-stable
 rm -fr buildkite-agent buildkite-agent-linux.tar.gz
 buildkite-agent-stable --version
 
-#echo "Downloading buildkite-agent beta..."
-#sudo curl -Lsf -o /usr/bin/buildkite-agent-beta \
-#  "https://download.buildkite.com/agent/unstable/latest/buildkite-agent-linux-arm64"
-#sudo chmod +x /usr/bin/buildkite-agent-beta
-#buildkite-agent-beta --version
+echo "Downloading buildkite-agent beta..."
+sudo curl -Lsf -o /usr/bin/buildkite-agent-beta \
+  "https://download.buildkite.com/agent/unstable/latest/buildkite-agent-linux-${ARCH}"
+sudo chmod +x /usr/bin/buildkite-agent-beta
+buildkite-agent-beta --version
 
 echo "Adding scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/* /usr/bin

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -40,6 +40,9 @@ elif [[ "${MACHINE}" == "aarch64" ]]; then
   sudo yum install -y gcc-c++ libffi-devel openssl11 openssl11-devel python3-devel
   sudo pip3 install docker-compose
 	docker-compose version
+else
+  echo "No docker compose option configured for arch ${MACHINE}"
+  exit 1
 fi
 
 echo "Adding docker cron tasks..."

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -40,8 +40,6 @@ sudo cp /tmp/conf/docker/cron.hourly/docker-gc /etc/cron.hourly/docker-gc
 sudo cp /tmp/conf/docker/cron.hourly/docker-low-disk-gc /etc/cron.hourly/docker-low-disk-gc
 sudo chmod +x /etc/cron.hourly/docker-*
 
-echo "Downloading jq..."
-sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-sudo chmod +x /usr/bin/jq
+echo "Installing jq..."
+sudo yum install -y -q jq
 jq --version
-

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -37,9 +37,9 @@ if [ "${MACHINE}" == "x86_64" ]; then
 	sudo chmod +x /usr/bin/docker-compose
 	docker-compose --version
 elif [[ "${MACHINE}" == "aarch64" ]]; then
-  sudo yum install -y gcc-c++ libffi-devel openssl-devel python3-devel
+  sudo yum install -y gcc-c++ libffi-devel openssl11 openssl11-devel python3-devel
   sudo pip3 install docker-compose
-	CRYPTOGRAPHY_ALLOW_OPENSSL_102=true docker-compose version
+	docker-compose version
 fi
 
 echo "Adding docker cron tasks..."

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 DOCKER_VERSION=19.03.13
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.27.4
-MACHINE=`uname -m`
+MACHINE=$(uname -m)
 
 # This performs a manual install of Docker.
 
@@ -13,7 +13,7 @@ sudo groupadd docker
 sudo usermod -a -G docker ec2-user
 
 # Manual install ala https://docs.docker.com/engine/installation/binaries/
-curl -Lsf -o docker.tgz https://download.docker.com/linux/static/${DOCKER_RELEASE}/${MACHINE}/docker-${DOCKER_VERSION}.tgz
+curl -Lsf -o docker.tgz "https://download.docker.com/linux/static/${DOCKER_RELEASE}/${MACHINE}/docker-${DOCKER_VERSION}.tgz"
 tar -xvzf docker.tgz
 sudo mv docker/* /usr/bin
 rm docker.tgz
@@ -31,12 +31,12 @@ sudo curl -Lfs -o /etc/systemd/system/docker.socket https://raw.githubuserconten
 sudo systemctl daemon-reload
 sudo systemctl enable docker.service
 
-if [ ${MACHINE} == "x86_64" ]; then
+if [ "${MACHINE}" == "x86_64" ]; then
 	echo "Downloading docker-compose..."
 	sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
 	sudo chmod +x /usr/bin/docker-compose
 	docker-compose --version
-elif [[ ${MACHINE} == "aarch64" ]]; then
+elif [[ "${MACHINE}" == "aarch64" ]]; then
   sudo yum install -y gcc-c++ libffi-devel openssl-devel python3-devel
   sudo pip3 install docker-compose
 	CRYPTOGRAPHY_ALLOW_OPENSSL_102=true docker-compose version

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -4,6 +4,7 @@ set -eu -o pipefail
 DOCKER_VERSION=19.03.13
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.27.4
+MACHINE=`uname -m`
 
 # This performs a manual install of Docker.
 
@@ -12,7 +13,7 @@ sudo groupadd docker
 sudo usermod -a -G docker ec2-user
 
 # Manual install ala https://docs.docker.com/engine/installation/binaries/
-curl -Lsf -o docker.tgz https://download.docker.com/linux/static/${DOCKER_RELEASE}/x86_64/docker-${DOCKER_VERSION}.tgz
+curl -Lsf -o docker.tgz https://download.docker.com/linux/static/${DOCKER_RELEASE}/${MACHINE}/docker-${DOCKER_VERSION}.tgz
 tar -xvzf docker.tgz
 sudo mv docker/* /usr/bin
 rm docker.tgz
@@ -30,10 +31,12 @@ sudo curl -Lfs -o /etc/systemd/system/docker.socket https://raw.githubuserconten
 sudo systemctl daemon-reload
 sudo systemctl enable docker.service
 
-echo "Downloading docker-compose..."
-sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
-sudo chmod +x /usr/bin/docker-compose
-docker-compose --version
+if [ ${MACHINE} == "x86_64" ]; then
+	echo "Downloading docker-compose..."
+	sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
+	sudo chmod +x /usr/bin/docker-compose
+	docker-compose --version
+fi
 
 echo "Adding docker cron tasks..."
 sudo cp /tmp/conf/docker/cron.hourly/docker-gc /etc/cron.hourly/docker-gc

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -36,6 +36,10 @@ if [ ${MACHINE} == "x86_64" ]; then
 	sudo curl -Lsf -o /usr/bin/docker-compose https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-Linux-x86_64
 	sudo chmod +x /usr/bin/docker-compose
 	docker-compose --version
+elif [[ ${MACHINE} == "aarch64" ]]; then
+  sudo yum install -y gcc-c++ libffi-devel openssl-devel python3-devel
+  sudo pip3 install docker-compose
+	CRYPTOGRAPHY_ALLOW_OPENSSL_102=true docker-compose version
 fi
 
 echo "Adding docker cron tasks..."

--- a/packer/linux/scripts/install-git-lfs.sh
+++ b/packer/linux/scripts/install-git-lfs.sh
@@ -2,8 +2,16 @@
 
 GIT_LFS_RELEASE="2.10.0"
 
+MACHINE=`uname -m`
+
+case "${MACHINE}" in
+	x86_64)    ARCH=amd64;;
+	aarch64)   ARCH=arm64;;
+	*)         ARCH=unknown;;
+esac
+
 echo "Installing git lfs ${GIT_LFS_RELEASE}..."
-curl -Lsf -o git-lfs.tgz https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_RELEASE}/git-lfs-linux-amd64-v${GIT_LFS_RELEASE}.tar.gz
+curl -Lsf -o git-lfs.tgz https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_RELEASE}/git-lfs-linux-${ARCH}-v${GIT_LFS_RELEASE}.tar.gz
 mkdir git-lfs
 tar -xvzf git-lfs.tgz -C git-lfs
 sudo chmod 755 git-lfs/git-lfs

--- a/packer/linux/scripts/install-git-lfs.sh
+++ b/packer/linux/scripts/install-git-lfs.sh
@@ -2,7 +2,7 @@
 
 GIT_LFS_RELEASE="2.10.0"
 
-MACHINE=`uname -m`
+MACHINE=$(uname -m)
 
 case "${MACHINE}" in
 	x86_64)    ARCH=amd64;;

--- a/packer/linux/scripts/install-lifecycled.sh
+++ b/packer/linux/scripts/install-lifecycled.sh
@@ -3,11 +3,19 @@ set -eu -o pipefail
 
 LIFECYCLED_VERSION=v3.0.2
 
+MACHINE=`uname -m`
+
+case "${MACHINE}" in
+	x86_64)    ARCH=amd64;;
+	aarch64)   ARCH=arm64;;
+	*)         ARCH=unknown;;
+esac
+
 echo "Installing lifecycled ${LIFECYCLED_VERSION}..."
 
 sudo touch /etc/lifecycled
 sudo curl -Lf -o /usr/bin/lifecycled \
-	https://github.com/lox/lifecycled/releases/download/${LIFECYCLED_VERSION}/lifecycled-linux-amd64
+	https://github.com/lox/lifecycled/releases/download/${LIFECYCLED_VERSION}/lifecycled-linux-${ARCH}
 sudo chmod +x /usr/bin/lifecycled
 sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
 	https://raw.githubusercontent.com/lox/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit

--- a/packer/linux/scripts/install-lifecycled.sh
+++ b/packer/linux/scripts/install-lifecycled.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 LIFECYCLED_VERSION=v3.0.2
 
-MACHINE=`uname -m`
+MACHINE=$(uname -m)
 
 case "${MACHINE}" in
 	x86_64)    ARCH=amd64;;

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -304,7 +304,6 @@ Parameters:
     Description: The operating system to run on the instances
     AllowedValues:
       - linux
-      - linuxarm
       - windows
     Default: "linux"
 
@@ -504,6 +503,17 @@ Conditions:
 
     UseLinuxAgents:
       !Equals [ !Ref InstanceOperatingSystem, "linux" ]
+
+    UsingArmInstances:
+      !Or
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "t4g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "a1" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6gd" ]
 
 Mappings:
   ECRManagedPolicy:
@@ -824,7 +834,7 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-          ImageId: !If [ HasImageId, !Ref ImageId, !If [ HasImageIdParameter, !GetAtt ImageIdParameterStack.Outputs.ImageId, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', !Ref InstanceOperatingSystem ] ] ]
+          ImageId: !If [ HasImageId, !Ref ImageId, !If [ HasImageIdParameter, !GetAtt ImageIdParameterStack.Outputs.ImageId, !If [ UseWindowsAgents, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'windows'], !If [ UsingArmInstances, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'linuxarm'], !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'linux'] ] ] ] ]
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
               Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -545,7 +545,7 @@ Mappings:
     sa-east-1 : { Bucket: "buildkite-lambdas-sa-east-1" }
 
   # Generated from Makefile via build/mappings.yml
-  AWSRegion2AMI: { linux: !Ref ImageId, windows: !Ref ImageId }
+  AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId }
 
 Resources:
   Vpc:
@@ -851,11 +851,11 @@ Resources:
                   - !FindInMap
                     - AWSRegion2AMI
                     - !Ref 'AWS::Region'
-                    - 'linuxarm'
+                    - 'linuxarm64'
                   - !FindInMap
                     - AWSRegion2AMI
                     - !Ref 'AWS::Region'
-                    - 'linux'
+                    - 'linuxamd64'
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
               Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -304,6 +304,7 @@ Parameters:
     Description: The operating system to run on the instances
     AllowedValues:
       - linux
+      - linuxarm
       - windows
     Default: "linux"
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -834,7 +834,28 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-          ImageId: !If [ HasImageId, !Ref ImageId, !If [ HasImageIdParameter, !GetAtt ImageIdParameterStack.Outputs.ImageId, !If [ UseWindowsAgents, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'windows'], !If [ UsingArmInstances, !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'linuxarm'], !FindInMap [ AWSRegion2AMI, !Ref 'AWS::Region', 'linux'] ] ] ] ]
+          ImageId: !If
+            - HasImageId
+            - !Ref ImageId
+            - !If
+              - HasImageIdParameter
+              - !GetAtt ImageIdParameterStack.Outputs.ImageId
+              - !If
+                - UseWindowsAgents
+                - !FindInMap
+                  - AWSRegion2AMI
+                  - !Ref 'AWS::Region'
+                  - 'windows'
+                - !If
+                  - UsingArmInstances
+                  - !FindInMap
+                    - AWSRegion2AMI
+                    - !Ref 'AWS::Region'
+                    - 'linuxarm'
+                  - !FindInMap
+                    - AWSRegion2AMI
+                    - !Ref 'AWS::Region'
+                    - 'linux'
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
               Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }


### PR DESCRIPTION
AWS has a growing number of ARM based instance types, using their gravitron and gravitron2 CPUs.

This expands on PR #690 by @galak, changing the CI pipeline to build an `linux/arm64` AMI, and ensuring that AMI is selected when a stack is deployed with OS:linux and and ARM instance type.

A few noteworthy things:

* On linux/amd64 we install docker-compose using a binary download. Sadly there's no official arm64 binary published (see https://github.com/docker/compose/issues/7472) so I've fallen back on installing via pip (for arm64 only). This works, but it's gross to install it differently depending on arch. Hopefully we can go back to binary installs if upstream starts publishing an arm64 version
* I'm not super happy with the changes to the CI pipeline scripts yet. They work, but they feel messy.
* Explicitly listing the ARM instance types feels fragile - we'll have to update it when future instance types are announced. I'm not sure how else we could do it though

Agents running on an ARM elastic stack look like this on buildkite.com:

![Screenshot from 2020-10-29 11-30-26](https://user-images.githubusercontent.com/8132/97511081-466c4e00-19da-11eb-921f-ccf02374c02f.png)
