### PR TITLE
BuildkiteAgentToken vs BuildkiteAgentTokenParameterStorePath clarity.

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -127,13 +127,13 @@ Parameters:
     Default: "stable"
 
   BuildkiteAgentToken:
-    Description: Buildkite agent registration token. Deprecated, use BuildkiteAgentTokenParameterStorePath instead.
+    Description: Buildkite agent registration token. Or, preload it into SSM Parameter Store and use BuildkiteAgentTokenParameterStorePath for secure environments.
     Type: String
     NoEcho: true
     Default: ""
 
   BuildkiteAgentTokenParameterStorePath:
-    Description: AWS SSM path to the Buildkite agent registration token (this takes precedence over BuildkiteAgentToken). Expects a leading slash ('/').
+    Description: Existing SSM Parameter Store path to the Buildkite agent registration token (takes precedence over BuildkiteAgentToken). Expects a leading slash ('/').
     Type: String
     Default: ""
     AllowedPattern: "^$|^/[a-zA-Z0-9_.\\-/]+$"


### PR DESCRIPTION
Clarify `BuildkiteAgentToken` vs `BuildkiteAgentTokenParameterStorePath` in the stack parameter descriptions.

I don't think `BuildkiteAgentToken` is _clearly_ deprecated (yet?), so don't mention that here just now.

I think we should first revisit the dynamics/security of [CloudFormation `NoEcho` parameters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html#parameters-section-structure-properties), and the ability to create encrypted SSM Parameter Store parameters from CloudFormation.

When `BuildkiteAgentToken` is provided, we currently store it in SSM Parameter Store anyway:

```yaml
  BuildkiteAgentTokenParameter:
    Type: AWS::SSM::Parameter
    Condition: CreateAgentTokenParameter
    Properties:
      Name: !Sub "/${AWS::StackName}/buildkite/agent-token"
      Type: String
      Value: !Ref BuildkiteAgentToken
```

But it's stored unencrypted, which I suspect was a limitation of CloudFormation : SSM integration. Maybe that's improved?

Also, one of the reasons `BuildkiteAgentTokenParameterStorePath` was introduced (https://github.com/buildkite/elastic-ci-stack-for-aws/pull/601) was because managing a `NoEcho` `BuildkiteAgentToken` parameter in this stack via Terraform resulted in problems which sound more like a Terraform bug, which may or may not have been fixed since.

So — I propose we clarify the descriptions a little and un-deprecate `BuildkiteAgentToken` until we're sure of its fate.