### PR TITLE
Bump buildx from 0.5.1 to 0.7.1

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 DOCKER_VERSION=20.10.9
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.29.2
-DOCKER_BUILDX_VERSION="0.5.1"
+DOCKER_BUILDX_VERSION="0.7.1"
 MACHINE=$(uname -m)
 
 # This performs a manual install of Docker.


### PR DESCRIPTION
### Context

[buildx](https://github.com/docker/buildx) v0.5.1 was released on December 15, 2020. Since then there have been a number of releases, introducing features and fixing defects. It would be awesome to take advantage of these changes in our Buildkite CI builds!

### Change

Upgrade buildx from 0.5.1 to 0.7.1.

### Considerations

See the [buildx release notes](https://github.com/docker/buildx/releases) for details of the changes.