### PR TITLE
Allow dashes in BuildkiteAgentToken Path

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -113,7 +113,8 @@ Parameters:
     Description: AWS SSM path to the Buildkite agent registration token (this takes precedence over BuildkiteAgentToken). Expects a leading slash ('/').
     Type: String
     Default: ""
-    AllowedPattern: "^$|^/[a-zA-Z0-9_.-/]+$"
+    AllowedPattern: "^$|^/[a-zA-Z0-9_.\\-/]+$"
+    ConstraintDescription: "Expects a leading forward slash"
 
   BuildkiteAgentTokenParameterStoreKMSKey:
     Description: AWS KMS key ID used to encrypt the SSM parameter (if encrypted)


### PR DESCRIPTION
Original Issue https://github.com/buildkite/elastic-ci-stack-for-aws/issues/834
Previous PRs https://github.com/buildkite/elastic-ci-stack-for-aws/pull/813 https://github.com/buildkite/elastic-ci-stack-for-aws/pull/835

cc: @yob @jufemaiz @vgrigoruk