### PR TITLE
Fix windows s3secrets-helper cross compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,4 +187,4 @@ build/s3secrets-helper-linux-arm64:
 	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=arm64 go build -o ../../../$@
 
 build/s3secrets-helper-windows-amd64.exe:
-	cd plugins/secrets/s3secrets-helper && GOOD=windows GOARCH=amd64 go build -o ../../../$@
+	cd plugins/secrets/s3secrets-helper && GOOS=windows GOARCH=amd64 go build -o ../../../$@


### PR DESCRIPTION
While testing https://github.com/buildkite/elastic-ci-stack-for-aws/issues/843 I noticed that this typo breaks building a Windows AMI locally on Linux. Specifically it builds a Linux executable which errors out when `buildkite-agent` tries to run it during the start of a step:

```
:llama: Setting up elastic stack environment (v5.3.1)
...
/usr/local/buildkite-aws-stack/plugins/secrets/hooks/environment: line 12: /c/buildkite-agent/bin/s3secrets-helper: cannot execute binary file: Exec format error
🚨 Error: Error setting up bootstrap: The global environment hook exited with status 126
```

Note that CI works because `GOOS` is specified correctly in the pipeline env; this make target isn't used.