### PR TITLE
Install Docker using CentOS yum repositories

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -35,17 +35,15 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=1
 EOF
 
-# Download the signing key for the repository
-if [ "${MACHINE}" = "x86_64" ]
-then
-  centos_key="https://centos.org/keys/RPM-GPG-KEY-CentOS-7"
-elif [ "${MACHINE}" = "aarch64" ]
-then
-  centos_key="https://centos.org/keys/RPM-GPG-KEY-CentOS-7-aarch64"
-fi
+import_rpm_key() {
+  local key="${1}"
+  local url="${2}"
+  sudo curl --fail --location --output "/etc/pki/rpm-gpg/${key}" "${url}"
+  sudo rpm -import "/etc/pki/rpm-gpg/${key}"
+}
 
-sudo curl --fail --location --output /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 "${centos_key}"
-sudo rpm -import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+import_rpm_key "RPM-GPG-KEY-CentOS-7" "https://centos.org/keys/RPM-GPG-KEY-CentOS-7"
+import_rpm_key "RPM-GPG-KEY-CentOS-7-aarch64" "https://centos.org/keys/RPM-GPG-KEY-CentOS-7-aarch64"
 
 # Do the install
 sudo yum install -y -q "docker-ce-${DOCKER_VERSION}" "docker-ce-cli-${DOCKER_VERSION}" containerd.io

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -36,7 +36,15 @@ priority=1
 EOF
 
 # Download the signing key for the repository
-sudo curl --fail --location --output /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 https://centos.org/keys/RPM-GPG-KEY-CentOS-7
+if [ "${MACHINE}" = "x86_64" ]
+then
+  centos_key="https://centos.org/keys/RPM-GPG-KEY-CentOS-7"
+elif [ "${MACHINE}" = "aarch64" ]
+then
+  centos_key="https://centos.org/keys/RPM-GPG-KEY-CentOS-7-aarch64"
+fi
+
+sudo curl --fail --location --output /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 "${centos_key}"
 sudo rpm -import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 
 # Do the install

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -23,7 +23,6 @@ name=CentOS-7 - Base
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=os
 enabled=1
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=1
 
 [extras]
@@ -31,7 +30,6 @@ name=CentOS-7 - Extras
 mirrorlist=http://mirrorlist.centos.org/?release=7&arch=$basearch&repo=extras
 enabled=1
 gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
 priority=1
 EOF
 

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -2,7 +2,6 @@
 set -eu -o pipefail
 
 DOCKER_VERSION=20.10.6
-DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.28.6
 MACHINE=$(uname -m)
 


### PR DESCRIPTION
Replace the manual Docker binary install with a yum based install.

This requires adding the CentOS 7 repositories so that the Docker repository package deps can be satisfied, and is the part I’m least confident in relying on 😬

I’ve tested these steps on a t3.large and t4g.large to cover both x86_64 and aarch64 and had it work in both places.

Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/765