### PR TITLE
Support IAM Permissions Boundaries

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -299,6 +299,11 @@ Parameters:
     Description: Optional - A name for the IAM Role attached to the Instance Profile
     Default: ""
 
+  InstanceRolePermissionsBoundaryARN:
+    Type: String
+    Description: The ARN of the policy used to set the permissions boundary for the role.
+    Default: ""
+
   InstanceOperatingSystem:
     Type: String
     Description: The operating system to run on the instances
@@ -435,6 +440,9 @@ Conditions:
 
     SetInstanceRoleName:
       !Not [ !Equals [ !Ref InstanceRoleName, "" ] ]
+
+    SetInstanceRolePermissionsBoundaryARN:
+      !Not [ !Equals [ !Ref InstanceRolePermissionsBoundaryARN, "" ] ]
 
     UseSpecifiedSecretsBucket:
       !Not [ !Equals [ !Ref SecretsBucket, "" ] ]
@@ -635,6 +643,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !If [ SetInstanceRoleName, !Ref InstanceRoleName, !Sub "${AWS::StackName}-Role" ]
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
       ManagedPolicyArns: !If
           - HasManagedPolicies
           # Support multiple policies to attach by merging the values together and splitting on ','
@@ -975,6 +984,7 @@ Resources:
   AsgProcessSuspenderRole:
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -1051,6 +1061,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: HasVariableSize
     Properties:
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
       Path: "/"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
This makes it a lot easier to give users access to create their own queue by allowing a permission boundary to be attached.

We currently do not allow iam role creation or attachment of policies without a permission boundary set.

For more context, see this [aws blog post on "Delegate permission management to developers by using IAM permissions boundaries"](https://aws.amazon.com/blogs/security/delegate-permission-management-to-developers-using-iam-permissions-boundaries/) and [AWS 2019 Reinvent "AWS Identity: Permission boundaries & delegation"](https://d1.awsstatic.com/events/reinvent/2019/REPEAT_1_AWS_identity_Permission_boundaries_&_delegation_SEC402-R1.pdf).

@yob @lox 