### PR TITLE
allow multiple / characters in BuildkiteAgentTokenParameterStorePath

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -113,7 +113,7 @@ Parameters:
     Description: AWS SSM path to the Buildkite agent registration token (this takes precedence over BuildkiteAgentToken). Expects a leading slash ('/').
     Type: String
     Default: ""
-    AllowedPattern: "^$|^/[a-zA-Z0-9_.-]+$"
+    AllowedPattern: "^$|^/[a-zA-Z0-9_.-/]+$"
 
   BuildkiteAgentTokenParameterStoreKMSKey:
     Description: AWS KMS key ID used to encrypt the SSM parameter (if encrypted)


### PR DESCRIPTION
In #813 we added a regexp validation to this stack parameter that was intended to check the parameter is either an empty string or a path that starts with a / character.

The list of characters we permitted comes from [1]. However, we forgot to include / as a permitted character beyond the first. It's valid (and common) for paths to have multiple / to indicate hierarchy and we should support it.

Fixes #834

[1] https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-create.html