### PR TITLE
Add warm pool with new ASG lifecycle hooks

### DIFF
--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -103,6 +103,7 @@ echo "--- Building templates"
 make "mappings-for-${os}-${arch}-image" build/aws-stack.yml "IMAGE_ID=$image_id"
 
 echo "--- Validating templates"
+# 2021-11-25 KD: template larger than template-body supports, needs moving to s3
 # make validate
 
 echo "--- Creating stack ${stack_name}"

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -103,7 +103,7 @@ echo "--- Building templates"
 make "mappings-for-${os}-${arch}-image" build/aws-stack.yml "IMAGE_ID=$image_id"
 
 echo "--- Validating templates"
-make validate
+# make validate
 
 echo "--- Creating stack ${stack_name}"
 make create-stack "STACK_NAME=$stack_name" "SERVICE_ROLE=$service_role"

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -103,11 +103,10 @@ echo "--- Building templates"
 make "mappings-for-${os}-${arch}-image" build/aws-stack.yml "IMAGE_ID=$image_id"
 
 echo "--- Validating templates"
-# 2021-11-25 KD: template larger than template-body supports, needs moving to s3
-# make validate
+make validate "BUCKET_PREFIX=$stack_name"
 
 echo "--- Creating stack ${stack_name}"
-make create-stack "STACK_NAME=$stack_name" "SERVICE_ROLE=$service_role"
+make create-stack "BUCKET_PREFIX=$stack_name" "STACK_NAME=$stack_name" "SERVICE_ROLE=$service_role"
 
 echo "+++ ⌛️ Waiting for update to complete"
 ./parfait watch-stack "${stack_name}"

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ create-stack: build/aws-stack.yml env-STACK_NAME env-BUILDKITE_AWS_STACK_BUCKET 
 		--output text \
 		--stack-name $(STACK_NAME) \
 		--disable-rollback \
-		--template-url "s3://$(BUILDKITE_AWS_STACK_BUCKET)/$(BUCKET_PREFIX)/aws-stack.yml" \
+		--template-url "https://$(BUILDKITE_AWS_STACK_BUCKET).s3.amazonaws.com/$(BUCKET_PREFIX)/aws-stack.yml" \
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
 		--parameters "$$(cat config.json)" \
 		"$(role_arn)"
@@ -180,7 +180,7 @@ validate: build/aws-stack.yml env-BUILDKITE_AWS_STACK_BUCKET env-BUCKET_PREFIX
 	aws s3 cp --content-type 'text/yaml' --acl public-read build/aws-stack.yml "s3://$(BUILDKITE_AWS_STACK_BUCKET)/$(BUCKET_PREFIX)/aws-stack.yml"
 	aws cloudformation validate-template \
 		--output text \
-		--template-url "s3://$(BUILDKITE_AWS_STACK_BUCKET)/$(BUCKET_PREFIX)/aws-stack.yml"
+		--template-url "https://$(BUILDKITE_AWS_STACK_BUCKET).s3.amazonaws.com/$(BUCKET_PREFIX)/aws-stack.yml"
 
 generate-toc:
 	docker run -it --rm -v "$(PWD):/app" node:slim bash \

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -215,6 +215,12 @@ fi
 
 systemctl enable "buildkite-agent"
 
+# If warm pool is enabled, don't start the agent until the ASG BootHook
+if [ "${BUILDKITE_USE_WARM_POOL:-false}" == "false" ]
+then
+	systemctl start "buildkite-agent"
+fi
+
 # let the stack know that this host has been initialized successfully
 /opt/aws/bin/cfn-signal \
 	--region "$AWS_REGION" \

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -216,7 +216,7 @@ fi
 systemctl enable "buildkite-agent"
 
 # If warm pool is enabled, don't start the agent until the ASG BootHook
