### PR TITLE
IMDSv2Tokens parameter: optional / required

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -51,6 +51,7 @@ Metadata:
         - RootVolumeType
         - ManagedPolicyARN
         - InstanceRoleName
+        - IMDSv2Tokens
 
       - Label:
           default: Auto-scaling Configuration
@@ -293,6 +294,14 @@ Parameters:
     Type: CommaDelimitedList
     Description: Optional - Comma separated list of managed IAM policy ARNs to attach to the instance role
     Default: ""
+
+  IMDSv2Tokens:
+    Type: String
+    Description: Whether IMDSv2 tokens must be used for the Instance Metadata Service.
+    AllowedValues:
+      - optional
+      - required
+    Default: optional
 
   InstanceRoleName:
     Type: String
@@ -835,6 +844,8 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
+          MetadataOptions:
+            HttpTokens: !Ref IMDSv2Tokens
           ImageId: !If
             - HasImageId
             - !Ref ImageId


### PR DESCRIPTION
This pull request is inspired by #786 (thanks @holmesjr!) and a follow-up to #788 which was also extract from the PR. It currently contains the bf42884 commit from that latter PR, which will rebase away.

Introduces an `IMDSv2Tokens` parameters, which determines whether the Instance Metadata Service requires IMDSv2 tokens on all requests. The parameter defaults to `optional`, which matches the default behaviour of the IMDS, and so it backwards compatible.

Setting it to `required` makes IMDSv2 tokens mandatory. #788 changes all elastic-stack calls to IMDS to use tokens. Any other code running within builds/plugins/hooks that talks to IMDS etc will also need to use IMDSv2 tokens. This is default for recent versions of AWS SDK and CLI tools. But setting it to `required` may be problematic for older CLI tooling and older AWS SDKs.

We might aim to eventually shift the default to `required`, deprecate the parameter, and then remove it. But not yet.

I'm not totally happy with the `IMDSv2Tokens` parameter name, but I think it's perhaps more descriptive/intuitive than `MetadataOptionsHttpTokens`. Happy for feedback, though.

I suspect we'll get away without exposing a parameter to configure `MetadataOptions.HttpPutResponseHopLimit`; it defaults to `1`, which is a sane setting for most people. We're near the CloudFormation template parameter limit, so will avoid adding one like this preemptively.