### PR TITLE
Revert PR 767

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -308,11 +308,6 @@ Parameters:
     Description: Optional - A name for the IAM Role attached to the Instance Profile
     Default: ""
 
-  InstanceRolePermissionsBoundaryARN:
-    Type: String
-    Description: The ARN of the policy used to set the permissions boundary for the role.
-    Default: ""
-
   InstanceOperatingSystem:
     Type: String
     Description: The operating system to run on the instances
@@ -449,9 +444,6 @@ Conditions:
 
     SetInstanceRoleName:
       !Not [ !Equals [ !Ref InstanceRoleName, "" ] ]
-
-    SetInstanceRolePermissionsBoundaryARN:
-      !Not [ !Equals [ !Ref InstanceRolePermissionsBoundaryARN, "" ] ]
 
     UseSpecifiedSecretsBucket:
       !Not [ !Equals [ !Ref SecretsBucket, "" ] ]
@@ -664,7 +656,6 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !If [ SetInstanceRoleName, !Ref InstanceRoleName, !Sub "${AWS::StackName}-Role" ]
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
       ManagedPolicyArns: !If
           - HasManagedPolicies
           # Support multiple policies to attach by merging the values together and splitting on ','
@@ -1028,7 +1019,6 @@ Resources:
   AsgProcessSuspenderRole:
     Type: AWS::IAM::Role
     Properties:
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -1105,7 +1095,6 @@ Resources:
     Type: AWS::IAM::Role
     Condition: HasVariableSize
     Properties:
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
       Path: "/"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
This reverts PR #767, which introduced a syntax error to the cloud formation template. I'm reverting to restore the build, but we can merge a revised PR when it's ready.