### PR TITLE
Delete testing stacks in parallel

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,9 +36,9 @@ steps:
       - "lint"
       - "bats-tests"
 
-  - id: "launch-windows"
+  - id: "launch-windows-amd64"
     name: ":cloudformation: :windows: Launch"
-    command: .buildkite/steps/launch.sh windows
+    command: .buildkite/steps/launch.sh windows amd64
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
@@ -46,14 +46,23 @@ steps:
       - "packer-windows"
       - "deploy-service-role-stack"
 
-  - id: "test-windows"
+  - id: "test-windows-amd64"
     name: ":cloudformation: :windows: Test"
     command: "docker info"
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: "launch-windows"
+    depends_on:
+      - "launch-windows-amd64"
+
+  - id: "delete-windows-amd64"
+    name: ":cloudformation: :windows: AMD64 Delete"
+    command: .buildkite/steps/delete.sh windows amd64
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    depends_on:
+      - "test-windows-amd64"
 
   - id: "packer-linux-amd64"
     name: ":packer: :linux: AMD64"
@@ -83,7 +92,16 @@ steps:
     agents:
       stack: "buildkite-aws-stack-test-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: "launch-linux-amd64"
+    depends_on:
+      - "launch-linux-amd64"
+
+  - id: "delete-linux-amd64"
+    name: ":cloudformation: :linux: AMD64 Delete"
+    command: .buildkite/steps/delete.sh linux amd64
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    depends_on:
+      - "test-linux-amd64"
 
   - id: "packer-linux-arm64"
     name: ":packer: :linux: ARM64"
@@ -113,7 +131,26 @@ steps:
     agents:
       stack: "buildkite-aws-stack-test-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: "launch-linux-arm64"
+    depends_on: 
+      - "launch-linux-arm64"
+
+  - id: "delete-linux-arm64"
+    name: ":cloudformation: :linux: ARM64 Delete"
+    command: .buildkite/steps/delete.sh linux arm64
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    depends_on:
+      - "test-linux-arm64"
+
+  - id: "delete-service-role-stack"
+    name: ":aws-iam: :cloudformation: Delete"
+    command: .buildkite/steps/delete-service-role-stack.sh
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    depends_on:
+      - "delete-windows-amd64"
+      - "delete-linux-amd64"
+      - "delete-linux-arm64"
 
   - id: "copy-ami"
     name: ":cloudformation: 🚚 🌎"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
       - "lint"
       - "bats-tests"
 
-  - id: "packer-windows"
+  - id: "packer-windows-amd64"
     name: ":packer: :windows:"
     command: .buildkite/steps/packer.sh windows
     timeout_in_minutes: 60
@@ -37,17 +37,17 @@ steps:
       - "bats-tests"
 
   - id: "launch-windows-amd64"
-    name: ":cloudformation: :windows: Launch"
+    name: ":cloudformation: :windows: AMD64 Launch"
     command: .buildkite/steps/launch.sh windows amd64
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
     depends_on:
-      - "packer-windows"
+      - "packer-windows-amd64"
       - "deploy-service-role-stack"
 
   - id: "test-windows-amd64"
-    name: ":cloudformation: :windows: Test"
+    name: ":cloudformation: :windows: AMD64 Test"
     command: "docker info"
     timeout_in_minutes: 5
     agents:
@@ -161,7 +161,7 @@ steps:
     depends_on:
       - "test-linux-amd64"
       - "test-linux-arm64"
-      - "test-windows"
+      - "test-windows-amd64"
 
   - id: "publish"
     name: ":cloudformation: :rocket:"

--- a/.buildkite/steps/delete-service-role-stack.sh
+++ b/.buildkite/steps/delete-service-role-stack.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+service_role_stack="$(buildkite-agent meta-data get service-role-stack-name)"
+if [ -n "${service_role_stack}" ]
+then
+	echo "--- Deleting service-role stack $service_role_stack"
+	aws cloudformation delete-stack --stack-name "$service_role_stack"
+	aws cloudformation wait stack-delete-complete --stack-name "$service_role_stack"
+fi

--- a/.buildkite/steps/delete.sh
+++ b/.buildkite/steps/delete.sh
@@ -6,14 +6,14 @@ arch="${2:-amd64}"
 stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
 
 secrets_bucket=$(aws cloudformation describe-stacks \
---stack-name "${stack_name}" \
---query 'Stacks[0].Outputs[?OutputKey==`ManagedSecretsBucket`].OutputValue' \
---output text)
+	--stack-name "${stack_name}" \
+	--query "Stacks[0].Outputs[?OutputKey=='ManagedSecretsBucket'].OutputValue" \
+	--output text)
 
 secrets_logging_bucket=$(aws cloudformation describe-stacks \
---stack-name "${stack_name}" \
---query 'Stacks[0].Outputs[?OutputKey==`ManagedSecretsLoggingBucket`].OutputValue' \
---output text)
+	--stack-name "${stack_name}" \
+	--query "Stacks[0].Outputs[?OutputKey=='ManagedSecretsLoggingBucket'].OutputValue" \
+	--output text)
 
 echo "--- Deleting stack $stack_name"
 aws cloudformation delete-stack --stack-name "$stack_name"

--- a/.buildkite/steps/delete.sh
+++ b/.buildkite/steps/delete.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+os="${1:-linux}"
+arch="${2:-amd64}"
+stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
+
+secrets_bucket=$(aws cloudformation describe-stacks \
+--stack-name "${stack_name}" \
+--query 'Stacks[0].Outputs[?OutputKey==`ManagedSecretsBucket`].OutputValue' \
+--output text)
+
+secrets_logging_bucket=$(aws cloudformation describe-stacks \
+--stack-name "${stack_name}" \
+--query 'Stacks[0].Outputs[?OutputKey==`ManagedSecretsLoggingBucket`].OutputValue' \
+--output text)
+
+echo "--- Deleting stack $stack_name"
+aws cloudformation delete-stack --stack-name "$stack_name"
+aws cloudformation wait stack-delete-complete --stack-name "$stack_name"
+
+echo "--- Deleting buckets for $stack_name"
+aws s3 rb "s3://${secrets_bucket}" --force
+aws s3 rb "s3://${secrets_logging_bucket}" --force


### PR DESCRIPTION
Follow up to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/926

This moves the per-os-arch cleanup to its own step leaving the `cleanup` step to do the sweep for old resources that need deleting.