### PR TITLE
Integrate Go s3secrets-helper into elastic-stack

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
       - build/s3secrets-helper-linux-amd64
 
   - id: "s3secrets-helper-windows-amd64"
-    name: ":golang: :windows: s3secrets-helper-windows-amd64"
+    name: ":golang: :windows: s3secrets-helper-windows-amd64.exe"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     plugins:
@@ -52,7 +52,7 @@ steps:
           - "GOARCH=amd64"
         command: ["go", "build", "-o", "/build/s3secrets-helper-windows-amd64.exe"]
     artifact_paths:
-      - build/s3secrets-helper-windows-amd64
+      - build/s3secrets-helper-windows-amd64.exe
 
   - id: "packer-windows"
     name: ":packer: :windows:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,44 @@ steps:
         run: unit-tests
         config: docker-compose.unit-tests.yml
 
+  - id: "s3secrets-helper-linux-amd64"
+    name: ":golang: s3secrets-helper-linux-amd64"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    plugins:
+      docker#v3.7.0:
+        image: "golang:1.15"
+        mount-checkout: false
+        volumes:
+          - "./build:/build:rw"
+          - "./plugins/secrets/s3secrets-helper:/s3secrets-helper:ro"
+        workdir: /s3secrets-helper
+        environment:
+          - "GOOS=linux"
+          - "GOARCH=amd64"
+        command: ["go", "build", "-o", "/build/s3secrets-helper-linux-amd64"]
+    artifact_paths:
+      - build/s3secrets-helper-linux-amd64
+
+  - id: "s3secrets-helper-windows-amd64"
+    name: ":golang: s3secrets-helper-windows-amd64"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    plugins:
+      docker#v3.7.0:
+        image: "golang:1.15"
+        mount-checkout: false
+        volumes:
+          - "./build:/build:rw"
+          - "./plugins/secrets/s3secrets-helper:/s3secrets-helper:ro"
+        workdir: /s3secrets-helper
+        environment:
+          - "GOOS=windows"
+          - "GOARCH=amd64"
+        command: ["go", "build", "-o", "/build/s3secrets-helper-windows-amd64"]
+    artifact_paths:
+      - build/s3secrets-helper-windows-amd64
+
   - id: "packer-windows"
     name: ":packer: :windows:"
     command: .buildkite/steps/packer.sh windows
@@ -26,6 +64,7 @@ steps:
     depends_on:
       - "lint"
       - "bats-tests"
+      - "s3secrets-helper-windows-amd64"
 
   - id: "windows-launch"
     name: ":cloudformation: :windows: Launch"
@@ -54,6 +93,7 @@ steps:
     depends_on:
       - "lint"
       - "bats-tests"
+      - "s3secrets-helper-linux-amd64"
 
   - id: "linux-launch"
     name: ":cloudformation: :linux: Launch"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
         config: docker-compose.unit-tests.yml
 
   - id: "s3secrets-helper-linux-amd64"
-    name: ":golang: s3secrets-helper-linux-amd64"
+    name: ":golang: :linux: s3secrets-helper-linux-amd64"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     plugins:
@@ -36,7 +36,7 @@ steps:
       - build/s3secrets-helper-linux-amd64
 
   - id: "s3secrets-helper-windows-amd64"
-    name: ":golang: s3secrets-helper-windows-amd64"
+    name: ":golang: :windows: s3secrets-helper-windows-amd64"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,7 +50,7 @@ steps:
         environment:
           - "GOOS=windows"
           - "GOARCH=amd64"
-        command: ["go", "build", "-o", "/build/s3secrets-helper-windows-amd64"]
+        command: ["go", "build", "-o", "/build/s3secrets-helper-windows-amd64.exe"]
     artifact_paths:
       - build/s3secrets-helper-windows-amd64
 

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -8,12 +8,16 @@ fi
 
 os="${1:-linux}"
 agent_binary="buildkite-agent-${os}-amd64"
+s3secrets_binary="s3secrets-helper-${os}-amd64"
 
 if [[ "$os" == "windows" ]] ; then
   agent_binary+=".exe"
+  s3secrets_binary+=".exe"
 fi
 
 mkdir -p "build/"
