### PR TITLE
bump docker from 19.03.x to 20.10.x

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-DOCKER_VERSION=19.03.13
+DOCKER_VERSION=20.10.6
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.27.4
 MACHINE=$(uname -m)

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$docker_version="19.03.12"
+$docker_version="20.10.0"
 
 Write-Output "Upgrading DockerMsftProvider module"
 Update-Module -Name DockerMsftProvider -Force


### PR DESCRIPTION
* Linux: 20.10.6
* Windows: 20.10.0

We're assuming this is a backwards compatible upgrade and safe to include in the elastic stack 5.2.x to 5.3.x upgrade. Assuming the AMIs build, we'll might merge and dogfood them for our internal builds to build confidence in the compatibility and safeness of the bump.

The windows patch release is older because that's all that seems to be available.