### PR TITLE
Add artifacts bucket config to environment hook

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -91,6 +91,15 @@ set_unless_present "AWS_DEFAULT_REGION" "$AWS_REGION"
 set_unless_present "AWS_REGION" "$AWS_REGION"
 EOF
 
+if [ -n "$BUILDKITE_ARTIFACTS_BUCKET" ]
+then
+	cat << EOF >> /var/lib/buildkite-agent/cfn-env
+
+set_always "BUILDKITE_ARTIFACTS_BUCKET" "$BUILDKITE_ARTIFACTS_BUCKET"
+set_always "BUILDKITE_ARTIFACTS_BUCKET_REGION" "$BUILDKITE_ARTIFACTS_BUCKET_REGION"
+EOF
+fi
+
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]] ; then
 	if [[ "$(uname -m)" == "aarch64" ]] ; then
 	  AGENT_ARCH="arm64"

--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -40,7 +40,7 @@ if ! /usr/local/bin/bk-check-disk-space.sh ; then
   fi
 fi
 
-if [ -n "${BUILDKITE_ARTIFACTS_BUCKET}" ]
+if [ -n "${BUILDKITE_ARTIFACTS_BUCKET:-}" ]
 then
   echo "Configuring artifacts"
 

--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -40,6 +40,14 @@ if ! /usr/local/bin/bk-check-disk-space.sh ; then
   fi
 fi
 
+if [ -n "${BUILDKITE_ARTIFACTS_BUCKET}" ]
+then
+  echo "Configuring artifacts"
+
+  export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://${BUILDKITE_ARTIFACTS_BUCKET}/${BUILDKITE_PIPELINE_ID}/${BUILDKITE_BUILD_ID}/${BUILDKITE_JOB_ID}"
+  export BUILDKITE_S3_DEFAULT_REGION="${BUILDKITE_ARTIFACTS_BUCKET_REGION}"
+fi
+
 echo "Configuring built-in plugins"
 
 [[ ! ${SECRETS_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/secrets/}

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -83,6 +83,14 @@ set_unless_present "AWS_DEFAULT_REGION" "$Env:AWS_REGION"
 set_unless_present "AWS_REGION" "$Env:AWS_REGION"
 "@
 
+if ($Env:BUILDKITE_ARTIFACTS_BUCKET -ne "") {
+  Add-Content -Path C:\buildkite-agent\cfn-env -Value @"
+
+set_always "BUILDKITE_ARTIFACTS_BUCKET" "$BUILDKITE_ARTIFACTS_BUCKET"
+set_always "BUILDKITE_ARTIFACTS_BUCKET_REGION" "$BUILDKITE_ARTIFACTS_BUCKET_REGION"
+"@
+}
+
 If ($Env:BUILDKITE_AGENT_RELEASE -eq "edge") {
   Write-Output "Downloading buildkite-agent edge..."
   Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-edge.exe -Uri "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-windows-amd64.exe"

--- a/packer/windows/conf/buildkite-agent/hooks/environment
+++ b/packer/windows/conf/buildkite-agent/hooks/environment
@@ -18,7 +18,7 @@ fi
 
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 
-if [ -n "${BUILDKITE_ARTIFACTS_BUCKET}" ]
+if [ -n "${BUILDKITE_ARTIFACTS_BUCKET:-}" ]
 then
   echo "Configuring artifacts"
 

--- a/packer/windows/conf/buildkite-agent/hooks/environment
+++ b/packer/windows/conf/buildkite-agent/hooks/environment
@@ -18,6 +18,14 @@ fi
 
 echo "~~~ :llama: Setting up elastic stack environment ($BUILDKITE_STACK_VERSION)"
 
+if [ -n "${BUILDKITE_ARTIFACTS_BUCKET}" ]
+then
+  echo "Configuring artifacts"
+
+  export BUILDKITE_ARTIFACT_UPLOAD_DESTINATION="s3://${BUILDKITE_ARTIFACTS_BUCKET}/${BUILDKITE_PIPELINE_ID}/${BUILDKITE_BUILD_ID}/${BUILDKITE_JOB_ID}"
+  export BUILDKITE_S3_DEFAULT_REGION="${BUILDKITE_ARTIFACTS_BUCKET_REGION}"
+fi
+
 echo "Configuring built-in plugins"
 
 [[ ! ${SECRETS_PLUGIN_ENABLED:-true} =~ (on|1|true) ]] && PLUGINS_ENABLED=${PLUGINS_ENABLED/secrets/}

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -975,6 +975,8 @@ Resources:
                   $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
                   $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
                   $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
+                  $Env:BUILDKITE_ARTIFACTS_BUCKET="${ArtifactsBucket}"
+                  $Env:BUILDKITE_ARTIFACTS_BUCKET_REGION="${ArtifactsBucketRegion}"
                   $Env:AWS_DEFAULT_REGION="${AWS::Region}"
                   $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
                   $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
@@ -1021,6 +1023,8 @@ Resources:
                   BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
                   BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
                   BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
+                  BUILDKITE_ARTIFACTS_BUCKET="${ArtifactsBucket}" \
+                  BUILDKITE_ARTIFACTS_BUCKET_REGION="${ArtifactsBucketRegion}" \
                   AWS_DEFAULT_REGION="${AWS::Region}" \
                   SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}" \
                   ECR_PLUGIN_ENABLED="${EnableECRPlugin}" \

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -66,6 +66,7 @@ Metadata:
         - SpotPrice
         - SecretsBucket
         - ArtifactsBucket
+        - ArtifactsBucketRegion
         - AuthorizedUsersUrl
         - BootstrapScriptUrl
         - RootVolumeSize
@@ -203,6 +204,11 @@ Parameters:
     Description: Optional - Name of an existing S3 bucket for build artifact storage
     Type: String
     Default: ""
+
+  ArtifactsBucketRegion:
+     Description: Optional - Region for the ArtifactsBucket. If blank the bucket’s region is dynamically discovered.
+     Type: String
+     Default: ""
 
   BootstrapScriptUrl:
     Description: Optional - HTTPS or S3 URL to run on each instance during boot


### PR DESCRIPTION
This exposes the existing `ArtifactsBucket` template parameter in the job environment so that artifact upload goes to the specified private bucket.

It also adds an `ArtifactBucketRegion` template parameter akin to the `SecretsBucketRegion` parameter added in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/962 to optionally bypass dynamic region discovery.

Depends on https://github.com/buildkite/agent/pull/1535 to ensure the dynamic region discovery escape hatch is present.

TODO

- [ ] Consider backwards compatibility implications of adding this config to the environment hook based on presence of existing template parameter. Add additional parameter to enable the new behaviour?

Fixes #640 