### PR TITLE
Don't accidentally send the token to logs on startup

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -161,7 +161,10 @@ then
 fi
 chown buildkite-agent: "${BUILDKITE_AGENT_BUILD_PATH}"
 
+set +x # Don't leak the agent token into logs
+echo "Setting \$BUILDKITE_AGENT_TOKEN to the value stored in the SSM Parameter $BUILDKITE_AGENT_TOKEN_PATH"
 BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value --output text)"
+set -x
 
 cat << EOF > /etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%spawn"


### PR DESCRIPTION
The elastic stack sends its startup logs to the `/buildkite/elastic-stack/{instance_id}` log group in cloudwatch, which is basically a bash script with `set -x` enabled. As part of this process, we fetch the token from SSM Parameter store, but this is included in the output, meaning that the token gets leaked into cloudwatch logs, which are potentially much less privileged than the agent tokens themselves.

![CleanShot 2022-07-05 at 10 46 49@2x](https://user-images.githubusercontent.com/15753101/177223060-46c02ffc-9bbc-4217-bc9c-122919a2b269.png)


This PR disables set -x while we do secret things, and then turns it back on afterwards