### PR TITLE
Revert "Remove IAM roles for SNS and SQS"

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -737,6 +737,12 @@ Resources:
               - logs:PutLogEvents
               - logs:DescribeLogStreams
             Resource: "*"
+          - Effect: Allow
+            Action:
+              - sqs:*
+              - sns:Unsubscribe
+              - sns:Subscribe
+            Resource: "*"
       Roles:
         - !Ref IAMRole
 


### PR DESCRIPTION
Reverts buildkite/elastic-ci-stack-for-aws#829 – This seems to have broken the agent when an EC2 is in service. I need more time to investigate, so this has to be reverted.