### PR TITLE
Fix mktemp issue on ubuntu(linux)

### DIFF
--- a/utils/log-collector
+++ b/utils/log-collector
@@ -55,7 +55,7 @@ outputFormat="${outputFormat:=text}"
 
 # Create a temporary directory to store our logs
 pwd=$(pwd)
-dir=$(mktemp -d "$pwd"/buildkite-logs-"$now")
+dir=$(mktemp -d "$pwd"/buildkite-logs-"$now"-XXXX)
 
 echo "Collecting logs for instance $instanceId"
 


### PR DESCRIPTION
This fixes an issue when running the log-collector script on linux based environments (or perhaps GNU).

It works on Mac/Unix, but linux requires the template passed to `mktemp` to contain at least 3 `X`'s in order to work.
