### PR TITLE
Enable eager concurrency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,6 +118,7 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     concurrency_group: "aws-stack-publish"
     concurrency: 1
+    concurrency_method: eager
     artifact_paths: "build/*.yml"
     depends_on: "copy-ami"
 


### PR DESCRIPTION
Spending too long waiting for the publish step from other builds to run when all the deps are already satisfied, this should unblock them faster.