### PR TITLE
Fix resource ordering

### DIFF
--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -91,6 +91,10 @@ cat << EOF > config.json
   {
     "ParameterKey": "EnableAgentGitMirrorsExperiment",
     "ParameterValue": "true"
+  },
+  {
+    "ParameterKey": "ScaleInIdlePeriod",
+    "ParameterValue": 60,
   }
 ]
 EOF

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -94,7 +94,7 @@ cat << EOF > config.json
   },
   {
     "ParameterKey": "ScaleInIdlePeriod",
-    "ParameterValue": "60",
+    "ParameterValue": "60"
   }
 ]
 EOF

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -94,7 +94,7 @@ cat << EOF > config.json
   },
   {
     "ParameterKey": "ScaleInIdlePeriod",
-    "ParameterValue": 60,
+    "ParameterValue": "60",
   }
 ]
 EOF

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -670,11 +670,11 @@ Resources:
   # a strict ordering can be established on teardown.
   VpcComplete:
     Type: AWS::CloudFormation::WaitConditionHandle
-    Condition: CreateVpcResources
-    DependsOn:
-      - RouteDefault
-      - Subnet0Routes
-      - Subnet1Routes
+    Metadata:
+      VpcResources: !If
+        - CreateVpcResources
+        - [ !Ref RouteDefault, !Ref Subnet0Routes, !Ref Subnet1Routes ]
+        - !Ref AWS::NoValue
 
   BuildkiteAgentTokenParameter:
     Type: AWS::SSM::Parameter
@@ -1004,6 +1004,7 @@ Resources:
     Type: AWS::AutoScaling::AutoScalingGroup
     DependsOn:
       - IAMPolicies
+      - VpcComplete
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       MixedInstancesPolicy:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -752,7 +752,8 @@ Resources:
         Statement:
           - !If
             - HasSecretsBucket
-            - Effect: Allow
+            - Sid: SecretsBucket
+              Effect: Allow
               Action:
                 - s3:Get*
                 - s3:List*
@@ -766,7 +767,8 @@ Resources:
             - !Ref AWS::NoValue
           - !If
             - UseArtifactsBucket
-            - Effect: Allow
+            - Sid: ArtifactsBucket
+              Effect: Allow
               Action:
                 - s3:GetObject
                 - s3:GetObjectAcl
@@ -786,20 +788,23 @@ Resources:
               - cloudformation:DescribeStackResource
               - ec2:DescribeTags
             Resource: "*"
-          - Effect: Allow
+          - Sid: TerminateInstance
+            Effect: Allow
             Action:
               - autoscaling:DescribeAutoScalingInstances
               - autoscaling:SetInstanceHealth
               - autoscaling:TerminateInstanceInAutoScalingGroup
             Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-AgentAutoScaleGroup-*
-          - Effect: Allow
+          - Sid: Logging
+            Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
               - logs:DescribeLogStreams
             Resource: "*"
-          - Effect: Allow
+          - Sid: Ssm
+            Effect: Allow
             Action:
               - ssm:DescribeInstanceProperties
               - ssm:ListAssociations

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -645,7 +645,8 @@ Resources:
   RouteDefault:
     Type: AWS::EC2::Route
     Condition: CreateVpcResources
-    DependsOn: GatewayAttachment
+    DependsOn:
+      - GatewayAttachment
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref Gateway
@@ -664,6 +665,16 @@ Resources:
     Properties:
       SubnetId: !Ref Subnet1
       RouteTableId: !Ref Routes
+
+  # A resource that depends on the leaf nodes of the VPC configuration so that
+  # a strict ordering can be established on teardown.
+  VpcComplete:
+    Type: AWS::CloudFormation::WaitConditionHandle
+    Condition: CreateVpcResources
+    DependsOn:
+      - RouteDefault
+      - Subnet0Routes
+      - Subnet1Routes
 
   BuildkiteAgentTokenParameter:
     Type: AWS::SSM::Parameter

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -750,6 +750,36 @@ Resources:
       PolicyName: InstancePolicy
       PolicyDocument:
         Statement:
