### PR TITLE
Add NewInstancesProtectedFromScaleIn: true to the ASG

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1044,6 +1044,7 @@ Resources:
       TerminationPolicies:
         - OldestLaunchConfiguration
         - ClosestToNextInstanceHour
+      NewInstancesProtectedFromScaleIn: true
     CreationPolicy:
       ResourceSignal:
         Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, PT5M ], !Ref InstanceCreationTimeout ]


### PR DESCRIPTION
We [continue](https://buildkite-community.slack.com/archives/C19BG77H9/p1631073431016900) to experience customer reports of a race condition in the ASG which spontaneously replaces terminating instances only to kill a random instance immediately afterwards. We previously observed the addition of [`Cooldown: 60`](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/888) fixing this but that appears to have been an incomplete fix.

This approach was [suggested](https://buildkite-community.slack.com/archives/C19BG77H9/p1631244925032800?thread_ts=1631073431.016900&cid=C19BG77H9) in Slack. I have tested that it still allows instances to self-terminate using the [`aws autoscaling terminate-instance-in-auto-scaling-group`](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/5c64f61111d2502e58a96ccfe68535f0927a00fc/packer/linux/conf/buildkite-agent/scripts/terminate-instance#L15) but the proof will be whether it successfully prevents the ASG from terminating an instance during scale-in 🤔 

![Screenshot 2021-09-20 at 14 29 07](https://user-images.githubusercontent.com/22101/133957795-74c3b7c6-c99b-47ad-8408-2916422efd00.png)

```
Sep 20 04:20:54 ip-10-0-2-101.ec2.internal buildkite-agent[4454]: 2021-09-20 04:20:54 INFO   buildkite-scaleinprotection-i-00102c6bcb2e28a9c-1 All agents have been idle for 600 seconds. Disconnecting...
Sep 20 04:20:54 ip-10-0-2-101.ec2.internal buildkite-agent[4454]: 2021-09-20 04:20:54 INFO   buildkite-scaleinprotection-i-00102c6bcb2e28a9c-1 Disconnecting...
Sep 20 04:20:54 ip-10-0-2-101.ec2.internal terminate-instance[4784]: sleeping for 10 seconds before terminating instance to allow agent logs to drain to cloudwatch...
Sep 20 04:21:04 ip-10-0-2-101.ec2.internal terminate-instance[4784]: requesting instance termination...
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: {
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "Activity": {
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "Description": "Terminating EC2 instance: i-00102c6bcb2e28a9c",
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "AutoScalingGroupName": "buildkite-scaleinprotection-AgentAutoScaleGroup-63TU3ILVSIGI",
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "ActivityId": "56a5f005-be8a-2631-6d83-e67bb162b693",
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "Details": "{\"Subnet ID\":\"subnet-088774992a7599844\",\"Availability Zone\":\"us-east-1b\"}",
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "StartTime": "2021-09-20T04:21:05.801Z",
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "Progress": 0,
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "Cause": "At 2021-09-20T04:21:05Z instance i-00102c6bcb2e28a9c was taken out of service in response to a user request, shrinking the capacity from 10 to 9.",
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: "StatusCode": "InProgress"
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: }
Sep 20 04:21:05 ip-10-0-2-101.ec2.internal terminate-instance[4784]: }
```