### PR TITLE
Add property to indicate if the EBS volume is encrypted

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -76,6 +76,7 @@ Metadata:
         - RootVolumeSize
         - RootVolumeName
         - RootVolumeType
+        - RootVolumeEncrypted
         - ManagedPolicyARN
         - InstanceRoleName
         - InstanceRolePermissionsBoundaryARN
@@ -324,6 +325,14 @@ Parameters:
     Description: Type of root volume to use
     Type: String
     Default: "gp3"
+
+  RootVolumeEncrypted:
+    Description: Indicates whether the EBS volume is encrypted
+    Type: String
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
 
   SecurityGroupId:
     Type: String
@@ -975,7 +984,7 @@ Resources:
                     - 'linuxamd64'
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
-              Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType }
+              Ebs: { VolumeSize: !Ref RootVolumeSize, VolumeType: !Ref RootVolumeType, Encrypted: !Ref RootVolumeEncrypted }
           TagSpecifications:
             - ResourceType: instance
               Tags:


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-blockdevicemapping-ebs.html#cfn-ec2-launchtemplate-blockdevicemapping-ebs-encrypted, add the option to indicate if the EBS volume is encrypted or not. Default value: `false`

![image](https://user-images.githubusercontent.com/6607375/200064128-6d679092-f39f-4c7b-8b7a-9e3f6013e01a.png)


(requested by a customer 🙂)