### PR TITLE
Allow Docker address pool customisation

### DIFF
--- a/packer/linux/conf/bin/bk-configure-docker.sh
+++ b/packer/linux/conf/bin/bk-configure-docker.sh
@@ -22,3 +22,6 @@ fi
 if [[ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]] ; then
   cat <<< "$(jq '."data-root"="/mnt/ephemeral/docker"' /etc/docker/daemon.json)" > /etc/docker/daemon.json
 fi
+
+# Customise address pools
+cat <<<"$(jq '."default-address-pools"=[{"base":"172.17.0.0/12","size":20},{"base":"192.168.0.0/16","size":24}]' /etc/docker/daemon.json)" >/etc/docker/daemon.json


### PR DESCRIPTION
# What

Adds the `EnableDockerClassCSubnets` flag which configure the Docker address pool to allocate `/24` subnet instead of the default `/16` and`/20`.

# Why

We're using large instance with nvme storage to leverage the docker cache in our build (`c5d.12xlarge` with 12 agents), we often get the following error:

```
ERROR: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network
```

This is because the default docker address pool configuration is as follow:


Type | Default Size | Default Pool
-- | -- | --
global | /24 | 10.0.0.0/8
local | /16 | 172.17.0.0/12
local* | /20 | 192.168.0.0/16

\* _Local networks are allocated from 172.17.0.0/12, and then 192.168.0.0/16 once 172.17.0.0/12 is exhausted._

This means you'll get the error once 32 networks are created, which can happen with large instances.

Using a `/24` allows up to 4,352 networks with 256 addresses each which should be a good compromise.

# Test

With the default settings:
```
$ sudo docker network inspect buildkitexxx_default | jq ".[].IPAM.Config"
[
  {
    "Subnet": "172.22.0.0/16",
    "Gateway": "172.22.0.1"
  }
]
```

With the option enabled:
```
$ sudo docker network inspect buildkitexxx_default | jq ".[].IPAM.Config"
[
  {
    "Subnet": "172.16.1.0/24",
    "Gateway": "172.16.1.1"
  }
]
```

# Notes

This is related to #148

Happy to rework the PR to allow for more customisation of the address pools but I thought this was a good balance between flexibility and ease of use.

Another option would be to reduce the `DOCKER_PRUNE_UNTIL` variable (which defaults to 4h) to clear more networks but this will also clear the image cache more often which is not ideal. And it still might cause issues if running lots of agents in parallel on the same instance.