### PR TITLE
Fix IAM permissions for SSM session

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -843,6 +843,7 @@ Resources:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
+              - logs:DescribeLogGroups
               - logs:DescribeLogStreams
             Resource: "*"
           - Sid: Ssm


### PR DESCRIPTION
Avoid getting the following error when "Enforce CloudWatch log
encryption" is enabled:

![image](https://user-images.githubusercontent.com/19894/155621014-3363dcd7-782d-4669-999f-bae129824b1a.png)


```
"Your session has been terminated for the following reasons: We couldn't
start the session because encryption is not set up on the selected
CloudWatch Logs log group. Either encrypt the log group or choose an
option to enable logging without encryption."
```