### PR TITLE
Specify asg perm resources in InstancePolicy

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -716,10 +716,13 @@ Resources:
               - cloudwatch:PutMetricData
               - cloudformation:DescribeStackResource
               - ec2:DescribeTags
+            Resource: "*"
+          - Effect: Allow
+            Action:
               - autoscaling:DescribeAutoScalingInstances
               - autoscaling:SetInstanceHealth
               - autoscaling:TerminateInstanceInAutoScalingGroup
-            Resource: "*"
+            Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-AgentAutoScaleGroup-*
           - Effect: Allow
             Action:
               - logs:CreateLogGroup


### PR DESCRIPTION
## What

I updated the `InstancePolicy` to match the `Resources` of the `AsgProcessSuspenderRole`'s `AsgProcessModification` policy.

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/b84d760a66f544c5f582702ba207d280fbac20a1/templates/aws-stack.yml#L1038-L1041

## Notes

The `InstancePolicy` could be further cut down.

For example, do we use `sqs` or `sns` anymore ?

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/b84d760a66f544c5f582702ba207d280fbac20a1/templates/aws-stack.yml#L730-L735

According to the 5.2.0's IAMRole's AccessAdvisor tab in AWS, it shows that the following are unused

* Amazon EC2 (InstancePolicy)
* Amazon CloudWatch (InstancePolicy)
* AWS CloudFormation (InstancePolicy)
* Amazon SQS (InstancePolicy)
* Amazon SNS (InstancePolicy)

It would be good to pair these (and other?) IAM changes with the permission boundary PR https://github.com/buildkite/elastic-ci-stack-for-aws/pull/767.