### PR TITLE
Increase the HttpPutResponseHopLimit from 1 to 2

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -851,6 +851,8 @@ Resources:
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
           MetadataOptions:
             HttpTokens: !Ref IMDSv2Tokens
+            # Allow containers using a Docker network on the host to receive IDMSv2 responses
+            HttpPutResponseHopLimit: 2
           ImageId: !If
             - HasImageId
             - !Ref ImageId


### PR DESCRIPTION
Small change to allow Docker containers running on an instance and not using an awsvpc CNI to receive responses from the IDMSv2 service.

Fixes #857