### PR TITLE
Add missing else condition to iam permission boundary

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -308,6 +308,11 @@ Parameters:
     Description: Optional - A name for the IAM Role attached to the Instance Profile
     Default: ""
 
+  InstanceRolePermissionsBoundaryARN:
+    Type: String
+    Description: The ARN of the policy used to set the permissions boundary for the role.
+    Default: ""
+
   InstanceOperatingSystem:
     Type: String
     Description: The operating system to run on the instances
@@ -444,6 +449,9 @@ Conditions:
 
     SetInstanceRoleName:
       !Not [ !Equals [ !Ref InstanceRoleName, "" ] ]
+
+    SetInstanceRolePermissionsBoundaryARN:
+      !Not [ !Equals [ !Ref InstanceRolePermissionsBoundaryARN, "" ] ]
 
     UseSpecifiedSecretsBucket:
       !Not [ !Equals [ !Ref SecretsBucket, "" ] ]

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -643,7 +643,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !If [ SetInstanceRoleName, !Ref InstanceRoleName, !Sub "${AWS::StackName}-Role" ]
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       ManagedPolicyArns: !If
           - HasManagedPolicies
           # Support multiple policies to attach by merging the values together and splitting on ','
@@ -984,7 +984,7 @@ Resources:
   AsgProcessSuspenderRole:
     Type: AWS::IAM::Role
     Properties:
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -1061,7 +1061,7 @@ Resources:
     Type: AWS::IAM::Role
     Condition: HasVariableSize
     Properties:
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN ]
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       Path: "/"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'


### PR DESCRIPTION
Original pr https://github.com/buildkite/elastic-ci-stack-for-aws/pull/767

Reverted https://github.com/buildkite/elastic-ci-stack-for-aws/pull/802

Added missing else condition. If the boundary is not supplied, the `!Ref "AWS:NoValue"` should null out the argument.

Opened this pr as the last one https://github.com/buildkite/elastic-ci-stack-for-aws/pull/804 closed due to branch rename.