### PR TITLE
Enable GroupDesiredCapacity metric collection on ASGs by default

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1128,6 +1128,7 @@ Resources:
             - GroupInServiceInstances
             - GroupTerminatingInstances
             - GroupPendingInstances
+            - GroupDesiredCapacity
       TerminationPolicies:
         - OldestLaunchConfiguration
         - ClosestToNextInstanceHour


### PR DESCRIPTION
Our team would like to monitor this metric, see slack thread for more details: https://rippling.slack.com/archives/C03HS62QYQJ/p1668464627626499