### PR TITLE
Default to IMDSv2 for instance metadata calls

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -12,8 +12,9 @@ on_error() {
 	local errorLine="$1"
 
 	if [[ $exitCode != 0 ]] ; then
+	  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
 		aws autoscaling set-instance-health \
-			--instance-id "$(curl http://169.254.169.254/latest/meta-data/instance-id)" \
+			--instance-id "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)" \
 			--health-status Unhealthy || true
 	fi
 

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -6,8 +6,9 @@ echo "sleeping for 10 seconds before terminating instance to allow agent logs to
 
 sleep 10
 
-instance_id=$(curl -fsSL http://169.254.169.254/latest/meta-data/instance-id)
-region=$(curl -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+instance_id=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/instance-id)
+region=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
 
 echo "requesting instance termination..."
 

--- a/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
@@ -13,8 +13,10 @@ mark_instance_unhealthy() {
 
   # mark the instance for termination
   echo "Marking instance as unhealthy"
+
+  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
   aws autoscaling set-instance-health \
-    --instance-id "$(curl http://169.254.169.254/latest/meta-data/instance-id)" \
+    --instance-id "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)" \
     --health-status Unhealthy
 }
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -9,7 +9,8 @@ function on_error {
   $errorLine=$_.InvocationInfo.ScriptLineNumber
   $errorMessage=$_.Exception
 
-  $instance_id=(Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
+  $Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '60'} http://169.254.169.254/latest/api/token).content
+  $instance_id=(Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
 
   aws autoscaling set-instance-health `
     --instance-id "$instance_id" `
@@ -25,7 +26,8 @@ function on_error {
 
 trap {on_error}
 
-$Env:INSTANCE_ID=(Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
+$Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '60'} http://169.254.169.254/latest/api/token).content
+$Env:INSTANCE_ID=(Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
 $DOCKER_VERSION=(docker --version).split(" ")[2].Replace(",","")
 
 $PLUGINS_ENABLED=@()

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,5 +1,7 @@
-$InstanceId = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content
-$Region = (Invoke-WebRequest -UseBasicParsing http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
+$Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '60'} http://169.254.169.254/latest/api/token).content
+
+$InstanceId = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
+$Region = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
 
 Write-Output "terminate-instance: requesting instance termination..."
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity" 2> $null

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -50,6 +50,8 @@ Metadata:
         - RootVolumeName
         - RootVolumeType
         - ManagedPolicyARN
+        - MetadataOptionsHttpPutResponseHopLimit
+        - MetadataOptionsHttpTokens
         - InstanceRoleName
 
       - Label:
@@ -293,6 +295,21 @@ Parameters:
     Type: CommaDelimitedList
     Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
     Default: ""
+
+  MetadataOptionsHttpPutResponseHopLimit:
+    Type: Number
+    Description: Optional - Number of hops that the PUT request can jump.
+    Default: 1
+    MinValue: 1
+    MaxValue: 64
+
+  MetadataOptionsHttpTokens:
+    Type: String
+    Description: Optional - "optional" | "required" Whether to require tokens for using the Instance Metadata service.
+    AllowedValues:
+      - optional
+      - required
+    Default: "required"
 
   InstanceRoleName:
     Type: String
@@ -835,6 +852,9 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
+          MetadataOptions:
+            HttpPutResponseHopLimit: !Ref MetadataOptionsHttpPutResponseHopLimit
+            HttpTokens: !Ref MetadataOptionsHttpTokens
           ImageId: !If
             - HasImageId
             - !Ref ImageId


### PR DESCRIPTION
This resolves #647

All manual metadata curl calls in the build scripts are now preceded by a call to get a token. The YAML template now defaults to enforcing this, with an option to allow older v1 calls. 

The ability to turn off metadata calls entirely has not been included, as the docker GC script requires it.