### PR TITLE
bump lifecycled from 3.0.2 to 3.2.0

### DIFF
--- a/packer/linux/scripts/install-lifecycled.sh
+++ b/packer/linux/scripts/install-lifecycled.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-LIFECYCLED_VERSION=v3.0.2
+LIFECYCLED_VERSION=v3.2.0
 
 MACHINE=$(uname -m)
 

--- a/packer/windows/scripts/install-lifecycled.ps1
+++ b/packer/windows/scripts/install-lifecycled.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$lifecycled_version = "v3.0.2"
+$lifecycled_version = "v3.2.0"
 
 Write-Output "Installing lifecycled ${lifecycled_version}..."
 


### PR DESCRIPTION
There have been two releases of lifecycled in the past 3 months - [3.1.0](https://github.com/buildkite/lifecycled/releases/tag/v3.1.0
) and [3.2.0](https://github.com/buildkite/lifecycled/releases/tag/v3.2.0).

Neither has any changes that should impact the elastic stack, but it's nice to stick near the latest release so the delta between the elastic stack and upstream doesn't get too big.

Most of the changes are about updating the version of go we build with, and updating some key dependencies (like aws-sdk-go).