### PR TITLE
Make the template own and delete the log group

### DIFF
--- a/.buildkite/steps/cleanup.sh
+++ b/.buildkite/steps/cleanup.sh
@@ -32,8 +32,10 @@ fi
 
 if [[ $OSTYPE =~ ^darwin ]] ; then
   cutoff_date=$(gdate --date='-1 days' +%Y-%m-%d)
+  cutoff_date_milli=$(gdate --date='-1 days' +%s%3N)
 else
   cutoff_date=$(date --date='-1 days' +%Y-%m-%d)
+  cutoff_date_milli=$(date --date='-1 days' +%s%3N)
 fi
 
 echo "--- Cleaning up resources older than ${cutoff_date}"
@@ -60,3 +62,10 @@ aws ec2 describe-instances \
   --query "$(printf 'Reservations[].Instances[?LaunchTime<`%s`].[InstanceId]' "$cutoff_date")" \
   --output text \
   | xargs -n1 -t -I% aws ec2 terminate-instances --instance-ids "%"
+
+echo "--- Deleting old lambda logs after ${cutoff_date_milli}"
+aws logs describe-log-groups \
+  --log-group-name-prefix "/aws/lambda/buildkite-aws-stack-test-" \
+  --query "$(printf 'logGroups[?creationTime<`%s`].[logGroupName]' "$cutoff_date_milli" )" \
+  --output text \
+  | xargs -n1 -t -I% aws logs delete-log-group --log-group-name "%"

--- a/.buildkite/steps/cleanup.sh
+++ b/.buildkite/steps/cleanup.sh
@@ -32,10 +32,8 @@ fi
 
 if [[ $OSTYPE =~ ^darwin ]] ; then
   cutoff_date=$(gdate --date='-1 days' +%Y-%m-%d)
-  cutoff_date_milli=$(gdate --date='-1 days' +%s%3N)
 else
   cutoff_date=$(date --date='-1 days' +%Y-%m-%d)
-  cutoff_date_milli=$(date --date='-1 days' +%s%3N)
 fi
 
 echo "--- Cleaning up resources older than ${cutoff_date}"

--- a/.buildkite/steps/cleanup.sh
+++ b/.buildkite/steps/cleanup.sh
@@ -62,10 +62,3 @@ aws ec2 describe-instances \
   --query "$(printf 'Reservations[].Instances[?LaunchTime<`%s`].[InstanceId]' "$cutoff_date")" \
   --output text \
   | xargs -n1 -t -I% aws ec2 terminate-instances --instance-ids "%"
-
-echo "--- Deleting old lambda logs after ${cutoff_date_milli}"
-aws logs describe-log-groups \
-  --log-group-name-prefix "/aws/lambda/buildkite-aws-stack-test-" \
-  --query "$(printf 'logGroups[?creationTime<`%s`].[logGroupName]' "$cutoff_date_milli" )" \
-  --output text \
-  | xargs -n1 -t -I% aws logs delete-log-group --log-group-name "%"

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1068,6 +1068,14 @@ Resources:
       Role: !GetAtt AsgProcessSuspenderRole.Arn
       Runtime: 'python3.7'
 
+  # This mirrors the group that would be created by the lambda, but enforces
+  # a retention period and also ensures it's removed when the stack is removed
+  AzRebalancingSuspenderFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AzRebalancingSuspenderFunction}"
+      RetentionInDays: 1
+
   AzRebalancingSuspender:
     Type: AWS::CloudFormation::CustomResource
     Version: 1.0

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1068,14 +1068,6 @@ Resources:
       Role: !GetAtt AsgProcessSuspenderRole.Arn
       Runtime: 'python3.7'
 
-  # This mirrors the group that would be created by the lambda, but enforces
-  # a retention period and also ensures it's removed when the stack is removed
-  AzRebalancingSuspenderFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName: !Sub "/aws/lambda/${AzRebalancingSuspenderFunction}"
-      RetentionInDays: 1
-
   AzRebalancingSuspender:
     Type: AWS::CloudFormation::CustomResource
     Version: 1.0


### PR DESCRIPTION
This errored in https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/2474#78f683fb-f935-40bd-bd85-1aa28114697c during cleanup because the log delete races with the stack delete.

Move the log group clean up before the stack cleanup to bypass it.