### PR TITLE
Drop the aws prefix from the default cost tag prefix

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -392,7 +392,7 @@ Parameters:
   CostAllocationTagName:
     Type: String
     Description: The name of the Cost Allocation Tag used for billing purposes
-    Default: "aws:createdBy"
+    Default: "user:createdBy"
 
   CostAllocationTagValue:
     Type: String

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -392,7 +392,7 @@ Parameters:
   CostAllocationTagName:
     Type: String
     Description: The name of the Cost Allocation Tag used for billing purposes
-    Default: "user:createdBy"
+    Default: "CreatedBy"
 
   CostAllocationTagValue:
     Type: String


### PR DESCRIPTION
See https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html for docs on the restrictions, you cannot create a tag starting with `aws:`. I’ll create a stack with this to see if you’re supposed to add the `user:` prefix or if you can cost allocate over any tag name and the `user:` part is just presentation in the cost allocation dashboard / reports.

Fixes #856 