### PR TITLE
Bump buildkite-agent to v3.35.2

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.35.1
+AGENT_VERSION=3.35.2
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.35.1"
+$AGENT_VERSION = "3.35.2"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
This PR updates the version of the buildkite agent used by the elastic stack to the latest, [v3.35.2](https://github.com/buildkite/agent/releases/tag/v3.35.2). This version includes a bugfix for a race condition, as well as a couple of dependency updates.