### PR TITLE
Remove IAM roles for SNS and SQS

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -737,12 +737,6 @@ Resources:
               - logs:PutLogEvents
               - logs:DescribeLogStreams
             Resource: "*"
-          - Effect: Allow
-            Action:
-              - sqs:*
-              - sns:Unsubscribe
-              - sns:Subscribe
-            Resource: "*"
       Roles:
         - !Ref IAMRole
 


### PR DESCRIPTION
These appear to be vestigial since we no longer use SNS/SQS queue for agent lifecycle operations when we removed that for lifecycled in #135.