### PR TITLE
ensure that custom build paths can have their permissions fixed

### DIFF
--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -118,7 +118,7 @@ if [[ "${DOCKER_USERNS_REMAP:-false}" == "false" ]] ; then
   # => "my-pipeline"
 
   # Now we can pass this to the sudo script which will validate it before safely chmodding:
-  echo "Fixing permissions for '${AGENT_DIR}/${ORG_DIR}/${PIPELINE_DIR}'..."
-  sudo /usr/bin/fix-buildkite-agent-builds-permissions "${AGENT_DIR}" "${ORG_DIR}" "${PIPELINE_DIR}"
+  echo "Fixing permissions for '${BUILDKITE_BUILD_PATH}/${AGENT_DIR}/${ORG_DIR}/${PIPELINE_DIR}'..."
+  sudo /usr/bin/fix-buildkite-agent-builds-permissions "${BUILDKITE_BUILD_PATH}" "${AGENT_DIR}" "${ORG_DIR}" "${PIPELINE_DIR}"
   echo
 fi

--- a/packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
+++ b/packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
@@ -27,13 +27,16 @@ set -eu -o pipefail
 # In here we need to check that they both don't contain slashes or contain a
 # traversal component.
 
-AGENT_DIR="$1"
+BUILDS_PATH="$1"
+# => "/var/lib/buildkite-agent/builds"
+
+AGENT_DIR="$2"
 # => "my-agent-1"
 
-ORG_DIR="$2"
+ORG_DIR="$3"
 # => "my-org"
 
-PIPELINE_DIR="$3"
+PIPELINE_DIR="$4"
 # => "my-pipeline"
 
 # Make sure it doesn't contain any slashes by substituting slashes with nothing
@@ -72,9 +75,6 @@ exit_if_blank "${ORG_DIR}"
 exit_if_blank "${PIPELINE_DIR}"
 
 # If we make it here, we're safe to go!
-
-# We know the builds path:
-BUILDS_PATH="/var/lib/buildkite-agent/builds"
 
 # And now we can reconstruct the full agent builds path:
 PIPELINE_PATH="${BUILDS_PATH}/${AGENT_DIR}/${ORG_DIR}/${PIPELINE_DIR}"

--- a/unit-tests/fix-buildkite-agent-builds-permissions.bats
+++ b/unit-tests/fix-buildkite-agent-builds-permissions.bats
@@ -3,136 +3,136 @@
 FIX_PERMISSIONS_SCRIPT="/src/packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions"
 
 @test "Slashes in the agent arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "/" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "/" "abc" "abc"
 	[ "$status" -eq 1 ]
 }
 
 @test "Slashes in the agent arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc/" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc/" "abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the agent arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "/abc" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "/abc" "abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the agent arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc/def" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc/def" "abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the agent arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc/def/ghi" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc/def/ghi" "abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the agent arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "/abc/" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "/abc/" "abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the org arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "/" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "/" "abc"
 	[ "$status" -eq 1 ]
 }
 
 @test "Slashes in the org arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc/" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc/" "abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the org arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "/abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "/abc" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the org arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc/def" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc/def" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the org arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc/def/ghi" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc/def/ghi" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the org arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "/abc/" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "/abc/" "abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the pipeline arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "/"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "/"
 	[ "$status" -eq 1 ]
 }
 
 @test "Slashes in the pipeline arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "abc/"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "abc/"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the pipeline arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "/abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "/abc"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the pipeline arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "abc/def"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "abc/def"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the pipeline arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "abc/def/ghi"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "abc/def/ghi"
   [ "$status" -eq 1 ]
 }
 
 @test "Slashes in the pipeline arg cause an exit 1" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "/abc/"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "/abc/"
   [ "$status" -eq 1 ]
 }
 
 @test "Single dot traversal in the agent arg cause an exit 2" {
-  run "$FIX_PERMISSIONS_SCRIPT" "." "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "." "abc" "abc"
   [ "$status" -eq 2 ]
 }
 
 @test "Double dot traversal in the agent arg cause an exit 2" {
-  run "$FIX_PERMISSIONS_SCRIPT" ".." "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" ".." "abc" "abc"
   [ "$status" -eq 2 ]
 }
 
 @test "Single dot traversal in the org arg cause an exit 2" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "." "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "." "abc"
   [ "$status" -eq 2 ]
 }
 
 @test "Double dot traversal in the org arg cause an exit 2" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" ".." "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" ".." "abc"
   [ "$status" -eq 2 ]
 }
 
 @test "Single dot traversal in the pipeline arg cause an exit 2" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" "."
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" "."
   [ "$status" -eq 2 ]
 }
 
 @test "Double dot traversal in the pipeline arg cause an exit 2" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" ".."
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" ".."
   [ "$status" -eq 2 ]
 }
 
 @test "Blank agent arg cause an exit 3" {
-  run "$FIX_PERMISSIONS_SCRIPT" "" "abc" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "" "abc" "abc"
   [ "$status" -eq 3 ]
 }
 
 @test "Blank org arg cause an exit 3" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "" "abc"
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "" "abc"
   [ "$status" -eq 3 ]
 }
 
 @test "Blank pipeline arg cause an exit 3" {
-  run "$FIX_PERMISSIONS_SCRIPT" "abc" "abc" ""
+  run "$FIX_PERMISSIONS_SCRIPT" "/builds" "abc" "abc" ""
   [ "$status" -eq 3 ]
 }


### PR DESCRIPTION
### Issue

The Buildkite `BuildPath` [config](https://github.com/buildkite/agent/blob/main/agent/job_runner.go#L494) allows us to set a custom build path. However, this build path is hardcoded to `/var/lib/buildkite-agent/builds` in the [fix-buildkite-agent-builds-permissions script](https://github.com/uber-workflow/elastic-ci-stack-for-aws/blob/master/packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions#L77), which results in this script not setting permissions properly.

We ran into this issue when we set a custom build path, and subsequently noticed that some docker artifacts on host could not be cleaned up properly by `buildkite-agent`, because some files in the workspace (residual artifacts of docker) were owned by other users.

---

### Fix

The fix is to add the build path as a parameter to the `fix-buildkite-agent-builds-permissions` script.

---

### Test Plan

`docker-compose -f docker-compose.unit-tests.yml run unit-tests` ran successfully