-if [ "${BUILDKITE_USE_WARM_POOL:-false}" == "false" ]
+if [ "${BUILDKITE_WARM_POOL:-false}" == "false" ]
 then
 	systemctl start "buildkite-agent"
 fi

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -210,6 +210,11 @@ If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppRestartDelay 5000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
+# If warm pool is enabled, don't start the agent until the ASG BootHook
+If ($null -eq $Env:BUILDKITE_USE_WARM_POOL -or $Env:BUILDKITE_USE_WARM_POOL -eq "false") {
+  Restart-Service buildkite-agent 
+}
+
 # renable debug tracing
 Set-PSDebug -Trace 2
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -211,7 +211,7 @@ nssm set buildkite-agent AppRestartDelay 5000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 # If warm pool is enabled, don't start the agent until the ASG BootHook
-If ($null -eq $Env:BUILDKITE_USE_WARM_POOL -or $Env:BUILDKITE_USE_WARM_POOL -eq "false") {
+If ($null -eq $Env:BUILDKITE_WARM_POOL -or $Env:BUILDKITE_WARM_POOL -eq "false") {
   Restart-Service buildkite-agent 
 }
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -231,11 +231,21 @@ Parameters:
 
   InstanceType:
     Description: Instance type. Comma-separated list with 1-4 instance types. The order is a prioritized preference for launching OnDemand instances, and a non-prioritized list of types to consider for Spot Instances (where used).
-    Type: String
+    Type: CommaDelimitedList
     Default: t3.large
     MinLength: 1
     AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
+
+  InstanceTypes:
+    Description: How many instance types are specified in InstanceType
+    Type: String
+    Default: "1"
+    AllowedValues:
+      - "1"
+      - "2"
+      - "3"
+      - "4"
 
   SpotPrice:
     Description: Maximum spot price to use for the instances, in instance cost per hour. Values >0 will result in 100% of instances being spot. 0 means only use normal (non-spot) instances. This parameter is deprecated - we recommend setting to 0 and using OnDemandPercentage to opt into spot instances.
@@ -462,6 +472,19 @@ Rules:
                 - !Ref BuildkiteAgentTokenParameterStorePath
                 - ""
         AssertDescription: "You must provide BuildkiteAgentToken or BuildkiteAgentTokenParameterStorePath"
+  WarmPoolInstanceTypeCompatible:
+    RuleCondition:
+      # If warm pool is enabled
+      !Not [ !Equals [ !Ref WarmPoolMinSize, 0 ] ]
+    Assertions:
+      # There must only be one instance type
+      - Assert:
+          !Equals [ !Ref InstanceTypes, "1" ]
+      # Spot must not be used
+      - Assert:
+          !And
+            - !Equals [ !Ref SpotPrice, 0 ]
+            - !Equals [ !Ref OnDemandPercentage, 100 ]
 
 Outputs:
   VpcId:
@@ -536,14 +559,21 @@ Conditions:
     UseDefaultRootVolumeName:
       !Equals [ !Ref RootVolumeName, "" ]
 
+    # If using spot, or multiple instances we need to use a MixedInstancesPolicy
+    UseMixedInstancesPolicy:
+      !Or
+        - !Not [ !Equals [ !Ref SpotPrice, 0 ] ]
+        - !Not [ !Equals [ !Ref OnDemandPercentage, 100 ] ]
+        - !Condition UseInstanceType2
+        - !Condition UseInstanceType3
+        - !Condition UseInstanceType4
+
     UseInstanceType2:
-      !Not [ !Equals [ !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ], ""] ]
-
+      !Equals [ !Ref InstanceTypes, "2" ]
     UseInstanceType3:
-      !Not [ !Equals [ !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ], ""] ]
-
+      !Equals [ !Ref InstanceTypes, "3" ]
     UseInstanceType4:
-      !Not [ !Equals [ !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ], ""] ]
+      !Equals [ !Ref InstanceTypes, "4" ]
 
     UseManagedPolicyARN:
       !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARN ], "" ] ]
@@ -587,15 +617,15 @@ Conditions:
 
     UsingArmInstances:
       !Or
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6gd" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "t4g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "a1" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gd" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gn" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "m6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "m6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "t4g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "a1" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "c6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "c6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "c6gn" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "r6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Select [ 0, !Ref InstanceType ] ] ], "r6gd" ]
 
     UseMaxInstanceLifetime:
       !Not [ !Equals [ !Ref MaxInstanceLifetime, 0 ] ]
