### PR TITLE
Permissions boundary for Autoscaling application

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1186,7 +1186,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler
-        SemanticVersion: '1.1.3'
+        SemanticVersion: '1.3.1'
       Parameters:
         BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
         BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1190,6 +1190,7 @@ Resources:
       Parameters:
         BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
         BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]
+        RolePermissionsBoundaryARN: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, "" ]
         BuildkiteQueue: !Ref BuildkiteQueue
         AgentsPerInstance: !Ref AgentsPerInstance
         MinSize: !Ref MinSize


### PR DESCRIPTION
Attempts to deploy a Buildkite elastic-ci stack via a role with permission boundary currently fail.  It looks like the autoscaling application doesn't apply the boundary condition ARN passed to the parent stack.  
These two PRs:
https://github.com/buildkite/buildkite-agent-scaler/pull/62
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/984
address this.