### PR TITLE
Add permissions to service role to allow deployment and deletion of encrypted s3 buckets with Bucket Policy

### DIFF
--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -204,7 +204,8 @@ Resources:
                 "s3:PutBucketTagging",
                 "s3:PutBucketVersioning",
                 "s3:PutEncryptionConfiguration",
-                "s3:PutBucketPolicy"
+                "s3:PutBucketPolicy",
+                "s3:DeleteBucketPolicy"
               ],
               "Resource": "arn:aws:s3:::*"
             },

--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -202,7 +202,9 @@ Resources:
                 "s3:PutBucketAcl",
                 "s3:PutBucketLogging",
                 "s3:PutBucketTagging",
-                "s3:PutBucketVersioning"
+                "s3:PutBucketVersioning",
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketPolicy"
               ],
               "Resource": "arn:aws:s3:::*"
             },


### PR DESCRIPTION
This is necessary prior to merging https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1050.
Ideally we should rebase that PR over master and run a build on it again, however it's a contributed PR, so we may not expect that.
I have cherry-picked those commits and run a build on with the commits in this PR applied, and it seems to work: https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/2884.