+          - !If
+            - HasSecretsBucket
+            - Effect: Allow
+              Action:
+                - s3:Get*
+                - s3:List*
+              Resource:
+                - !Sub
+                  - "arn:aws:s3:::${Bucket}/*"
+                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
+                - !Sub
+                  - "arn:aws:s3:::${Bucket}"
+                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
+            - !Ref AWS::NoValue
+          - !If
+            - UseArtifactsBucket
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:GetObjectAcl
+                - s3:GetObjectVersion
+                - s3:GetObjectVersionAcl
+                - s3:ListBucket
+                - s3:PutObject
+                - s3:PutObjectAcl
+                - s3:PutObjectVersionAcl
+              Resource:
+                - !Sub "arn:aws:s3:::${ArtifactsBucket}/*"
+                - !Sub "arn:aws:s3:::${ArtifactsBucket}"
+            - !Ref AWS::NoValue
           - Effect: Allow
             Action:
               - cloudwatch:PutMetricData
@@ -817,50 +847,6 @@ Resources:
           - Key: !Ref CostAllocationTagName
             Value: !Ref CostAllocationTagValue
           - !Ref "AWS::NoValue"
-
-  SecretsBucketPolicy:
-    Type: AWS::IAM::Policy
-    Condition: HasSecretsBucket
-    Properties:
-      PolicyName: SecretsBucketPolicy
-      PolicyDocument:
-        Statement:
-          - Effect: Allow
-            Action:
-              - s3:Get*
-              - s3:List*
-            Resource:
-              - !Sub
-                  - "arn:aws:s3:::${Bucket}/*"
-                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
-              - !Sub
-                  - "arn:aws:s3:::${Bucket}"
-                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
-      Roles:
-        - !Ref IAMRole
-
-  ArtifactsBucketPolicies:
-    Type: AWS::IAM::Policy
-    Condition: UseArtifactsBucket
-    Properties:
-      PolicyName: ArtifactsBucketPolicy
-      PolicyDocument:
-        Statement:
-          - Effect: Allow
-            Action:
-              - s3:GetObject
-              - s3:GetObjectAcl
-              - s3:GetObjectVersion
-              - s3:GetObjectVersionAcl
-              - s3:ListBucket
-              - s3:PutObject
-              - s3:PutObjectAcl
-              - s3:PutObjectVersionAcl
-            Resource:
-              - !Sub "arn:aws:s3:::${ArtifactsBucket}/*"
-              - !Sub "arn:aws:s3:::${ArtifactsBucket}"
-      Roles:
-        - !Ref IAMRole
 
   ImageIdParameterStack:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Subsequent to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/928 I found more resource ordering issues.

Similar to that change which ensures the IAM control pane continues to allow instances to `autoscaling:TerminateInstanceInAutoScalingGroup` under stack deletion, this change aims to enforce a delete ordering on the VPC resources such that the instances continue to have the _network access_ needed to instigate that terminate action. Previously there was no order dependency on the route table or route table to subnet association. Under stack deletion we could rip the networking out from under the instances again preventing them from ever being able to self terminate. This was fine so long as the instances weren’t protected from scale in because the ASG would initiate termination of them. Now that it can’t it requires a manual intervention to terminate the instance.

This change:

- Moves the conditional and standalone `AWS::IAM::Policy` resources into conditional statements of the existing `IAMPolicy` resource. There already exists a `DependsOn` relationship on this resource as of #928. Because these are conditionally created resources we cannot `DependsOn` them specifically.
- Attempts to create an unconditional `VpcComplete` resource that can be `DependsOn` by the `AutoScalingGroup` that itself establishes a conditional relationship on the leaf nodes of the VPC configuration. I’m not sure if this part is going to work yet.