### PR TITLE
Instance lifetime timeout

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -158,8 +158,10 @@ if ! docker ps ; then
   exit 1
 fi
 
-systemctl enable "buildkite-agent"
-systemctl start "buildkite-agent"
+systemctl enable --now "buildkite-agent"
+
+systemctl enable --now "buildkite-agent-soft-limit.timer"
+systemctl enable --now "buildkite-agent-hard-limit.timer"
 
 # let the stack know that this host has been initialized successfully
 /opt/aws/bin/cfn-signal \

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-hard-limit.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-hard-limit.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Hard stop buildkite agent
+
+[Service]
+ExecStart=/bin/systemctl stop buildkite-agent
+RemainAfterExit=true

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-hard-limit.timer
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-hard-limit.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Initiate hard stop of agent
+After=buildkite-agent.service
+
+[Timer]
+# 3hr soft timer + 21hr grace period
+OnBootSec=24hr
+
+[Install]
+WantedBy=timers.target

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-soft-limit.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-soft-limit.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Soft stop buildkite agent
+
+[Service]
+ExecStart=/bin/systemctl kill --signal=TERM --kill-who=main buildkite-agent
+RemainAfterExit=true

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-soft-limit.timer
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent-soft-limit.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Initiate soft stop of agent
+After=buildkite-agent.service
+
+[Timer]
+OnBootSec=3hr
+
+[Install]
+WantedBy=timers.target

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -60,7 +60,8 @@ sudo mkdir -p /var/lib/buildkite-agent/plugins
 sudo chown -R buildkite-agent: /var/lib/buildkite-agent/plugins
 
 echo "Adding systemd service template..."
-sudo cp /tmp/conf/buildkite-agent/systemd/buildkite-agent.service /etc/systemd/system/buildkite-agent.service
+sudo cp /tmp/conf/buildkite-agent/systemd/*.service /etc/systemd/system/
+sudo cp /tmp/conf/buildkite-agent/systemd/*.timer /etc/systemd/system/
 
 echo "Adding cloud-init failure safety check..."
 sudo mkdir -p /etc/systemd/system/cloud-final.service.d/


### PR DESCRIPTION
This is something we've been running in our version of the elastic stack, which I thought might be of interest upstream. This is pretty much cut and paste from what we do internally, and while this behaviour (with these timeouts) may or may not be ideal as defaults for everyone I thought it would be worthwhile to start a discussion.

We have one agent queue which acts as a shared pool for a variety of tasks. These instances are also configured to run several agents per instance. The combination of these two things means that even with a reasonably short `idle-timeout` it was often the case that instances could go days (if not weeks) without hitting their idle timeout, up to the point where the disk would fill up and jobs would start failing. At which point we'd have to go and kill them manually.

After several attempts at managing disk space on long-running instances, this is the solution we came up with. We haven't had any of that kind of problem since implementing this, although it is what ultimately led to buildkite/buildkite-agent-scaler/issues/39.

What this does is start a pair of systemd timers when the instance starts. After three hours, the first timer will be reached and trigger a job which sends a `TERM` signal to the agent telling it to stop accepting new jobs. Once the running jobs complete the agent will shut down, triggering the standard shutdown behaviour.

If any builds are in a stuck/hung state (or otherwise still running after 21+ hours), then the second timer will be reached once the instance has been alive for 24 hours (21 hours after the soft stop). This timer tells systemd to stop the `buildkite-agent` service (forcefully if necessary), which again results in the instance shutting down so it can be replaced.