### PR TITLE
Update docker-compose on all operating systems to 1.28.x

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 DOCKER_VERSION=20.10.6
 DOCKER_RELEASE="stable"
-DOCKER_COMPOSE_VERSION=1.27.4
+DOCKER_COMPOSE_VERSION=1.28.6
 MACHINE=$(uname -m)
 
 # This performs a manual install of Docker.
@@ -47,7 +47,7 @@ elif [[ "${MACHINE}" == "aarch64" ]]; then
   # https://github.com/docker/compose/issues/7472
   CONSTRAINT_FILE="/tmp/docker-compose-pip-constraint"
   echo 'cryptography<3.4' >"$CONSTRAINT_FILE"
-  sudo pip3 install --constraint "$CONSTRAINT_FILE" docker-compose
+  sudo pip3 install --constraint "$CONSTRAINT_FILE" "docker-compose==${DOCKER_COMPOSE_VERSION}"
 
 	docker-compose version
 else

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -2,6 +2,7 @@
 $ErrorActionPreference = "Stop"
 
 $docker_version="20.10.0"
+$docker_compose_version="1.28.5"
 
 Write-Output "Upgrading DockerMsftProvider module"
 Update-Module -Name DockerMsftProvider -Force
@@ -15,7 +16,7 @@ Install-Package -Name docker -ProviderName DockerMsftProvider -Force -RequiredVe
 Start-Service docker
 
 Write-Output "Installing docker-compose"
-choco install -y docker-compose
+choco install -y docker-compose --version $docker_compose_version
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing jq"


### PR DESCRIPTION
* Linux 1.28.6
* Windows 1.28.5 (the latest available on chocolatey)

There's no specific features we need, we just want to do regular small bumps so the elastic stack never falls behind, and also avoid big changes in behaviour from release to release

1.29.1 is the latest released version, but I stuck with 1.28.x so we can have consistent minor versions across linux and windows. There's so new features in 1.29.x that can't wait for the next elastic stack release.