### PR TITLE
Revert "Remove lifecycled"

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -44,6 +44,10 @@ service:
     enabled: true
     running: true
 
+  lifecycled:
+    enabled: true
+    running: true
+
   sshd:
     enabled: true
     running: true
@@ -87,6 +91,9 @@ group:
 
 process:
   buildkite-agent:
+    running: true
+
+  lifecycled:
     running: true
 
   sshd:

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -47,6 +47,10 @@
     },
     {
       "type": "shell",
+      "script": "scripts/install-lifecycled.sh"
+    },
+    {
+      "type": "shell",
       "script": "scripts/install-docker.sh"
     },
     {

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -197,6 +197,15 @@ if [[ -n "${BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT}" ]] ; then
 	rm /tmp/elastic_bootstrap
 fi
 
+cat << EOF > /etc/lifecycled
+AWS_REGION=${AWS_REGION}
+LIFECYCLED_HANDLER=/usr/local/bin/stop-agent-gracefully
+LIFECYCLED_CLOUDWATCH_GROUP=/buildkite/lifecycled
+EOF
+
+systemctl enable lifecycled.service
+systemctl start lifecycled
+
 # wait for docker to start
 next_wait_time=0
 until docker ps || [ $next_wait_time -eq 5 ]; do

--- a/packer/linux/scripts/install-lifecycled.sh
+++ b/packer/linux/scripts/install-lifecycled.sh
@@ -15,8 +15,8 @@ echo "Installing lifecycled ${LIFECYCLED_VERSION}..."
 
 sudo touch /etc/lifecycled
 sudo curl -Lf -o /usr/bin/lifecycled \
-	https://github.com/lox/lifecycled/releases/download/${LIFECYCLED_VERSION}/lifecycled-linux-${ARCH}
+	https://github.com/buildkite/lifecycled/releases/download/${LIFECYCLED_VERSION}/lifecycled-linux-${ARCH}
 sudo chmod +x /usr/bin/lifecycled
 sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
-	https://raw.githubusercontent.com/lox/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit
+	https://raw.githubusercontent.com/buildkite/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit
 

--- a/packer/linux/scripts/install-lifecycled.sh
+++ b/packer/linux/scripts/install-lifecycled.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eu -o pipefail
+
+LIFECYCLED_VERSION=v3.2.0
+
+MACHINE=$(uname -m)
+
+case "${MACHINE}" in
+	x86_64)    ARCH=amd64;;
+	aarch64)   ARCH=arm64;;
+	*)         ARCH=unknown;;
+esac
+
+echo "Installing lifecycled ${LIFECYCLED_VERSION}..."
+
+sudo touch /etc/lifecycled
+sudo curl -Lf -o /usr/bin/lifecycled \
+	https://github.com/lox/lifecycled/releases/download/${LIFECYCLED_VERSION}/lifecycled-linux-${ARCH}
+sudo chmod +x /usr/bin/lifecycled
+sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
+	https://raw.githubusercontent.com/lox/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit
+

--- a/packer/windows/buildkite-ami.json
+++ b/packer/windows/buildkite-ami.json
@@ -46,6 +46,10 @@
     },
     {
       "type": "powershell",
+      "script": "scripts/install-lifecycled.ps1"
+    },
+    {
+      "type": "powershell",
       "script": "scripts/install-docker.ps1"
     },
     {

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -140,6 +140,10 @@ disconnect-after-job=${Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
 "@
 $OFS=" "
 
+nssm set lifecycled AppEnvironmentExtra :AWS_REGION=$Env:AWS_REGION
+nssm set lifecycled AppEnvironmentExtra +LIFECYCLED_HANDLER="C:\buildkite-agent\bin\stop-agent-gracefully.ps1"
+Restart-Service lifecycled
+
 # wait for docker to start
 $next_wait_time=0
 do {

--- a/packer/windows/conf/cloudwatch-agent/amazon-cloudwatch-agent.json
+++ b/packer/windows/conf/cloudwatch-agent/amazon-cloudwatch-agent.json
@@ -22,6 +22,11 @@
             "file_path": "C:\\buildkite-agent\\buildkite-agent.log",
             "log_group_name": "/buildkite/buildkite-agent",
             "timestamp_format": "%Y-%m-%dT%H:%M:%S.%f"
+          },
+          {
+            "file_path": "C:\\lifecycled\\lifecycled.log",
+            "log_group_name": "/buildkite/lifecycled",
+            "timestamp_format": "%Y-%m-%dT%H:%M:%S.%f"
           }
         ]
       },

--- a/packer/windows/scripts/install-lifecycled.ps1
+++ b/packer/windows/scripts/install-lifecycled.ps1
@@ -1,0 +1,19 @@
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+$lifecycled_version = "v3.2.0"
+
+Write-Output "Installing lifecycled ${lifecycled_version}..."
+
+New-Item -ItemType directory -Path C:\lifecycled\bin
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -OutFile C:\lifecycled\bin\lifecycled.exe https://github.com/buildkite/lifecycled/releases/download/${lifecycled_version}/lifecycled-windows-amd64.exe
+
+Write-Output "Configure lifecycled to run on startup..."
+nssm install lifecycled C:\lifecycled\bin\lifecycled.exe
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+nssm set lifecycled AppStdout C:\lifecycled\lifecycled.log
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+nssm set lifecycled AppStderr C:\lifecycled\lifecycled.log
+If ($lastexitcode -ne 0) { Exit $lastexitcode }


### PR DESCRIPTION
Reverts buildkite/elastic-ci-stack-for-aws#908 This is still used and was removed in error, noticed by @pzeballos :bow:

The poll-for-spot-termination handler in lifecycled is still used for the time being, I mistakenly removed this following the SQS and SNS method clean-up.

This may let be re-removed following experimentation with Lambda based approaches to better support ASG initiated termination.