### PR TITLE
buildkite-agent v3.27.0, agent names use %spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ If you really want to store your secrets unencrypted, you can disable it entirel
 ## What’s On Each Machine?
 
 * [Amazon Linux 2 LTS](https://aws.amazon.com/amazon-linux-2/)
-* [Buildkite Agent v3.26.0](https://buildkite.com/docs/agent)
+* [Buildkite Agent v3.27.0](https://buildkite.com/docs/agent)
 * [Docker](https://www.docker.com) - 19.03.13 (Linux) and 19.03.12 (Windows)
 * [Docker Compose](https://docs.docker.com/compose/) - 1.27.4 (Linux) and 1.27.2 (Windows)
 * [aws-cli](https://aws.amazon.com/cli/) - useful for performing any ops-related tasks

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -115,7 +115,7 @@ if [[ -n "${BUILDKITE_AGENT_TOKEN_PATH}" ]] ; then
 fi
 
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
-name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%n"
+name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%spawn"
 token="${BUILDKITE_AGENT_TOKEN}"
 tags=$(IFS=, ; echo "${agent_metadata[*]}")
 tags-from-ec2-meta-data=true

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.26.0
+AGENT_VERSION=3.27.0
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -86,7 +86,7 @@ If ($null -ne $Env:BUILDKITE_AGENT_TOKEN_PATH -and $Env:BUILDKITE_AGENT_TOKEN_PA
 
 $OFS=","
 Set-Content -Path C:\buildkite-agent\buildkite-agent.cfg -Value @"
-name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%n"
+name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%spawn"
 token="${Env:BUILDKITE_AGENT_TOKEN}"
 tags=$agent_metadata
 tags-from-ec2-meta-data=true

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.26.0"
+$AGENT_VERSION = "3.27.0"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
Bump buildkite-agent from v3.26.0 to the just-released [v3.27.0](https://github.com/buildkite/agent/releases/tag/v3.27.0). This brings, amongst other things, support for `%spawn` in agent naming, which the elastic-stack will use in an upcoming ~PR~ commit.