### PR TITLE
docs: ✏️ Add reference to BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Features:
 
 <!-- toc -->
 
-- [Contents](#contents)
 - [Getting Started](#getting-started)
 - [Build Secrets](#build-secrets)
 - [What’s On Each Machine?](#whats-on-each-machine)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Features:
 
 <!-- toc -->
 
+- [Contents](#contents)
 - [Getting Started](#getting-started)
 - [Build Secrets](#build-secrets)
 - [What’s On Each Machine?](#whats-on-each-machine)
@@ -80,6 +81,7 @@ The following s3 objects are downloaded and processed:
 * `/{pipeline-slug}/env` - An [agent environment hook](https://buildkite.com/docs/agent/hooks), specific to a pipeline
 * `/{pipeline-slug}/private_ssh_key` - A private key that is added to ssh-agent for your builds, specific to the pipeline
 * `/{pipeline-slug}/git-credentials` - A [git-credentials](https://git-scm.com/docs/git-credential-store#_storage_format) file for git over https, specific to a pipeline
+* When provided, the environment variable `BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX` will overwrite `{pipeline-slug}`
 
 These files are encrypted using [Amazon's KMS Service](https://aws.amazon.com/kms/). See the [Security](#security) section for more details.
 


### PR DESCRIPTION
The [AWS S3 Secrets Buildkite Plugin](https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks) allows the location of the secret files on the S3 bucket to be defined using the environment variable `BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX` ([code](https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/blob/67c4e227b5e591608794776d6330c7fe4ea2273a/s3secrets-helper/secrets/secrets.go#L35)). 

Therefore, instead of using the pipeline name, e.g:
`s3://{bucket_name}/{pipeline-slug}/private_ssh_key`

We can point it to any other location, e.g:
`s3://{bucket_name}/{BUILDKITE_PLUGIN_S3_SECRETS_BUCKET_PREFIX}/private_ssh_key`

This is a very handy feature when dealing with multiple pipelines in a monorepo, as it allow pipelines to share the same secrets (if that is desired). 

