### PR TITLE
Fix hourly disk check

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -11,10 +11,11 @@ on_error() {
 	local exitCode="$?"
 	local errorLine="$1"
 
+	local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location http://169.254.169.254/latest/api/token)
+
 	if [[ $exitCode != 0 ]] ; then
-	  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
 		aws autoscaling set-instance-health \
-			--instance-id "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)" \
+			--instance-id "$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id)" \
 			--health-status Unhealthy || true
 	fi
 

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -11,6 +11,8 @@ on_error() {
 	local exitCode="$?"
 	local errorLine="$1"
 
+	# If the curl fails, we're already in the error trap...
+	# shellcheck disable=SC2155
 	local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
 
 	if [[ $exitCode != 0 ]] ; then

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -11,11 +11,11 @@ on_error() {
 	local exitCode="$?"
 	local errorLine="$1"
 
-	local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location http://169.254.169.254/latest/api/token)
+	local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
 
 	if [[ $exitCode != 0 ]] ; then
 		aws autoscaling set-instance-health \
-			--instance-id "$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id)" \
+			--instance-id "$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")" \
 			--health-status Unhealthy || true
 	fi
 

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -6,9 +6,9 @@ echo "sleeping for 10 seconds before terminating instance to allow agent logs to
 
 sleep 10
 
-token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location http://169.254.169.254/latest/api/token)
-instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id)
-region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/placement/region)
+token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
+instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
+region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
 
 echo "requesting instance termination..."
 

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -8,7 +8,7 @@ sleep 10
 
 TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
 instance_id=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/instance-id)
-region=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/placement/availability-zone | head -c -1)
+region=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/placement/region)
 
 echo "requesting instance termination..."
 

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -6,9 +6,9 @@ echo "sleeping for 10 seconds before terminating instance to allow agent logs to
 
 sleep 10
 
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
-instance_id=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/instance-id)
-region=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -fsSL http://169.254.169.254/latest/meta-data/placement/region)
+token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location http://169.254.169.254/latest/api/token)
+instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id)
+region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/placement/region)
 
 echo "requesting instance termination..."
 

--- a/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
@@ -14,9 +14,9 @@ mark_instance_unhealthy() {
   # mark the instance for termination
   echo "Marking instance as unhealthy"
 
-  local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location http://169.254.169.254/latest/api/token)
-  local instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id)
-  local region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/placement/region)
+  local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
+  local instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
+  local region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
 
   aws autoscaling set-instance-health \
     --instance-id "${instance_id}" \

--- a/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
@@ -17,6 +17,7 @@ mark_instance_unhealthy() {
   TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
   aws autoscaling set-instance-health \
     --instance-id "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)" \
+    --region "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)" \
     --health-status Unhealthy
 }
 

--- a/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
@@ -14,10 +14,13 @@ mark_instance_unhealthy() {
   # mark the instance for termination
   echo "Marking instance as unhealthy"
 
-  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+  local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location http://169.254.169.254/latest/api/token)
+  local instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id)
+  local region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/placement/region)
+
   aws autoscaling set-instance-health \
-    --instance-id "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)" \
-    --region "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)" \
+    --instance-id "${instance_id}" \
+    --region "${region}" \
     --health-status Unhealthy
 }
 

--- a/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
@@ -33,7 +33,7 @@ if ! /usr/local/bin/bk-check-disk-space.sh ; then
   docker builder prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
 
   if ! /usr/local/bin/bk-check-disk-space.sh ; then
-    echo "Disk health checks failed" >&2
+    echo "Disk health checks failed" >&2 && false
     exit 1
   fi
 fi

--- a/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
+++ b/packer/linux/conf/docker/cron.hourly/docker-low-disk-gc
@@ -14,8 +14,11 @@ mark_instance_unhealthy() {
   # mark the instance for termination
   echo "Marking instance as unhealthy"
 
+  # shellcheck disable=SC2155
   local token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
+  # shellcheck disable=SC2155
   local instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
+  # shellcheck disable=SC2155
   local region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
 
   aws autoscaling set-instance-health \

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,7 +1,7 @@
 $Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '60'} http://169.254.169.254/latest/api/token).content
 
 $InstanceId = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
-$Region = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/placement/availability-zone).content -replace ".$"
+$Region = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/placement/region).content
 
 Write-Output "terminate-instance: requesting instance termination..."
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity" 2> $null


### PR DESCRIPTION
Fix the hourly cron disk check to correctly mark the instance as unhealthy with a `--region` and ensure the bash ERR trap is triggered by having a command exit non-zero.

I’ve also updated the use of IDMS to retrieve the region to use the new region API rather than munging the AvailabilityZone API.

Fixes #742