### PR TITLE
Bump Docker Buildx from 0.7.1 to 0.8.2

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 DOCKER_VERSION=20.10.9
 DOCKER_RELEASE="stable"
 DOCKER_COMPOSE_VERSION=1.29.2
-DOCKER_BUILDX_VERSION="0.7.1"
+DOCKER_BUILDX_VERSION="0.8.2"
 MACHINE=$(uname -m)
 
 # This performs a manual install of Docker.


### PR DESCRIPTION
### Context

[Docker buildx](https://github.com/docker/buildx) v0.8.0 has been released and includes a number of nice features. In particular, I'm excited about the new [remote cache support](https://www.docker.com/blog/image-rebase-and-improved-remote-cache-support-in-new-buildkit/). It would be awesome to take advantage of this in our Buildkite pipelines!

### Change

Upgrade buildx from 0.7.1 to 0.8.2.

### Considerations

See the [buildx release notes](https://github.com/docker/buildx/releases) for details of the changes:
- [v0.8.0 release notes](https://github.com/docker/buildx/releases/tag/v0.8.0)
- [v0.8.1 release notes](https://github.com/docker/buildx/releases/tag/v0.8.1)
- [v0.8.2 release notes](https://github.com/docker/buildx/releases/tag/v0.8.2)