### PR TITLE
Add capabilities and supporting policies for Cloudformation macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ aws cloudformation create-stack \
   --output text \
   --stack-name buildkite \
   --template-url "https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml" \
-  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+  --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
   --parameters "$(cat config.json)"
 ```
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -716,6 +716,16 @@ Resources:
                   !Sub
                     - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ParameterPath}
                     - ParameterPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
+        - PolicyName: ServerlessCloudformation
+          PolicyDocument:
+            Version: '2021-09-08'
+            Statement:
+              - Effect: Allow
+                Action: serverlessrepo:CreateCloudFormationTemplate
+                Resource: arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler
+              - Effect: Allow
+                Action: serverlessrepo:GetCloudFormationTemplate
+                Resource: arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler      
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
The latest aws-stack.yml uses a macro that requires:

1) `CAPABILITY_AUTO_EXPAND` capability when creating the Cloudformation stack
2) policies that grant `CreateCloudFormationTemplate` and `GetCloudFormationTemplate` to the EC2 instance role

This PR adds documentation for 1), and an inline policy for 2)