### PR TITLE
bump scaler from 1.0.2 to 1.1.0

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1175,7 +1175,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [LambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-agent-scaler/v1.0.2/handler.zip"
+        S3Key: "buildkite-agent-scaler/v1.1.0/handler.zip"
       Role: !GetAtt AutoscalingLambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler


### PR DESCRIPTION
A single new feature is included in this release. When the elastic stack is very small (<=2 running instances), consider adding a new instance when we suspect the current instances are shutting down and there's pending jobs.

Pull request with more details is here: https://github.com/buildkite/buildkite-agent-scaler/pull/40