### PR TITLE
Remove unused s3:Get action

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -782,7 +782,6 @@ Resources:
           - Effect: Allow
             Action:
               - s3:Get*
-              - s3:Get
               - s3:List*
             Resource:
               - !Sub "arn:aws:s3:::${ManagedSecretsBucket}/*"
@@ -800,7 +799,6 @@ Resources:
           - Effect: Allow
             Action:
               - s3:Get*
-              - s3:Get
               - s3:List*
             Resource:
               - !Sub "arn:aws:s3:::${SecretsBucket}/*"


### PR DESCRIPTION
This IAM action is redundant, there is no s3:Get action and the asterisk rule will already match s3:Get.

Fixes #852 