### PR TITLE
Use Amazon Linux 2 AMI with working cloud init

### DIFF
--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -12,7 +12,7 @@
       "region": "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "amzn2-ami-hvm-2.0.*-gp2",
+          "name": "amzn2-ami-hvm-2.0.20220207.1-gp2",
           "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },
@@ -81,4 +81,3 @@
     }
   ]
 }
-

--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -12,7 +12,7 @@
       "region": "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "amzn2-ami-hvm-2.0.20220207.1-gp2",
+          "name": "amzn2-ami-hvm-2.0.20220207.1-{{user `arch`}}-gp2",
           "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },


### PR DESCRIPTION
There's an issue confirmed by AWS support with the more recent 20220218 release where instances using AWS Nitro to fail to run cloud-init, so this PR adjusts our Packer AMI build process to use the 20220207 AL2 AMI as the base image, which doesn't have the issue.

We'll revert this PR when AWS support have confirmed that the issue is resolved.