### PR TITLE
Declare that the ASG depends on the IAM policies

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1005,6 +1005,8 @@ Resources:
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn:
+      - IAMPolicies
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       MixedInstancesPolicy:


### PR DESCRIPTION
An out-of-order deletion of these resources can result in stranded instances that can't self terminate.

See the docs in https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles for details of this.

Fixes #927 