### PR TITLE
Add trailing slash to install path

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -74,4 +74,4 @@ echo "Copying built-in plugins..."
 sudo mkdir -p /usr/local/buildkite-aws-stack/plugins
 sudo cp -a /tmp/plugins/* /usr/local/buildkite-aws-stack/plugins/
 sudo chown -R buildkite-agent: /usr/local/buildkite-aws-stack
-sudo install --mode=0755 /tmp/s3secrets-helper /usr/local/bin
+sudo install --mode=0755 /tmp/s3secrets-helper /usr/local/bin/


### PR DESCRIPTION
Add the trailing slash so that the command fails if the path doesn't exist, rather than creating a file call /usr/local/bin

Inspired by this ticket: https://secure.helpscout.net/conversation/1370252863/14773?folderId=1113730