@@ -912,7 +942,7 @@ Resources:
           KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
-          InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
+          InstanceType: !Select [ 0, !Ref InstanceType  ]
           MetadataOptions:
             HttpTokens: !Ref IMDSv2Tokens
             # Allow containers using a Docker network on the host to receive IDMSv2 responses
@@ -1056,29 +1086,38 @@ Resources:
       - VpcComplete
     Properties:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
+      LaunchTemplate:
+        !If
+          - !Not [ UseMixedInstancesPolicy ]
+          - LaunchTemplateId: !Ref AgentLaunchTemplate
+            Version: !GetAtt AgentLaunchTemplate.LatestVersionNumber
+          - !Ref AWS::NoValue
       MixedInstancesPolicy:
-        InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: !If [ SpotPriceSet, 0, !Ref OnDemandPercentage ]
-          SpotAllocationStrategy: capacity-optimized
-          SpotMaxPrice: !If [SpotPriceSet, !Ref SpotPrice, !Ref "AWS::NoValue"]
-        LaunchTemplate:
-          LaunchTemplateSpecification:
-            LaunchTemplateId: !Ref AgentLaunchTemplate
-            Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
-          Overrides:
-          - InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-          - !If
-            - UseInstanceType2
-            - InstanceType: !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType3
-            - InstanceType: !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType4
-            - InstanceType: !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceType, "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
+        !If
+          - UseMixedInstancesPolicy
+          - InstancesDistribution:
+              OnDemandPercentageAboveBaseCapacity: !If [ SpotPriceSet, 0, !Ref OnDemandPercentage ]
+              SpotAllocationStrategy: capacity-optimized
+              SpotMaxPrice: !If [SpotPriceSet, !Ref SpotPrice, !Ref "AWS::NoValue"]
+            LaunchTemplate:
+              LaunchTemplateSpecification:
+                LaunchTemplateId: !Ref AgentLaunchTemplate
+                Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
+              Overrides:
+              - InstanceType: !Select [ 0, !Ref InstanceType ]
+              - !If
+                - UseInstanceType2
+                - InstanceType: !Select [ 1, !Ref InstanceType ]
+                - !Ref "AWS::NoValue"
+              - !If
+                - UseInstanceType3
+                - InstanceType: !Select [ 2, !Ref InstanceType ]
+                - !Ref "AWS::NoValue"
+              - !If
+                - UseInstanceType4
+                - InstanceType: !Select [ 3, !Ref InstanceType ]
+                - !Ref "AWS::NoValue"
+          - !Ref AWS::NoValue
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 60

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1295,8 +1295,8 @@ Resources:
           Id: TargetSsmAutomation
           InputTransformer:
             InputPathsMap:
-              instanceid: "$.detail.EC2InstanceId"
-            InputTemplate: "{\"InstanceId\":[<instanceid>]}"
+              token: "$.detail.LifecycleActionToken"
+            InputTemplate: "{\"LifecycleActionToken\":[<token>]}"
 
   BootHookWarmedAutomation:
     Type: AWS::SSM::Document
@@ -1308,7 +1308,7 @@ Resources:
         assumeRole: !GetAtt AutomationRole.Arn
         description: Complete the Warmed:Pending:Wait lifecycle action
         parameters:
-          InstanceId:
+          LifecycleActionToken:
             type: String
           AutoScalingGroupName:
             type: String
@@ -1323,7 +1323,7 @@ Resources:
               Service: autoscaling
               Api: CompleteLifecycleAction
               AutoScalingGroupName: "{{ AutoScalingGroupName }}"
-              InstanceId: "{{ InstanceId }}"
+              LifecycleActionToken: "{{ LifecycleActionToken }}"
               LifecycleActionResult: "CONTINUE"
               LifecycleHookName: "{{ LifecycleHook }}"
 
@@ -1348,8 +1348,9 @@ Resources:
           Id: TargetSsmAutomation
           InputTransformer:
             InputPathsMap:
