### PR TITLE
Fix typo in README about log collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Provide us with logs from CloudWatch Logs:
 
 ```
 /buildkite/elastic-stack/{instance-id}
-/buildkite/systemd/{instance-id}
+/buildkite/system/{instance-id}
 ```
 ### Collect logs via script
 An alternative method to collect the logs is to use the `log-collector` script in the `utils` folder.


### PR DESCRIPTION
The log group is `system` not `systemd`