### PR TITLE
fix: force symlink override if exists

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -111,7 +111,7 @@ if [[ "${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" != "" ]] ; then
 fi
 
 # Choose the right agent binary
-ln -s "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
+ln -sf "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
 
 agent_metadata=(
 	"queue=${BUILDKITE_QUEUE}"


### PR DESCRIPTION
We at NEAR use a custom AMI, recently the update of the stack started failing due to a failure while creating the buildkite-agent binary symlink:

```
Dec  1 18:08:22 ip-10-0-2-221 user-data: ln: failed to create symbolic link ‘/usr/bin/buildkite-agent’: File exists
Dec  1 18:08:22 ip-10-0-2-221 user-data: ++ on_error 113
Dec  1 18:08:22 ip-10-0-2-221 user-data: ++ local exitCode=1
Dec  1 18:08:22 ip-10-0-2-221 user-data: ++ local errorLine=113
Dec  1 18:08:22 ip-10-0-2-221 user-data: +++ curl -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' --fail --silent --show-error --location http://169.254.169.254/latest/api/token
Dec  1 18:08:22 ip-10-0-2-221 user-data: ++ local token=AQAAAOpIVEeW-ZgjyDYWEQLzrBRHKV7UxYgIi3Rm0BON3WXY1661Aw==
Dec  1 18:08:22 ip-10-0-2-221 user-data: ++ [[ 1 != 0 ]]
Dec  1 18:08:22 ip-10-0-2-221 user-data: +++ curl -H 'X-aws-ec2-metadata-token: AQAAAOpIVEeW-ZgjyDYWEQLzrBRHKV7UxYgIi3Rm0BON3WXY1661Aw==' --fail --silent --show-error --location http://169.254.169.254/latest/meta-data/instance-id
```

This wasn't the case before and I assume something in error handling has potentially changed. I was able to manually change this line of code on our AMI and tried to deploy the stack, it works now. Seems like the image we used was created from a already existing/running buildkite instance and it happened to have the symlink generated causing the rollout to fail and auto-revert.