### PR TITLE
bump git on windows from 2.22.0 to 2.31.0

### DIFF
--- a/packer/windows/scripts/install-utils.ps1
+++ b/packer/windows/scripts/install-utils.ps1
@@ -12,7 +12,7 @@ choco install -y awscli --version=1.18.11
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing Git for Windows"
-choco install -y git --version 2.22.0
+choco install -y git --version 2.31.0
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing nssm"


### PR DESCRIPTION
The windows AMI build has started failing because 2.2.0 isn't available any more:

![Screenshot from 2021-03-25 10-54-00](https://user-images.githubusercontent.com/8132/112398495-738a1600-8d58-11eb-81e3-719217edb511.png)

I have zero knowledge about Chocolatey and how it manages package versions - it seems weird that a version would just go away. Anyway, I checked https://chocolatey.org/packages/git and it seems 2.31.0 is available now. Git is very backwards compatible, so upgrading should be safe.