### PR TITLE
Bump lifecycled to v3.3.0

### DIFF
--- a/packer/linux/scripts/install-lifecycled.sh
+++ b/packer/linux/scripts/install-lifecycled.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-LIFECYCLED_VERSION=v3.2.0
+LIFECYCLED_VERSION=v3.3.0
 
 MACHINE=$(uname -m)
 
@@ -19,4 +19,3 @@ sudo curl -Lf -o /usr/bin/lifecycled \
 sudo chmod +x /usr/bin/lifecycled
 sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
 	https://raw.githubusercontent.com/buildkite/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit
-


### PR DESCRIPTION
## [v3.3.0](https://github.com/buildkite/lifecycled/tree/v3.3.0) (2022-10-19)
[Full Changelog](https://github.com/buildkite/lifecycled/compare/v3.2.0...v3.3.0)

### Added
- Support configuring intervals for spot instance termination and autoscaling heartbeats [#97](https://github.com/buildkite/lifecycled/pull/97) (@stevenmatthewt)