### PR TITLE
Restore the ability to change InstanceType on a running stack

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -970,17 +970,17 @@ Resources:
             Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
           Overrides:
           - InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-          - InstanceType: !If
+          - !If
             - UseInstanceType2
-            - !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
+            - InstanceType: !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
             - !Ref "AWS::NoValue"
-          - InstanceType: !If
+          - !If
             - UseInstanceType3
-            - !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
+            - InstanceType: !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
             - !Ref "AWS::NoValue"
-          - InstanceType: !If
+          - !If
             - UseInstanceType4
-            - !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
+            - InstanceType: !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
             - !Ref "AWS::NoValue"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize


### PR DESCRIPTION
In PR #710 we added the option to select multiple instance types by providing the InstanceType stack param as a CSV.

Unfortunately, after merging we discovered that stack updates that changed only the InstanceType stack param would fail with a cryptic error:

> Internal Failure

Helpful!

After some experimentation, I realised my original PR was incorrectly skipping the instance type overrides for types that weren't provided by the user.

Turns out, it's possible to use YAML for 15 years and *still* get confused about lists 😳

Fixes #774