### PR TITLE
Revert "Use Amazon Linux 2 AMI with working cloud init"

### DIFF
--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -12,7 +12,7 @@
       "region": "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "amzn2-ami-hvm-2.0.20220207.1-{{user `arch`}}-gp2",
+          "name": "amzn2-ami-hvm-2.0.*-gp2",
           "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },
@@ -81,3 +81,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
Reverts buildkite/elastic-ci-stack-for-aws#995

New AMIs have been released that fix this issue, so we can safely go back to using the latest AMIs :)