+              token: "$.detail.LifecycleActionToken"
               instanceid: "$.detail.EC2InstanceId"
-            InputTemplate: "{\"InstanceId\":[<instanceid>]}"
+            InputTemplate: "{\"InstanceId\":[<instanceid>],\"LifecycleActionToken\":[<token>]}"
 
   BootHookInServiceAutomation:
     Type: AWS::SSM::Document
@@ -1361,6 +1362,8 @@ Resources:
         assumeRole: !GetAtt AutomationRole.Arn
         description: Start the buildkite-agent and complete the launch lifecycle action
         parameters:
+          LifecycleActionToken:
+            type: String
           InstanceId:
             type: String
           AutoScalingGroupName:
@@ -1398,7 +1401,7 @@ Resources:
               Service: autoscaling
               Api: CompleteLifecycleAction
               AutoScalingGroupName: "{{ AutoScalingGroupName }}"
-              InstanceId: "{{ InstanceId }}"
+              LifecycleActionToken: "{{ LifecycleActionToken }}"
               LifecycleActionResult: "CONTINUE"
               LifecycleHookName: "{{ LifecycleHook }}"
 
@@ -1430,8 +1433,9 @@ Resources:
           Id: TargetSsmAutomation
           InputTransformer:
             InputPathsMap:
+              token: "$.detail.LifecycleActionToken"
               instanceid: "$.detail.EC2InstanceId"
-            InputTemplate: "{\"InstanceId\":[<instanceid>]}"
+            InputTemplate: "{\"InstanceId\":[<instanceid>],\"LifecycleActionToken\":[<token>]}"
 
   ShutdownHookAutomation:
     Type: AWS::SSM::Document
@@ -1442,6 +1446,8 @@ Resources:
         assumeRole: !GetAtt AutomationRole.Arn
         description: Stop the buildkite-agent, wait for it to exit, complete the launch lifecycle action
         parameters:
+          LifecycleActionToken:
+            type: String
           InstanceId:
             type: String
           AutoScalingGroupName:
@@ -1479,7 +1485,7 @@ Resources:
               Service: autoscaling
               Api: CompleteLifecycleAction
               AutoScalingGroupName: "{{ AutoScalingGroupName }}"
-              InstanceId: "{{ InstanceId }}"
+              LifecycleActionToken: "{{ LifecycleActionToken }}"
               LifecycleActionResult: "CONTINUE"
               LifecycleHookName: "{{ LifecycleHook }}"
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1209,7 +1209,9 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: autoscaling:CompleteLifecycleAction
+                Action:
+                  - autoscaling:CompleteLifecycleAction
+                  - autoscaling:TerminateInstanceInAutoScalingGroup
                 Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-AgentAutoScaleGroup-*
 
   BootHook:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1278,7 +1278,7 @@ Resources:
     Type: AWS::Events::Rule
     Condition: UseWarmPool
     Properties:
-      Description: !Sub Run the ${BootHook} warmed AWS SSM Automation
+      Description: !Sub Run the ${AgentAutoScaleGroup} ${BootHook} warmed AWS SSM Automation ${BootHookWarmedAutomation}
       EventPattern:
         source:
           - aws.autoscaling
@@ -1331,7 +1331,7 @@ Resources:
     Type: AWS::Events::Rule
     Condition: UseWarmPool
     Properties:
-      Description: !Sub Run the ${BootHook} in service AWS SSM Automation
+      Description: !Sub Run the ${AgentAutoScaleGroup} ${BootHook} in service AWS SSM Automation ${BootHookInServiceAutomation}
       EventPattern:
         source:
           - aws.autoscaling
@@ -1418,7 +1418,7 @@ Resources:
   ShutdownHookRule:
     Type: AWS::Events::Rule
     Properties:
-      Description: !Sub Run the shutdown time AWS SSM Automation for ${ShutdownHook}
+      Description: !Sub Run the ${AgentAutoScaleGroup} ${ShutdownHook} AWS SSM Automation ${ShutdownHookAutomation}
       EventPattern:
         source:
           - aws.autoscaling

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1296,7 +1296,8 @@ Resources:
           InputTransformer:
             InputPathsMap:
               token: "$.detail.LifecycleActionToken"
