### PR TITLE
Use pre-built s3-secrets-helper binaries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,63 +16,6 @@ steps:
         run: unit-tests
         config: docker-compose.unit-tests.yml
 
-  - id: "s3secrets-helper-linux-amd64"
-    name: ":golang: :linux: s3secrets-helper-linux-amd64"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
-    plugins:
-      docker#v3.7.0:
-        image: "golang:1.15"
-        mount-checkout: false
-        volumes:
-          - "./build:/build:rw"
-          - "./plugins/secrets/s3secrets-helper:/s3secrets-helper:ro"
-        workdir: /s3secrets-helper
-        environment:
-          - "GOOS=linux"
-          - "GOARCH=amd64"
-        command: ["go", "build", "-o", "/build/s3secrets-helper-linux-amd64"]
-    artifact_paths:
-      - build/s3secrets-helper-linux-amd64
-
-  - id: "s3secrets-helper-linux-arm64"
-    name: ":golang: :linux: s3secrets-helper-linux-arm64"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
-    plugins:
-      docker#v3.7.0:
-        image: "golang:1.15"
-        mount-checkout: false
-        volumes:
-          - "./build:/build:rw"
-          - "./plugins/secrets/s3secrets-helper:/s3secrets-helper:ro"
-        workdir: /s3secrets-helper
-        environment:
-          - "GOOS=linux"
-          - "GOARCH=arm64"
-        command: ["go", "build", "-o", "/build/s3secrets-helper-linux-arm64"]
-    artifact_paths:
-      - build/s3secrets-helper-linux-arm64
-
-  - id: "s3secrets-helper-windows-amd64"
-    name: ":golang: :windows: s3secrets-helper-windows-amd64.exe"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
-    plugins:
-      docker#v3.7.0:
-        image: "golang:1.15"
-        mount-checkout: false
-        volumes:
-          - "./build:/build:rw"
-          - "./plugins/secrets/s3secrets-helper:/s3secrets-helper:ro"
-        workdir: /s3secrets-helper
-        environment:
-          - "GOOS=windows"
-          - "GOARCH=amd64"
-        command: ["go", "build", "-o", "/build/s3secrets-helper-windows-amd64.exe"]
-    artifact_paths:
-      - build/s3secrets-helper-windows-amd64.exe
-
   - id: "packer-windows"
     name: ":packer: :windows:"
     command: .buildkite/steps/packer.sh windows
@@ -83,7 +26,6 @@ steps:
     depends_on:
       - "lint"
       - "bats-tests"
-      - "s3secrets-helper-windows-amd64"
 
   - id: "launch-windows"
     name: ":cloudformation: :windows: Launch"
@@ -112,7 +54,6 @@ steps:
     depends_on:
       - "lint"
       - "bats-tests"
-      - "s3secrets-helper-linux-amd64"
 
   - id: "launch-linux-amd64"
     name: ":cloudformation: :linux: AMD64 Launch"
@@ -141,7 +82,6 @@ steps:
     depends_on:
       - "lint"
       - "bats-tests"
-      - "s3secrets-helper-linux-arm64"
 
   - id: "launch-linux-arm64"
     name: ":cloudformation: :linux: ARM64 Launch"

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -9,16 +9,12 @@ fi
 os="${1:-linux}"
 arch="${2:-amd64}"
 agent_binary="buildkite-agent-${os}-${arch}"
-s3secrets_binary="s3secrets-helper-${os}-${arch}"
 
 if [[ "$os" == "windows" ]] ; then
   agent_binary+=".exe"
-  s3secrets_binary+=".exe"
 fi
 
 mkdir -p "build/"
