### PR TITLE
Bump s3secrets from v2.1.2 to v2.1.4

### DIFF
--- a/packer/linux/scripts/install-s3secrets-helper.sh
+++ b/packer/linux/scripts/install-s3secrets-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-S3_SECRETS_HELPER_VERSION=2.1.2
+S3_SECRETS_HELPER_VERSION=2.1.3
 
 MACHINE="$(uname -m)"
 

--- a/packer/linux/scripts/install-s3secrets-helper.sh
+++ b/packer/linux/scripts/install-s3secrets-helper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-S3_SECRETS_HELPER_VERSION=2.1.3
+S3_SECRETS_HELPER_VERSION=2.1.4
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/scripts/install-s3secrets-helper.ps1
+++ b/packer/windows/scripts/install-s3secrets-helper.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$S3_SECRETS_HELPER_VERSION = "2.1.2"
+$S3_SECRETS_HELPER_VERSION = "2.1.3"
 
 Write-Output "Downloading s3-secrets-helper v${S3_SECRETS_HELPER_VERSION}..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\s3secrets-helper.exe -Uri "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-windows-amd64"

--- a/packer/windows/scripts/install-s3secrets-helper.ps1
+++ b/packer/windows/scripts/install-s3secrets-helper.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$S3_SECRETS_HELPER_VERSION = "2.1.3"
+$S3_SECRETS_HELPER_VERSION = "2.1.4"
 
 Write-Output "Downloading s3-secrets-helper v${S3_SECRETS_HELPER_VERSION}..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\s3secrets-helper.exe -Uri "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-windows-amd64"


### PR DESCRIPTION
This brings in the following fixes:

- https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/pull/48
- https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/pull/47