### PR TITLE
Create secrets bucket only when needed

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -447,7 +447,9 @@ Conditions:
       !Equals [ !Ref SecurityGroupId, "" ]
 
     CreateSecretsBucket:
-      !Equals [ !Ref SecretsBucket, "" ]
+      !And
+         - !Equals [ !Ref EnableSecretsPlugin, "true"]
+         - !Equals [ !Ref SecretsBucket, "" ]
 
     SetInstanceRoleName:
       !Not [ !Equals [ !Ref InstanceRoleName, "" ] ]


### PR DESCRIPTION
We would like to avoid managed secret buckets creation in case of `EnableSecretsPlugin = false`