-            InputTemplate: "{\"LifecycleActionToken\":[<token>]}"
+              instanceid: "$.detail.EC2InstanceId"
+            InputTemplate: "{\"InstanceId\":[<instanceid>],\"LifecycleActionToken\":[<token>]}"
 
   BootHookWarmedAutomation:
     Type: AWS::SSM::Document
@@ -1308,6 +1309,8 @@ Resources:
         assumeRole: !GetAtt AutomationRole.Arn
         description: Complete the Warmed:Pending:Wait lifecycle action
         parameters:
+          InstanceId:
+            type: String
           LifecycleActionToken:
             type: String
           AutoScalingGroupName:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1070,6 +1070,7 @@ Resources:
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
       Cooldown: 60
+      CapacityRebalance: true
       MetricsCollection:
         - Granularity: 1Minute
           Metrics:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -568,6 +568,8 @@ Conditions:
         - !Condition UseInstanceType2
         - !Condition UseInstanceType3
         - !Condition UseInstanceType4
+    UseSingleInstanceLaunchTemplate:
+      !Not [ !Condition UseMixedInstancesPolicy ]
 
     UseInstanceType2:
       !Equals [ !Ref InstanceTypes, "2" ]
@@ -1089,7 +1091,7 @@ Resources:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       LaunchTemplate:
         !If
-          - !Not [ !Condition UseMixedInstancesPolicy ]
+          - UseSingleInstanceLaunchTemplate
           - LaunchTemplateId: !Ref AgentLaunchTemplate
             Version: !GetAtt AgentLaunchTemplate.LatestVersionNumber
           - !Ref AWS::NoValue

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1089,7 +1089,7 @@ Resources:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       LaunchTemplate:
         !If
-          - !Not [ UseMixedInstancesPolicy ]
+          - !Not [ !Condition UseMixedInstancesPolicy ]
           - LaunchTemplateId: !Ref AgentLaunchTemplate
             Version: !GetAtt AgentLaunchTemplate.LatestVersionNumber
           - !Ref AWS::NoValue

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1211,7 +1211,11 @@ Resources:
                 Resource:
                   - !If
                     - UseWarmPool
-                    - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookAutomation}:$DEFAULT
+                    - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookWarmedAutomation}:$DEFAULT
+                    - !Ref "AWS::NoValue"
+                  - !If
+                    - UseWarmPool
+                    - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookInServiceAutomation}:$DEFAULT
                     - !Ref "AWS::NoValue"
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${ShutdownHookAutomation}:$DEFAULT
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${SpotInteruptionAutomation}:$DEFAULT
@@ -1270,11 +1274,11 @@ Resources:
       # them
       HeartbeatTimeout: !If [ UseLinuxAgents, 300, 600 ]
 
-  BootHookRule:
+  BootHookWarmedRule:
     Type: AWS::Events::Rule
     Condition: UseWarmPool
     Properties:
-      Description: !Sub Run the boot time AWS SSM Automation for ${BootHook}
+      Description: !Sub Run the ${BootHook} warmed AWS SSM Automation
       EventPattern:
         source:
           - aws.autoscaling
@@ -1283,8 +1287,10 @@ Resources:
         detail:
           AutoScalingGroupName: [ !Ref AgentAutoScaleGroup ]
           LifecycleHookName: [ !Ref BootHook ]
+          # Launching directly into the WarmPool
+          Destination: [ "WarmPool" ]
       Targets:
-        - Arn: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookAutomation}:$DEFAULT
+        - Arn: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookWarmedAutomation}:$DEFAULT
           RoleArn: !GetAtt EventBridgeRuleRole.Arn
           Id: TargetSsmAutomation
           InputTransformer:
@@ -1292,7 +1298,60 @@ Resources:
               instanceid: "$.detail.EC2InstanceId"
             InputTemplate: "{\"InstanceId\":[<instanceid>]}"
 