+
+buildkite-agent artifact download "build/$s3secrets_binary" .
 
 # Build a hash of packer files and the agent versions
 packer_files_sha=$(find Makefile "packer/${os}" plugins/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build/linux-ami.txt: packer-linux.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linux packer image
-packer-linux.output: $(PACKER_LINUX_FILES)
+packer-linux.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-amd64
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -87,7 +87,7 @@ build/windows-ami.txt: packer-windows.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build windows packer image
-packer-windows.output: $(PACKER_WINDOWS_FILES)
+packer-windows.output: $(PACKER_WINDOWS_FILES) build/s3secrets-helper-windows-amd64
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -149,3 +149,9 @@ validate: build/aws-stack.yml
 generate-toc:
 	docker run -it --rm -v "$(PWD):/app" node:slim bash \
 		-c "npm install -g markdown-toc && cd /app && markdown-toc -i README.md"
+
+build/s3secrets-helper-linux-amd64:
+	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=amd64 go build -o ../../../$@
+
+build/s3secrets-helper-windows-amd64:
+	cd plugins/secrets/s3secrets-helper && GOOD=windows GOARCH=amd64 go build -o ../../../$@

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ build/windows-ami.txt: packer-windows.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build windows packer image
-packer-windows.output: $(PACKER_WINDOWS_FILES) build/s3secrets-helper-windows-amd64
+packer-windows.output: $(PACKER_WINDOWS_FILES) build/s3secrets-helper-windows-amd64.exe
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -153,5 +153,5 @@ generate-toc:
 build/s3secrets-helper-linux-amd64:
 	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=amd64 go build -o ../../../$@
 
-build/s3secrets-helper-windows-amd64:
+build/s3secrets-helper-windows-amd64.exe:
 	cd plugins/secrets/s3secrets-helper && GOOD=windows GOARCH=amd64 go build -o ../../../$@

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -34,6 +34,11 @@
       "destination": "/tmp/plugins"
     },
     {
+      "type": "file",
+      "source": "../../build/s3secrets-helper-linux-amd64",
+      "destination": "/tmp/s3secrets-helper"
+    },
+    {
       "type": "shell",
       "script": "scripts/install-utils.sh"
     },

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -66,4 +66,4 @@ echo "Copying built-in plugins..."
 sudo mkdir -p /usr/local/buildkite-aws-stack/plugins
 sudo cp -a /tmp/plugins/* /usr/local/buildkite-aws-stack/plugins/
 sudo chown -R buildkite-agent: /usr/local/buildkite-aws-stack
-sudo cp -a /tmp/s3secrets-helper /usr/local/bin
+sudo install --mode=0755 /tmp/s3secrets-helper /usr/local/bin

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -66,3 +66,4 @@ echo "Copying built-in plugins..."
 sudo mkdir -p /usr/local/buildkite-aws-stack/plugins
 sudo cp -a /tmp/plugins/* /usr/local/buildkite-aws-stack/plugins/
 sudo chown -R buildkite-agent: /usr/local/buildkite-aws-stack
+sudo cp -a /tmp/s3secrets-helper /usr/local/bin

--- a/packer/windows/buildkite-ami.json
+++ b/packer/windows/buildkite-ami.json
@@ -37,6 +37,11 @@
       "destination": "C:/packer-temp"
     },
     {
+      "type": "file",
+      "source": "../../build/s3secrets-helper-windows-amd64.exe",
+      "destination": "C:/packer-temp/s3secrets-helper.exe"
+    },
+    {
       "type": "powershell",
       "script": "scripts/install-utils.ps1"
     },

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -45,3 +45,4 @@ Copy-Item -Path C:\packer-temp\conf\buildkite-agent\scripts\stop-agent-gracefull
 Write-Output "Copying built-in plugins..."
 New-Item -ItemType directory -Path "C:\Program Files\Git\usr\local\buildkite-aws-stack\plugins"
 Copy-Item -Recurse -Path C:\packer-temp\plugins\* -Destination "C:\Program Files\Git\usr\local\buildkite-aws-stack\plugins\"
+Copy-Item -Path C:\packer-temp\s3secrets-helper.exe -Destination C:\buildkite-agent\bin


### PR DESCRIPTION
Integrating https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/pull/37 into elastic-stack.

CI:
- [x] Build the `s3secrets-helper` binaries as CI steps (linux & windows)
- [x] Upload binaries as artifacts
- [x] Add them to the packer AMI builds, place them in `PATH`

Development:
- [x] Build the `s3secrets-helper` binaries via `Makefile`
- [x] Packer will pick them up from there.