-
-buildkite-agent artifact download "build/$s3secrets_binary" .
 
 # Build a hash of packer files and the agent versions
 packer_files_sha=$(find Makefile "packer/${os}" plugins/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linux packer image
-packer-linux-amd64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-amd64
+packer-linux-amd64.output: $(PACKER_LINUX_FILES)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -96,7 +96,7 @@ build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linuxarm64 packer image
-packer-linux-arm64.output: $(PACKER_LINUX_FILES) build/s3secrets-helper-linux-arm64
+packer-linux-arm64.output: $(PACKER_LINUX_FILES)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -117,7 +117,7 @@ build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build windows packer image
-packer-windows-amd64.output: $(PACKER_WINDOWS_FILES) build/s3secrets-helper-windows-amd64.exe
+packer-windows-amd64.output: $(PACKER_WINDOWS_FILES)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -179,12 +179,3 @@ validate: build/aws-stack.yml
 generate-toc:
 	docker run -it --rm -v "$(PWD):/app" node:slim bash \
 		-c "npm install -g markdown-toc && cd /app && markdown-toc -i README.md"
-
-build/s3secrets-helper-linux-amd64:
-	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=amd64 go build -o ../../../$@
-
-build/s3secrets-helper-linux-arm64:
-	cd plugins/secrets/s3secrets-helper && GOOS=linux GOARCH=arm64 go build -o ../../../$@
-
-build/s3secrets-helper-windows-amd64.exe:
-	cd plugins/secrets/s3secrets-helper && GOOS=windows GOARCH=amd64 go build -o ../../../$@

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -38,11 +38,6 @@
       "destination": "/tmp/plugins"
     },
     {
-      "type": "file",
-      "source": "../../build/s3secrets-helper-linux-{{user `goarch`}}",
-      "destination": "/tmp/s3secrets-helper"
-    },
-    {
       "type": "shell",
       "script": "scripts/install-utils.sh"
     },
