### PR TITLE
Recognise c7g instances as ARM

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -582,15 +582,16 @@ Conditions:
 
     UsingArmInstances:
       !Or
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6gd" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "t4g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "a1" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gd" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gn" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c7g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6gd" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6gd" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "t4g" ]
 
 Mappings:
   ECRManagedPolicy:


### PR DESCRIPTION
Recognise [newish](https://aws.amazon.com/blogs/aws/join-the-preview-amazon-ec2-c7g-instances-powered-by-new-aws-graviton3-processors/) `c7g.*` instance types as ARM so they use the `linuxarm64` AMI.

This PR is a subset of https://github.com/buildkite/elastic-ci-stack-for-aws/pull/969 …  there are other new ARM instance types, but this brings us to the limit of 10 conditions within `Fn::Or` in CloudFormation. Of the new instance type, `c7g` sounds most generally useful for CI workloads, maybe, and has been [specifically requested](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/969#issuecomment-1010509706).