-  BootHookAutomation:
+  BootHookWarmedAutomation:
+    Type: AWS::SSM::Document
+    Condition: UseWarmPool
+    Properties:
+      DocumentType: Automation
+      Content:
+        schemaVersion: "0.3"
+        assumeRole: !GetAtt AutomationRole.Arn
+        description: Complete the Warmed:Pending:Wait lifecycle action
+        parameters:
+          InstanceId:
+            type: String
+          AutoScalingGroupName:
+            type: String
+            default: !Ref AgentAutoScaleGroup
+          LifecycleHook:
+            type: String
+            default: !Ref BootHook
+        mainSteps:
+          - name: CompleteLifecycleAction
+            action: aws:executeAwsApi
+            inputs:
+              Service: autoscaling
+              Api: CompleteLifecycleAction
+              AutoScalingGroupName: "{{ AutoScalingGroupName }}"
+              InstanceId: "{{ InstanceId }}"
+              LifecycleActionResult: "CONTINUE"
+              LifecycleHookName: "{{ LifecycleHook }}"
+
+  BootHookInServiceRule:
+    Type: AWS::Events::Rule
+    Condition: UseWarmPool
+    Properties:
+      Description: !Sub Run the ${BootHook} in service AWS SSM Automation
+      EventPattern:
+        source:
+          - aws.autoscaling
+        detail-type:
+          - "EC2 Instance-launch Lifecycle Action"
+        detail:
+          AutoScalingGroupName: [ !Ref AgentAutoScaleGroup ]
+          LifecycleHookName: [ !Ref BootHook ]
+          # Launching directly into the ASG, or moving from the WarmPool into the ASG
+          Destination: [ "AutoScalingGroup" ]
+      Targets:
+        - Arn: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookInServiceAutomation}:$DEFAULT
+          RoleArn: !GetAtt EventBridgeRuleRole.Arn
+          Id: TargetSsmAutomation
+          InputTransformer:
+            InputPathsMap:
+              instanceid: "$.detail.EC2InstanceId"
+            InputTemplate: "{\"InstanceId\":[<instanceid>]}"
+
+  BootHookInServiceAutomation:
     Type: AWS::SSM::Document
     Condition: UseWarmPool
     Properties:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1394,6 +1394,9 @@ Resources:
                 Parameters:
                   executionTimeout: "300"
                   commands:
+                    # Wait for cloud-init to complete
+                    - cloud-init status --wait
+                    # Start the buildkite-agent
                     - systemctl start buildkite-agent
             - name: RunCommand
               action: aws:runCommand

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1167,7 +1167,10 @@ Resources:
               - Effect: Allow
                 Action: ssm:StartAutomationExecution
                 Resource:
-                  - !If [ UseWarmPool, !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookAutomation}:$DEFAULT, !Ref "AWS::NoValue" ]
+                  - !If
+                    - UseWarmPool
+                    - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookAutomation}:$DEFAULT
+                    - !Ref "AWS::NoValue"
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${ShutdownHookAutomation}:$DEFAULT
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${SpotInteruptionAutomation}:$DEFAULT
               - Effect: Allow

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -233,8 +233,9 @@ Parameters:
     Description: Instance type. Comma-separated list with 1-4 instance types. The order is a prioritized preference for launching OnDemand instances, and a non-prioritized list of types to consider for Spot Instances (where used).
     Type: CommaDelimitedList
     Default: t3.large
-    MinLength: 1
-    AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
+    # AllowedPattern and MinLength not allowed on a CommaDelimitedList :(
+    # MinLength: 1
+    # AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
 
   InstanceTypes:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1145,14 +1145,6 @@ Resources:
       AutoScalingReplacingUpdate:
         WillReplace: true
 
-  WarmPool: 
-    Type: AWS::AutoScaling::WarmPool
-    Condition: UseWarmPool
-    Properties:
-      AutoScalingGroupName: !Ref AgentAutoScaleGroup
-      MinSize: !Ref WarmPoolMinSize
-      PoolState: Stopped
-
   SecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: CreateSecurityGroup
