### PR TITLE
Increase timeout for `docker info` goss test and bump goss to latest version

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -115,6 +115,7 @@ command:
   # Checks that docker is running
   "docker info":
     exit-status: 0
+    timeout: 30000 # it can take some time for the daemon to start
 
   # Checks that docker containers can run
   "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker:latest version":

--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -23,4 +23,4 @@ echo "Configuring awscli to use v4 signatures..."
 sudo aws configure set s3.signature_version s3v4
 
 echo "Installing goss for system validation..."
-curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.6 sudo sh
+curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.20 sudo sh


### PR DESCRIPTION
I was investigating some pipeline flakeyness and I think this will improve the situation. The previous default timeout was 10s, it is now 30s.

Bumping the version of [goss](https://github.com/goss-org/goss) is not necessary, but it should not hurt if the pipeline succeeds.