### PR TITLE
fix: Pin docker systemd services to the same docker version

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -26,8 +26,8 @@ sudo chown -R ec2-user:docker /etc/docker
 
 # Install systemd services
 echo "Installing systemd services"
-sudo curl -Lfs -o /etc/systemd/system/docker.service https://raw.githubusercontent.com/moby/moby/master/contrib/init/systemd/docker.service
-sudo curl -Lfs -o /etc/systemd/system/docker.socket https://raw.githubusercontent.com/moby/moby/master/contrib/init/systemd/docker.socket
+sudo curl -Lfs -o /etc/systemd/system/docker.service "https://raw.githubusercontent.com/moby/moby/v${DOCKER_VERSION}/contrib/init/systemd/docker.service"
+sudo curl -Lfs -o /etc/systemd/system/docker.socket "https://raw.githubusercontent.com/moby/moby/v${DOCKER_VERSION}/contrib/init/systemd/docker.socket"
 sudo systemctl daemon-reload
 sudo systemctl enable docker.service
 


### PR DESCRIPTION
The latest moby upstream changes expect a `containerd` service to be installed and run independently. Thus if you were to build the AMI in master right now (we do this to get the latest ami security updates) it would cause the buildkite-ami to fail to start the docker-service and hence the machine gets killed. This fix pins the systemd images to the docker version so that the AMI's will be correctly aligned with the expected docker start commands. 

# Links
- https://github.com/moby/moby/blob/master/contrib/init/systemd/docker.service#L13
- https://github.com/moby/moby/blob/v20.10.6/contrib/init/systemd/docker.service#L13