### PR TITLE
Quote additional sudo permissions

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -989,7 +989,7 @@ Resources:
                   BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
                   BUILDKITE_ECR_POLICY=${ECRAccessPolicy} \
                   BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BuildkiteTerminateInstanceAfterJob} \
-                  BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS=${BuildkiteAdditionalSudoPermissions} \
+                  BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
                   AWS_DEFAULT_REGION=${AWS::Region} \
                   SECRETS_PLUGIN_ENABLED=${EnableSecretsPlugin} \
                   ECR_PLUGIN_ENABLED=${EnableECRPlugin} \


### PR DESCRIPTION
Commands specified in a sudoers file can be simple commands, or they
can be commands and arguments. Thus,
`BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS` can be expected to contain
spaces, and should be quoted.

Without quotes, anything after the space is taken to be a separate
command to be invoked, which will often give you a non-functional
instance (at least as far as interacting with Buildkite is concerned).

A workaround is to manually escape any spaces.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>