@@ -1548,3 +1540,14 @@ Resources:
               Api: TerminateInstanceInAutoScalingGroup
               InstanceId: "{{ InstanceId }}"
               ShouldDecrementDesiredCapacity: false
+
+  WarmPool:
+    Type: AWS::AutoScaling::WarmPool
+    Condition: UseWarmPool
+    DependsOn:
+      - BootHookWarmedRule
+      - BootHookInServiceRule
+    Properties:
+      AutoScalingGroupName: !Ref AgentAutoScaleGroup
+      MinSize: !Ref WarmPoolMinSize
+      PoolState: Stopped

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -473,19 +473,19 @@ Rules:
                 - !Ref BuildkiteAgentTokenParameterStorePath
                 - ""
         AssertDescription: "You must provide BuildkiteAgentToken or BuildkiteAgentTokenParameterStorePath"
-  WarmPoolInstanceTypeCompatible:
-    RuleCondition:
-      # If warm pool is enabled
-      !Not [ !Equals [ !Ref WarmPoolMinSize, 0 ] ]
-    Assertions:
-      # There must only be one instance type
-      - Assert:
-          !Equals [ !Ref InstanceTypes, "1" ]
-      # Spot must not be used
-      - Assert:
-          !And
-            - !Equals [ !Ref SpotPrice, 0 ]
-            - !Equals [ !Ref OnDemandPercentage, 100 ]
+  # WarmPoolInstanceTypeCompatible:
+  #   RuleCondition:
+  #     # If warm pool is enabled
+  #     !Not [ !Equals [ !Ref WarmPoolMinSize, 0 ] ]
+  #   Assertions:
+  #     # There must only be one instance type
+  #     - Assert:
+  #         !Equals [ !Ref InstanceTypes, "1" ]
+  #     # Spot must not be used
+  #     - Assert:
+  #         !And
+  #           - !Equals [ !Ref SpotPrice, 0 ]
+  #           - !Equals [ !Ref OnDemandPercentage, 100 ]
 
 Outputs:
   VpcId:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1317,6 +1317,21 @@ Resources:
             type: String
             default: !Ref BootHook
         mainSteps:
+          - !If
+            - UseLinuxAgents
+            - name: RunCommand
+              action: aws:runCommand
+              inputs:
+                DocumentName: AWS-RunShellScript
+                InstanceIds:
+                  - "{{ InstanceId }}"
+                Parameters:
+                  executionTimeout: "300"
+                  commands:
+                    # Wait for cloud-init to complete
+                    - cloud-init status --wait
+            # TODO add a wait barrier for Windows instances to complete cloud-init
+            - !Ref AWS::NoValue
           - name: CompleteLifecycleAction
             action: aws:executeAwsApi
             inputs:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -991,11 +991,13 @@ Resources:
                   $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
                   $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
                   $Env:AWS_REGION="${AWS::Region}"
+                  $Env:BUILDKITE_WARM_POOL="${WarmPool}"
                   powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
                   </powershell>
                 - {
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
                     AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
+                    WarmPool: !If [ UseWarmPool, "true", "false" ],
                   }
               - !Sub
                 - |
@@ -1038,11 +1040,13 @@ Resources:
                   DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}" \
                   DOCKER_EXPERIMENTAL="${EnableDockerExperimental}" \
                   AWS_REGION="${AWS::Region}" \
+                  BUILDKITE_WARM_POOL="${WarmPool}" \
                     /usr/local/bin/bk-install-elastic-stack.sh
                   --==BOUNDARY==--
                 - {
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
                     AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
+                    WarmPool: !If [ UseWarmPool, "true", "false" ],
                   }
 
   AgentAutoScaleGroup:
@@ -1099,7 +1103,7 @@ Resources:
       AutoScalingReplacingUpdate:
         WillReplace: true
 
-  AsgWarmPool: 
+  WarmPool: 
     Type: AWS::AutoScaling::WarmPool
     Condition: UseWarmPool
     Properties:
