### PR TITLE
Add support policy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ We aim to support new regions within one month of general availability.
 
 We build and deploy the following AMIs to all our supported regions:
 
-- Amazon Linux 2 LTS (x86_64)
-- Amazon Linux 2 LTS (arm64)
+- Amazon Linux 2 (x86_64)
+- Amazon Linux 2 (arm64)
 - Windows Server 2019 (x86_64)
 
 ## Questions and support

--- a/README.md
+++ b/README.md
@@ -77,15 +77,13 @@ We support all AWS Regions, except China and US GovCloud.
 
 We aim to support new regions within one month of general availability.
 
-### Included Software
+### Operating Systems
 
 We build and deploy the following AMIs to all our supported regions:
 
 - Amazon Linux 2 LTS (x86_64)
 - Amazon Linux 2 LTS (arm64)
 - Windows Server 2019 (x86_64)
-
-[What expectations do customers have on tracking releases of Docker, Docker Compose, aws-cli, and the Buildkite Agent? Should we track minor releases within X days and major releases (that support our underlying OS) in major bumps to the elastic stack itself?]
 
 ## Questions and support
 

--- a/README.md
+++ b/README.md
@@ -67,25 +67,6 @@ If you need to build your own AMI (because you've changed something in the `pack
 make packer
 ```
 
-## Questions and support
-
-Feel free to drop an email to support@buildkite.com with questions. It helps us if you can provide the following details:
-
-```
-# List your stack parameters
-aws cloudformation describe-stacks --stack-name MY_STACK_NAME \
-  --query 'Stacks[].Parameters[].[ParameterKey,ParameterValue]' --output table
-```
-
-Provide us with logs from CloudWatch Logs:
-
-```
-/buildkite/elastic-stack/{instance-id}
-/buildkite/systemd/{instance-id}
-```
-
-You can also drop by `#aws-stack` and `#aws` channels in [Buildkite Community Slack](https://chat.buildkite.com/) and ask your question!
-
 ## Support Policy
 
 We provide support for security and bug fixes on the current major release only.
@@ -105,6 +86,25 @@ We build and deploy the following AMIs to all our supported regions:
 - Windows Server 2019 (x86_64)
 
 [What expectations do customers have on tracking releases of Docker, Docker Compose, aws-cli, and the Buildkite Agent? Should we track minor releases within X days and major releases (that support our underlying OS) in major bumps to the elastic stack itself?]
+
+## Questions and support
+
+Feel free to drop an email to support@buildkite.com with questions. It helps us if you can provide the following details:
+
+```
+# List your stack parameters
+aws cloudformation describe-stacks --stack-name MY_STACK_NAME \
+  --query 'Stacks[].Parameters[].[ParameterKey,ParameterValue]' --output table
+```
+
+Provide us with logs from CloudWatch Logs:
+
+```
+/buildkite/elastic-stack/{instance-id}
+/buildkite/systemd/{instance-id}
+```
+
+You can also drop by `#aws-stack` and `#aws` channels in [Buildkite Community Slack](https://chat.buildkite.com/) and ask your question!
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Features:
 - [Security](#security)
 - [Development](#development)
 - [Questions and Support](#questions-and-support)
+- [Support Policy](#support-policy)
 - [Licence](#licence)
 
 <!-- tocstop -->
@@ -308,6 +309,22 @@ Provide us with logs from Cloudwatch Logs:
 ```
 
 Alternately, drop by `#aws-stack` and `#aws` channels in [Buildkite Community Slack](https://chat.buildkite.com/) and ask your question!
+
+## Support Policy
+
+We provide support for bug fixes on the current major release only.
+
+### AWS Regions
+
+We support all AWS Regions, except China and US GovCloud.
+
+We aim to support new regions within one month of general availability.
+
+### Included Software
+
+We build and deploy an AMI built on Amazon Linux 2 LTS and Windows Server 2019.
+
+[What expectations do customers have on tracking releases of Docker, Docker Compose, aws-cli, and the Buildkite Agent? Should we track minor releases within X days and major releases (that support our underlying OS) in major bumps to the elastic stack itself?]
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ make packer
 
 We provide support for security and bug fixes on the current major release only.
 
+If there are any changes in the master branch since the last tagged release, we
+aim to publish a new tagged release of this template at the end of each month.
+
 ### AWS Regions
 
 We support all AWS Regions, except China and US GovCloud.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ We build and deploy the following AMIs to all our supported regions:
 - Amazon Linux 2 (arm64)
 - Windows Server 2019 (x86_64)
 
+### Buildkite Agent
+
+The Elastic CI Stack template [published from the master branch](https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml)
+tracks the latest Buildkite Agent release.
+
+You may wish to preview any updates to your stack from this template
+[using a CloudFormation Stack Change Set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html)
+to decide whether to apply it.
+
 ## Questions and support
 
 Feel free to drop an email to support@buildkite.com with questions. It helps us if you can provide the following details:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -782,7 +782,6 @@ Resources:
           - Effect: Allow
             Action:
               - s3:Get*
-              - s3:Get
               - s3:List*
             Resource:
               - !Sub "arn:aws:s3:::${ManagedSecretsBucket}/*"
@@ -800,7 +799,6 @@ Resources:
           - Effect: Allow
             Action:
               - s3:Get*
-              - s3:Get
               - s3:List*
             Resource:
               - !Sub "arn:aws:s3:::${SecretsBucket}/*"


### PR DESCRIPTION
While the template and AMIs are entangled I think this is probably the most sensible support policy we can come up with.

I think there may be a future in making the AMI builds more readily forkable, perhaps with EC2 Image Builder, for folks to track software components differently to how we do in the main release series.

Down the road I’d also like to add a Windows Server 2019 arm64 build to complete our ARM line up at the Elastic CI Stack for AWS layer.