### PR TITLE
Bind mount ephemeral storage into main file system

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -134,14 +134,14 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
     BUILDKITE_AGENT_EXPERIMENTS+=",git-mirrors"
   fi
 
+  BUILDKITE_AGENT_GIT_MIRRORS_PATH="/var/lib/buildkite-agent/git-mirrors"
+
   if [ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]
   then
-    BUILDKITE_AGENT_GIT_MIRRORS_PATH="/mnt/ephemeral/git-mirrors"
-
-    mkdir -p "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
-    chown buildkite-agent: "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
-  else
-    BUILDKITE_AGENT_GIT_MIRRORS_PATH="/var/lib/buildkite-agent/git-mirrors"
+    EPHEMERAL_GIT_MIRRORS_PATH="/mnt/ephemeral/git-mirrors"
+    mkdir -p "${EPHEMERAL_GIT_MIRRORS_PATH}"
+    mount -o bind "${EPHEMERAL_GIT_MIRRORS_PATH}" "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
+    echo "${EPHEMERAL_GIT_MIRRORS_PATH} ${BUILDKITE_AGENT_GIT_MIRRORS_PATH} none defaults,bind 0 0" >>/etc/fstab
   fi
 fi
 

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -148,9 +148,10 @@ fi
 BUILDKITE_AGENT_BUILD_PATH="/var/lib/buildkite-agent/builds"
 if [ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]
 then
-  BUILDKITE_AGENT_BUILD_PATH="/mnt/ephemeral/builds"
-
-  mkdir -p "${BUILDKITE_AGENT_BUILD_PATH}"
+  EPHEMERAL_BUILD_PATH="/mnt/ephemeral/builds"
+  mkdir -p "${EPHEMERAL_BUILD_PATH}"
+  mount -o bind "${EPHEMERAL_BUILD_PATH}" "${BUILDKITE_AGENT_BUILD_PATH}"
+  echo "${EPHEMERAL_BUILD_PATH} ${BUILDKITE_AGENT_BUILD_PATH} none defaults,bind 0 0" >>/etc/fstab
   chown buildkite-agent: "${BUILDKITE_AGENT_BUILD_PATH}"
 fi
 

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -135,25 +135,30 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
   fi
 
   BUILDKITE_AGENT_GIT_MIRRORS_PATH="/var/lib/buildkite-agent/git-mirrors"
+  mkdir -p "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
 
   if [ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]
   then
     EPHEMERAL_GIT_MIRRORS_PATH="/mnt/ephemeral/git-mirrors"
     mkdir -p "${EPHEMERAL_GIT_MIRRORS_PATH}"
+
     mount -o bind "${EPHEMERAL_GIT_MIRRORS_PATH}" "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
     echo "${EPHEMERAL_GIT_MIRRORS_PATH} ${BUILDKITE_AGENT_GIT_MIRRORS_PATH} none defaults,bind 0 0" >>/etc/fstab
   fi
+
+  chown buildkite-agent: "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
 fi
 
 BUILDKITE_AGENT_BUILD_PATH="/var/lib/buildkite-agent/builds"
+mkdir -p "${BUILDKITE_AGENT_BUILD_PATH}"
 if [ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]
 then
   EPHEMERAL_BUILD_PATH="/mnt/ephemeral/builds"
   mkdir -p "${EPHEMERAL_BUILD_PATH}"
   mount -o bind "${EPHEMERAL_BUILD_PATH}" "${BUILDKITE_AGENT_BUILD_PATH}"
   echo "${EPHEMERAL_BUILD_PATH} ${BUILDKITE_AGENT_BUILD_PATH} none defaults,bind 0 0" >>/etc/fstab
-  chown buildkite-agent: "${BUILDKITE_AGENT_BUILD_PATH}"
 fi
+chown buildkite-agent: "${BUILDKITE_AGENT_BUILD_PATH}"
 
 BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value --output text)"
 


### PR DESCRIPTION
Follow up to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/557 I realised pointing the buildkite-agent config for the builds location would break [fix-buildkite-agent-builds-permissions](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/e1c5f8b3965fc9b6101c48aca24e91ef778c34a4/packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions#L77) on instances with instance storage.

Instead of parameterising the builds path, or reading it from the agent config, I decided to bind mount the ephemeral storage into the main file system. This way the paths stay the same but the underlying block device is the nvme or RAID device.

I think this is also preferable to partitioning the block device and mounting separate partitions into the `git-mirrors` and `builds` directory 🤔 this way we mount the drive(s) once in the [bk-mount-instance-storage.sh](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/packer/linux/conf/bin/bk-mount-instance-storage.sh) script and then additionally bind mount slices of that into different spots of the main file system.

Presently git-mirrors, builds, and the docker data-dir are unconditionally stored on the instance storage, but I could see this expanding to be configurable at some point.