### PR TITLE
recognise c6gn.* instances as ARM

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -512,6 +512,7 @@ Conditions:
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "a1" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gn" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6gd" ]
 


### PR DESCRIPTION
Earlier this month AWS announced the new c6gn.* family of instances [1]. They have an ARM based Graviton CPU, and have additional network capacity over the standard c6g.* instances.

It's unlikely these will be commonly used in CI stacks, but you never know and it's easy for us to support them.

[1] https://aws.amazon.com/blogs/aws/coming-soon-ec2-c6gn-instances-100-gbps-networking-with-aws-graviton2-processors/