### PR TITLE
Adjust the way we set IAM role for the process suspender

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1026,7 +1026,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - 'autoscaling:SuspendProcesses'
-                Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AgentAutoScaleGroup}
+                Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-AgentAutoScaleGroup-*
 
   AzRebalancingSuspenderFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
The old way works, but any time the ASG is recreated it gets a new name and the IAM role also needs to be updated. It'd be nice to skip the IAM changes so some common stack updates (like changing only InstanceType) can be performed by users without permissions to make IAM changes. 

This converts the resource in the role to use a wildcard suffix, so the role has permission to suspend the process on any ASG called `{stack-name}-AgentAutoScaleGroup-*`.

With this change, updating a stack with only an InstanceType change requires no IAM changes:

![Screenshot from 2020-12-08 08-48-24](https://user-images.githubusercontent.com/8132/101409591-36794f80-3932-11eb-8515-5388da2755d3.png)

Fixes #764 

Alternative to #768 