### PR TITLE
Enable ASG cooldown period

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1018,7 +1018,7 @@ Resources:
             - !Ref "AWS::NoValue"
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
-      Cooldown: 0
+      Cooldown: 60
       MetricsCollection:
         - Granularity: 1Minute
           Metrics:


### PR DESCRIPTION
Customers are increasingly reporting issues with interrupted jobs due to the agent process being lost. On investigation we have discovered an issue with the way instances are terminated which has prompted a re-evaluation of how we scale out and in.

The issue appears to be a platform side race condition in the [`terminate-instance-in-auto-scaling-group`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/linux/conf/buildkite-agent/scripts/terminate-instance#L15) API request we use to terminate instances that have fallen idle. Observing the ASG activity log we see the ASG receive the request to terminate and decrement the desired count. Concurrently, the ASG decides to boot a new instance in order to recovery the Actual Capacity by one, followed by the `terminate-instance-in-auto-scaling-group` activity finishing, and the ASG picking a random instance to terminate to re-decrement the actual capacity to match the desired count.

The intent behind the idle self-termination feature was to take lifecycle hooks out of the equation, and simplify the scaling process. This manifests as the scaling Lambda being [configured](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/e1e96a92102e804fc414c5e91d715509adf4ffbe/templates/aws-stack.yml#L1203) to never decrease the [desired count](https://github.com/buildkite/buildkite-agent-scaler/blob/master/scaler/scaler.go#L128-L130). However, in practice there are still occasions where the ASG will decide to terminate an instance, so long as the ASG [`Terminate process`](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-suspend-resume-processes.html#choosing-suspend-resume) is not suspended.

This change, manually applied in the console, has been shown to improve reliability by removing another source of random instance termination.

This change _may_ make the ASG less responsive to rapid changes in desired count. Applying this change, the ASG will wait one minute between scaling activities which should fix the original issue. However a slower response to rapid changes in requested capacity will manifest as longer wait times for instances to boot, and jobs to start running.

The scaler sets [HonourCooldown](https://github.com/buildkite/buildkite-agent-scaler/blob/a4c8be3efb1d37f13c63ac52a3e65e53add46e1e/scaler/asg.go#L72) to false and so _should_ bypass the cooldown on scale out, but this needs testing. Ideally, the cooldown will only result in ASG-internal scaling activities such as this one to be delayed while our scale out `SetDesiredCount`s aren’t throttled.

TODO:

- [x] Verify that `HonourCooldown: false` allows for rapid scale out despite setting `Cooldown: 60`
---

I do feel we are swimming against the current with our present approach to instance scaling. ASG termination decisions can be [influenced](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html) using instance scale-in protection, and there is also now a [Lambda based termination policy](https://docs.aws.amazon.com/autoscaling/ec2/userguide/lambda-custom-termination-policy.html) that is new to me. There are also lifecycle hooks and the SSM agent which can be used to shepherd and make runtime changes to the host.

In addition to reliability, I’d also like our solution to accommodate as many of the following features as possible:
- Warm Pool (pre-InService state, must not run the buildkite-agent before being moved to InService)
- Max Instance Lifetime (ASG termination policy to cap how long an instance can live for)
- Instance Cordoning (remove instances from ASG for manual forensics, sidestepping ASG termination)
- Third-party ASG scaling policies (if people prefer to add scheduled, metric, or predictive scaling policies)