### PR TITLE
Update buildkite-agent-scaler SemanticVersion 1.1.3

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1163,7 +1163,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler
-        SemanticVersion: '1.1.2'
+        SemanticVersion: '1.1.3'
       Parameters:
         BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
         BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]


### PR DESCRIPTION
Update SemanticVersion for buildkite-agent-scaler to v1.1.3 for most recent release: https://github.com/buildkite/buildkite-agent-scaler/releases/tag/v1.1.3

EDIT: had to re-roll up to 1.1.3