@@ -61,6 +56,10 @@
     {
       "type": "shell",
       "script": "scripts/install-buildkite-agent.sh"
+    },
+    {
+      "type": "shell",
+      "source": "scripts/install-s3secrets-helper.sh"
     },
     {
       "type": "shell",

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -59,7 +59,7 @@
     },
     {
       "type": "shell",
-      "source": "scripts/install-s3secrets-helper.sh"
+      "script": "scripts/install-s3secrets-helper.sh"
     },
     {
       "type": "shell",

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -74,4 +74,3 @@ echo "Copying built-in plugins..."
 sudo mkdir -p /usr/local/buildkite-aws-stack/plugins
 sudo cp -a /tmp/plugins/* /usr/local/buildkite-aws-stack/plugins/
 sudo chown -R buildkite-agent: /usr/local/buildkite-aws-stack
-sudo install --mode=0755 /tmp/s3secrets-helper /usr/local/bin/

--- a/packer/linux/scripts/install-s3secrets-helper.sh
+++ b/packer/linux/scripts/install-s3secrets-helper.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu -o pipefail
+
+S3_SECRETS_HELPER_VERSION=2.1.1
+
+MACHINE="$(uname -m)"
+
+case "${MACHINE}" in
+	x86_64)    ARCH=amd64;;
+	aarch64)   ARCH=arm64;;
+esac
+
+echo "Downloading s3-secrets-helper..."
+curl -Lsf -o /usr/local/bin/s3secrets-helper \
+	"https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-linux-${ARCH}"
+sudo chmod +x /usr/local/bin/s3secrets-helper

--- a/packer/linux/scripts/install-s3secrets-helper.sh
+++ b/packer/linux/scripts/install-s3secrets-helper.sh
@@ -11,6 +11,6 @@ case "${MACHINE}" in
 esac
 
 echo "Downloading s3-secrets-helper..."
-curl -Lsf -o /usr/local/bin/s3secrets-helper \
+sudo curl -Lsf -o /usr/local/bin/s3secrets-helper \
 	"https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-linux-${ARCH}"
 sudo chmod +x /usr/local/bin/s3secrets-helper

--- a/packer/linux/scripts/install-s3secrets-helper.sh
+++ b/packer/linux/scripts/install-s3secrets-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-S3_SECRETS_HELPER_VERSION=2.1.1
+S3_SECRETS_HELPER_VERSION=2.1.2
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/buildkite-ami.json
+++ b/packer/windows/buildkite-ami.json
@@ -57,7 +57,7 @@
       "script": "scripts/install-buildkite-agent.ps1"
     },
     {
-      "type": "shell",
+      "type": "powershell",
       "script": "scripts/install-s3secrets-helper.ps1"
     },
     {

--- a/packer/windows/buildkite-ami.json
+++ b/packer/windows/buildkite-ami.json
@@ -37,11 +37,6 @@
       "destination": "C:/packer-temp"
     },
     {
-      "type": "file",
-      "source": "../../build/s3secrets-helper-windows-amd64.exe",
-      "destination": "C:/packer-temp/s3secrets-helper.exe"
-    },
-    {
       "type": "powershell",
       "script": "scripts/install-utils.ps1"
     },
@@ -60,6 +55,10 @@
     {
       "type": "powershell",
       "script": "scripts/install-buildkite-agent.ps1"
+    },
+    {
+      "type": "shell",
+      "source": "scripts/install-s3secrets-helper.ps1"
     },
     {
       "type": "powershell",

--- a/packer/windows/buildkite-ami.json
+++ b/packer/windows/buildkite-ami.json
@@ -58,7 +58,7 @@
     },
     {
       "type": "shell",
-      "source": "scripts/install-s3secrets-helper.ps1"
+      "script": "scripts/install-s3secrets-helper.ps1"
     },
     {
       "type": "powershell",

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -45,4 +45,3 @@ Copy-Item -Path C:\packer-temp\conf\buildkite-agent\scripts\stop-agent-gracefull
 Write-Output "Copying built-in plugins..."
 New-Item -ItemType directory -Path "C:\Program Files\Git\usr\local\buildkite-aws-stack\plugins"
 Copy-Item -Recurse -Path C:\packer-temp\plugins\* -Destination "C:\Program Files\Git\usr\local\buildkite-aws-stack\plugins\"
-Copy-Item -Path C:\packer-temp\s3secrets-helper.exe -Destination C:\buildkite-agent\bin

--- a/packer/windows/scripts/install-s3secrets-helper.ps1
+++ b/packer/windows/scripts/install-s3secrets-helper.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$S3_SECRETS_HELPER_VERSION = "2.1.1"
+$S3_SECRETS_HELPER_VERSION = "2.1.2"
 
 Write-Output "Downloading s3-secrets-helper v${S3_SECRETS_HELPER_VERSION}..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\s3secrets-helper.exe -Uri "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-windows-amd64"

--- a/packer/windows/scripts/install-s3secrets-helper.ps1
+++ b/packer/windows/scripts/install-s3secrets-helper.ps1
@@ -5,5 +5,5 @@ $S3_SECRETS_HELPER_VERSION = "2.1.1"
 
 Write-Output "Downloading s3-secrets-helper v${S3_SECRETS_HELPER_VERSION}..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\s3secrets-helper.exe -Uri "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-windows-amd64"
-s3-secrets-helper.exe
+s3secrets-helper.exe
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/packer/windows/scripts/install-s3secrets-helper.ps1
+++ b/packer/windows/scripts/install-s3secrets-helper.ps1
@@ -1,0 +1,9 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+$S3_SECRETS_HELPER_VERSION = "2.1.1"
+
+Write-Output "Downloading s3-secrets-helper v${S3_SECRETS_HELPER_VERSION}..."
+Invoke-WebRequest -OutFile C:\buildkite-agent\bin\s3secrets-helper.exe -Uri "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-windows-amd64"
+s3-secrets-helper.exe
+If ($lastexitcode -ne 0) { Exit $lastexitcode }


### PR DESCRIPTION
Consumes the output of the build and release pipeline in the https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks repository.

These binaries are now attached to a release there and don’t need to be built here. This also allows that project to control the go compiler used to build its source.

Fixes #880 