### PR TITLE
Fix typo in the mappings file rendered during CI

### DIFF
--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -112,7 +112,7 @@ if [[ $BUILDKITE_BRANCH != "master" ]] && [[ "$BUILDKITE_TAG" != "$BUILDKITE_BRA
   cat << EOF > "$mapping_file"
 Mappings:
   AWSRegion2AMI:
-    ${AWS_REGION} : { linux_amd64: $linux_amd64_source_image_id, linux_arm64: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id }
+    ${AWS_REGION} : { linuxamd64: $linux_amd64_source_image_id, linuxarm64: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id }
 EOF
   exit 0
 fi
@@ -190,7 +190,7 @@ for region in ${ALL_REGIONS[*]}; do
   fi
 
   # Write yaml to file
-  echo "    $region : { linux_amd64: $linux_amd64_image_id, linux_arm64: $linux_arm64_image_id, windows: $windows_amd64_image_id }"  >> "$mapping_file"
+  echo "    $region : { linuxamd64: $linux_amd64_image_id, linuxarm64: $linux_arm64_image_id, windows: $windows_amd64_image_id }"  >> "$mapping_file"
 
   # Shift off the processed images
   IMAGES=("${IMAGES[@]:3}")


### PR DESCRIPTION
In PR #758 we changed the AMI mappings keys to linxuamd64/linuxarm64/windows. However, we left an older format (linux_arm64/linux_amd64) in the version of the template rendered during CI.