### PR TITLE
Bump Linux from 4.14 to 5.10

### DIFF
--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -12,7 +12,7 @@
       "region": "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "amzn2-ami-hvm-2.0.*-gp2",
+          "name": "amzn2-ami-kernel-5.10-hvm-2.0.*-gp2",
           "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },


### PR DESCRIPTION
It'd be awesome to make use of the new Linux kernel.

https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-linux-2-ami-kernel-5-10/

(untested)