### PR TITLE
Optionally enable the ecr credential helper plugin

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -48,6 +48,7 @@ PLUGINS_ENABLED=()
 [[ $SECRETS_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("secrets")
 [[ $ECR_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("ecr")
 [[ $DOCKER_LOGIN_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("docker-login")
+[[ ${ECR_CRED_HELPER_PLUGIN_ENABLED:-} == "true" ]] && PLUGINS_ENABLED+=("ecr-cred-helper")
 
 # cfn-env is sourced by the environment hook in builds
 cat << EOF > /var/lib/buildkite-agent/cfn-env

--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -8,6 +8,9 @@ source ~/cfn-env
 BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY=$(mktemp -d)
 export BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY
 export DOCKER_CONFIG="$BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY"
+DOCKER_CONFIG_FILE="${DOCKER_CONFIG}/config.json"
+# Write an empty docker config file
+echo '{}' > $DOCKER_CONFIG_FILE
 
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 cat ~/cfn-env
@@ -39,10 +42,12 @@ echo "Configuring built-in plugins"
 [[ ! ${SECRETS_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/secrets/}
 [[ ! ${DOCKER_LOGIN_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/docker-login/}
 [[ ! ${ECR_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/ecr/}
+[[ ! ${ECR_CRED_HELPER_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/ecr-cred-helper/}
 
 SECRETS_PLUGIN_ENABLED=0
 DOCKER_LOGIN_PLUGIN_ENABLED=0
 ECR_PLUGIN_ENABLED=0
+ECR_CRED_HELPER_PLUGIN_ENABLED=0
 
 for plugin in $PLUGINS_ENABLED ; do
   case "$plugin" in
@@ -58,8 +63,16 @@ for plugin in $PLUGINS_ENABLED ; do
       export ECR_PLUGIN_ENABLED=1
       echo "ECR plugin enabled"
       ;;
+    ecr-cred-helper)
+      export ECR_CRED_HELPER_PLUGIN_ENABLED=1
+      echo "ECR cred helper plugin enabled"
+      ;;
   esac
 done
+
+if [[ "${ECR_CRED_HELPER_PLUGIN_ENABLED:-}" == "1" ]] ; then
+  cat <<< "$(jq '."credsStore"="ecr-login"' $DOCKER_CONFIG_FILE)" > $DOCKER_CONFIG_FILE
+fi
 
 if [[ -n "${BUILDKITE_SECRETS_BUCKET:-}" &&  "${SECRETS_PLUGIN_ENABLED:-}" == "1" ]] ; then
   export BUILDKITE_PLUGIN_S3_SECRETS_BUCKET="$BUILDKITE_SECRETS_BUCKET"

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -45,3 +45,6 @@ sudo curl -Lsf -o /usr/bin/jq https://github.com/stedolan/jq/releases/download/j
 sudo chmod +x /usr/bin/jq
 jq --version
 
+echo "Installing ecr credential helper..."
+sudo amazon-linux-extras enable docker
+sudo yum install -y amazon-ecr-credential-helper

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -86,6 +86,7 @@ Metadata:
         Parameters:
         - EnableSecretsPlugin
         - EnableECRPlugin
+        - EnableECRCredHelperPlugin
         - EnableDockerLoginPlugin
 
 Parameters:
@@ -340,6 +341,14 @@ Parameters:
       - "true"
       - "false"
     Default: "true"
+
+  EnableECRCredHelperPlugin:
+    Type: String
+    Description: Enables ecr credential helper plugin
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
 
   EnableDockerLoginPlugin:
     Type: String
@@ -915,6 +924,7 @@ Resources:
                   AWS_DEFAULT_REGION=${AWS::Region} \
                   SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
                   ECR_PLUGIN_ENABLED=${EnableECRPlugin} \
+                  ECR_CRED_HELPER_PLUGIN_ENABLED=${EnableECRCredHelperPlugin} \
                   DOCKER_LOGIN_PLUGIN_ENABLED=${EnableDockerLoginPlugin} \
                   AWS_REGION=${AWS::Region} \
                     /usr/local/bin/bk-install-elastic-stack.sh


### PR DESCRIPTION
This allows optionally enabling https://github.com/awslabs/amazon-ecr-credential-helper as mentioned in #676 . This plugin's cache should write to the appropriate home folder and should be shared between builds as it's not in the ephemeral `DOCKER_HOME`. That's my desired behavior, but I'm not 100% sure that's what everyone would want. I think this has the benefit over the ECR plugin of both maintaining a cache between builds and also working against any ECR repo you have access to without having to pre-populate the appropriate registry IDs. I should note I've had a little bit of trouble with this plugin's interactions with docker-compose, but that was years ago. I believe the docker project has resolved those issues with how it calls credential helpers at this point. This worked with the docker and docker-compose plugins for me in testing.

Overview:

- Installs the credential helper no matter the plugin setting. The binary won't do anything when it's not used and it's only 8mb and some change.
- Writes an empty `{}` `config.yaml` in the temp `DOCKER_HOME` so it can be modified later by various things if necessary.
- Follows the standard 

Known issues:

I have almost no Windows knowledge. I'm hoping to get some feedback on this general pattern before attempting to get this working in Windows at well.

I'm not sure if this is better off being made into a more general plugin and then incorporated into this stack via git submodules or not? I opted to bake it right in.

This configuration also precludes any other docker auth, like dockerhub. To make that work it would need to configure the `credHelpers` object to only work on certain configured ECR URLs. That would probably be best done in a separate plugin that was incorporated and configured via a git submodule? We currently only use ECR as an authenticated repo, so this meets that need.