### PR TITLE
Add cross-parameter rules

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -407,6 +407,21 @@ Parameters:
       - "false"
     Default: "false"
 
+Rules:
+  HasToken:
+    Assertions:
+      - Assert:
+          !Or
+            - !Not
+              - !Equals
+                - !Ref BuildkiteAgentToken
+                - ""
+            - !Not
+              - !Equals
+                - !Ref BuildkiteAgentTokenParameterStorePath
+                - ""
+        AssertDescription: "You must provide BuildkiteAgentToken or BuildkiteAgentTokenParameterStorePath"
+
 Outputs:
   VpcId:
     Value:


### PR DESCRIPTION
Adds a [`Rules`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/rules-section-structure.html) section to validate cross-parameter values:

- One of BuildkiteAgentToken or BuildkiteAgentTokenParameterStorePath must be specified

Fixes #648 