### PR TITLE
Allow accessing tags via instance metadata

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -928,6 +928,7 @@ Resources:
             HttpTokens: !Ref IMDSv2Tokens
             # Allow containers using a Docker network on the host to receive IDMSv2 responses
             HttpPutResponseHopLimit: 2
+            InstanceMetadataTags: enabled
           Monitoring:
             Enabled: !Ref EnableDetailedMonitoring
           ImageId: !If


### PR DESCRIPTION
With this new parameter, we can enable access from the instance to its tags via metadata.

This change does not break the current configuration, as defaults to the `disabled` value, with is the default one.