### PR TITLE
Bump buildkite-agent to v3.38.0

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.37.0
+AGENT_VERSION=3.38.0
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.37.0"
+$AGENT_VERSION = "3.38.0"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
Agent [v3.38](https://github.com/buildkite/agent/releases/tag/v3.38.0) is out! We should use this in new versions of the elastic stack.