### PR TITLE
bump agent from 3.27.0 to 3.29.0

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.27.0
+AGENT_VERSION=3.29.0
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.27.0"
+$AGENT_VERSION = "3.29.0"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
Mostly just bugfixes. Bumping in preparation for a new elastic stack release.