### PR TITLE
Bump lambda scaler version

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1170,7 +1170,7 @@ Resources:
     Properties:
       Code:
         S3Bucket: { 'Fn::FindInMap': [LambdaBucket, !Ref 'AWS::Region', 'Bucket'] }
-        S3Key: "buildkite-agent-scaler/v1.1.0/handler.zip"
+        S3Key: "buildkite-agent-scaler/v1.1.1/handler.zip"
       Role: !GetAtt AutoscalingLambdaExecutionRole.Arn
       Timeout: 120
       Handler: handler


### PR DESCRIPTION
Depends on https://github.com/buildkite/buildkite-agent-scaler/pull/47 being merged to release the updated scaler version.