### PR TITLE
default to gp3 volumes

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -272,7 +272,7 @@ Parameters:
   RootVolumeType:
     Description: Type of root volume to use
     Type: String
-    Default: "gp2"
+    Default: "gp3"
 
   SecurityGroupId:
     Type: String


### PR DESCRIPTION
AWS [announced gp3 EBS volumes earlier this month](https://aws.amazon.com/about-aws/whats-new/2020/12/introducing-new-amazon-ebs-general-purpose-volumes-gp3/). They're slightly cheaper and have [the same or better performance than gp2](https://aws.amazon.com/ebs/general-purpose/), so we may as well default to the new type.