### PR TITLE
Add a missing permission in the service role

### DIFF
--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -180,7 +180,8 @@ Resources:
                 "lambda:AddPermission",
                 "lambda:RemovePermission",
                 "lambda:DeleteFunction",
-                "lambda:InvokeFunction"
+                "lambda:InvokeFunction",
+                "lambda:TagResource"
               ],
               "Resource": "arn:aws:lambda:*:*:function:*"
             },


### PR DESCRIPTION
When I tried creating a new CI stack using the IAM role defined in `templates/service-role.yml`, I got the following error:

```
User: arn:aws:iam::XXX is not authorized to perform: lambda:TagResource on resource: arn:aws:lambda:XXX
```

I submit this pull request to add the missing permission `lambda:TagResource` to the IAM role.