@@ -1163,7 +1167,7 @@ Resources:
               - Effect: Allow
                 Action: ssm:StartAutomationExecution
                 Resource:
-                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookAutomation}:$DEFAULT
+                  - !If [ UseWarmPool, !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${BootHookAutomation}:$DEFAULT, !Ref "AWS::NoValue" ]
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${ShutdownHookAutomation}:$DEFAULT
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:automation-definition/${SpotInteruptionAutomation}:$DEFAULT
               - Effect: Allow
@@ -1210,6 +1214,7 @@ Resources:
 
   BootHook:
     Type: AWS::AutoScaling::LifecycleHook
+    Condition: UseWarmPool
     Properties:
       AutoScalingGroupName: !Ref AgentAutoScaleGroup
       LifecycleHookName: BootHook
@@ -1220,6 +1225,7 @@ Resources:
 
   BootHookRule:
     Type: AWS::Events::Rule
+    Condition: UseWarmPool
     Properties:
       Description: !Sub Run the boot time AWS SSM Automation for ${BootHook}
       EventPattern:
@@ -1241,6 +1247,7 @@ Resources:
 
   BootHookAutomation:
     Type: AWS::SSM::Document
+    Condition: UseWarmPool
     Properties:
       DocumentType: Automation
       Content:


### PR DESCRIPTION
Builds on the lifecycle hooks added in #964 and incorporates the warm pool configuration from #838.

Makes the boothook lifecycle hook conditional on the use of warm pool so that instances once again always start the agent on instance boot, unless warm pool is enabled. When warm pool is enabled, we delay agent start until the boothook triggered by the instance moving to InService.

This also changes how we parse the `InstanceType` parameter and adds an `InstanceTypes` count parameter. Warm pool is incompatible with `MixedInstanceTypes` so we need to be able to switch the Auto Scaling group resource between a static `LaunchTemplate` reference and a `MixedInstanceTypes` specification. Warm pool only supports single instance type, and on-demand instance types, using either precludes the use of an ASG warm pool. Adding the count parameter is copied from the AWS VPC Quick Start which uses a similar pattern.

---

TODO

- [ ] Fix the template `Rule` added to prevent incompatible options across spot, multiple instance types, and warm pool
- [ ] Find `wait` command for Windows instances that the `BootHookWarmedAutomation` can use to wait for ec2config, or decide that Windows instances don’t get Warm Pool support and block it using a CloudFormation template `Rule` :cry:
- [ ] Confirm how the NVMe `InstanceStorage` setting interoperates with 'stopped' EC2 instances. Since the warm pool instances are stopped and re-started, they will come up on new hardware without initialised NVMe drives. If this is irreconcilable these might be incompatible options which should be disabled using a template `Rules` entry.
- [ ] Will likely need a tunable parameter for the `BootHook` `HeartbeatTimeout` property. This is statically 5 and 10 minutes for Linux and Windows respectively right now. Presently the same launch hook is used for both Warm Pool launch events, direct to ASG launch events, and Warm Pool to ASG launch events, meaning they all have the same timeout applied. We likely want to apply distinct timeouts to each type of lifecycle movement. Launched into the warm pool the timeout should be enough for the UserData script to run to completion, launched directly into the ASG the timeout should be enough for the UserData script and the agent to start, and transitioned from the Warm Pool into the ASG should just be enough to start the agent.
- [ ] Warm Pool booted instances will cache the buildkite-agent token from the SSM parameter store. If you roll the token, you should also perform an Instance Refresh to ensure that none of the warm pool instances are sitting there with a stale token. Ideally the agent would fetch the token live and the unencrypted token wouldn’t be written to disk, but that is what it is. There may be some systemd environment hook where we could derive the token live at process start time and so should the process exit a new token be refetched.
- [ ] Possibly change the warm pool configuration from being a min size to a max size. By default the warm pool with keep the ASG max size number of instances around and stopped, for large MaxSize stacks that could be excessive. Capping max size rather than providing a floor for min size seems more useful and strikes a balance between latency sensitive customers and cost sensitive customers.