### PR TITLE
Add `CancelGracePeriod` param to aws template

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -46,6 +46,7 @@ Metadata:
         - ArtifactsBucket
         - AuthorizedUsersUrl
         - BootstrapScriptUrl
+        - CancelGracePeriod
         - RootVolumeSize
         - RootVolumeName
         - RootVolumeType
@@ -183,6 +184,12 @@ Parameters:
     Description: Optional - HTTPS or S3 URL to run on each instance during boot
     Type: String
     Default: ""
+
+  CancelGracePeriod:
+    Description: Optional - The number of seconds a canceled or timed out job is given to gracefully terminate and upload its artifacts
+    Type: Number
+    Default: 10
+    MinValue: 1
 
   AuthorizedUsersUrl:
     Description: Optional - HTTPS or S3 URL to periodically download ssh authorized_keys from, setting this will enable SSH ingress
@@ -900,6 +907,7 @@ Resources:
                   $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
                   $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT="${EnableAgentGitMirrorsExperiment}"
                   $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
+                  $Env:BUILDKITE_CANCEL_GRACE_PERIOD="${CancelGracePeriod}"
                   $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
                   $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
                   $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
@@ -941,6 +949,7 @@ Resources:
                   BUILDKITE_QUEUE="${BuildkiteQueue}" \
                   BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT=${EnableAgentGitMirrorsExperiment} \
                   BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
+                  BUILDKITE_CANCEL_GRACE_PERIOD="${CancelGracePeriod}" \
                   BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
                   BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
                   BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \


### PR DESCRIPTION
[It seems](https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite-cancel-grace-period) this value isn't modifiable via environment variables, so it would be nice to be able to modify this value in the cloudformation config