### PR TITLE
Push access logs to cloudwatch for linux instances

### DIFF
--- a/packer/linux/conf/cloudwatch-agent/config.json
+++ b/packer/linux/conf/cloudwatch-agent/config.json
@@ -47,6 +47,12 @@
 						"log_group_name": "/buildkite/system",
 						"log_stream_name": "{instance_id}",
 						"timestamp_format": "%b %d %H:%M:%S"
+					},
+					{
+						"file_path": "/var/log/secure",
+						"log_group_name": "/buildkite/auth",
+						"log_stream_name": "{instance_id}",
+						"timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
 					}
 				]
 			}


### PR DESCRIPTION
**This PR:** Adds a clause to the cloudwatch agent configuration in elastic stack instances to forward logs from `/var/log/secure` to a new Cloudwatch Logs stream, `/buildkite/auth/{instance_id}`. Here's an annotated (and slightly edited for clarity) sample of logs from that log stream:
```
// Attempting to log in with an invalid user
Jan 15 21:57:15 ip-10-0-2-201 sshd[3113]: Invalid user ben from 122.58.194.209 port 56616
Jan 15 21:57:15 ip-10-0-2-201 sshd[3113]: input_userauth_request: invalid user ben [preauth]
// oh noes, they're trying to get into the admin user
Jan 15 22:05:43 ip-10-0-2-201 sshd[3634]: Invalid user admin from 1.34.170.6 port 36540
Jan 15 22:05:43 ip-10-0-2-201 sshd[3634]: input_userauth_request: invalid user admin [preauth]
Jan 15 22:05:45 ip-10-0-2-201 sshd[3634]: Connection reset by 1.34.170.6 port 36540 [preauth]
// Someone has logged into the ec2-user user successfully
Jan 15 22:07:33 ip-10-0-2-201 sshd[3727]: Accepted publickey for ec2-user from 122.58.194.209 port 56861 ssh2: RSA SHA256:EFe0f3vSM5Z9iBFxMT3lF76Q3NjD4pA8QnPhWYFlIms
Jan 15 22:07:33 ip-10-0-2-201 sshd[3727]: pam_unix(sshd:session): session opened for user ec2-user by (uid=0)
// They ran the `sudo su`
Jan 15 22:08:23 ip-10-0-2-201 sudo: ec2-user : TTY=pts/0 ; PWD=/home/ec2-user ; USER=root ; COMMAND=/bin/su
Jan 15 22:08:23 ip-10-0-2-201 sudo: pam_unix(sudo:session): session opened for user root by ec2-user(uid=0)
Jan 15 22:08:23 ip-10-0-2-201 su: pam_unix(su:session): session opened for user root by ec2-user(uid=0)
// Then they logged out of the root account
Jan 15 22:09:11 ip-10-0-2-201 su: pam_unix(su:session): session closed for user root
Jan 15 22:09:11 ip-10-0-2-201 sudo: pam_unix(sudo:session): session closed for user root
// They ran `sudo echo "hi there"`. Scary!
Jan 15 22:09:16 ip-10-0-2-201 sudo: ec2-user : TTY=pts/0 ; PWD=/home/ec2-user ; USER=root ; COMMAND=/bin/echo hi there
Jan 15 22:09:16 ip-10-0-2-201 sudo: pam_unix(sudo:session): session opened for user root by ec2-user(uid=0)
Jan 15 22:09:16 ip-10-0-2-201 sudo: pam_unix(sudo:session): session closed for user root
// And now they're gone
Jan 15 22:10:45 ip-10-0-2-201 sshd[3761]: Received disconnect from 122.58.194.209 port 56861:11: disconnected by user
Jan 15 22:10:45 ip-10-0-2-201 sshd[3761]: Disconnected from 122.58.194.209 port 56861
Jan 15 22:10:45 ip-10-0-2-201 sshd[3727]: pam_unix(sshd:session): session closed for user ec2-user
// 👇 this is what someone trying to ssh in with an invalid key looks like
Jan 15 22:14:17 ip-10-0-2-201 sshd[4159]: Connection closed by 122.58.194.209 port 56931 [preauth]
Jan 15 22:15:02 ip-10-0-2-201 sshd[4220]: Connection closed by 122.58.194.209 port 56935 [preauth]
```

Interestingly, while conducting this testing, it looks like someone tried (and failed) to get into another box in the stack that i stood up:
```
Jan 15 21:57:42 ip-10-0-1-73 sshd[3133]: Connection reset by 76.248.42.241 port 38958 [preauth]
--
Jan 15 21:59:15 ip-10-0-1-73 sshd[3213]: reverse mapping checking getaddrinfo for 18-232-213-49.tinp.net.tw [49.213.232.18] failed - POSSIBLE BREAK-IN ATTEMPT!
Jan 15 21:59:16 ip-10-0-1-73 sshd[3213]: Connection reset by 49.213.232.18 port 60564 [preauth]
Jan 15 22:00:24 ip-10-0-1-73 sshd[3272]: Connection reset by 125.228.182.253 port 49384 [preauth]
Jan 15 22:07:27 ip-10-0-1-73 sshd[3704]: Invalid user admin from 111.70.9.103 port 55166
Jan 15 22:07:27 ip-10-0-1-73 sshd[3704]: input_userauth_request: invalid user admin [preauth]
Jan 15 22:07:31 ip-10-0-1-73 sshd[3704]: error: maximum authentication attempts exceeded for invalid user admin from 111.70.9.103 port 55166 ssh2 [preauth]
Jan 15 22:07:31 ip-10-0-1-73 sshd[3704]: Disconnecting: Too many authentication failures [preauth]
Jan 15 22:07:41 ip-10-0-1-73 sshd[3712]: Invalid user admin from 111.70.9.103 port 55300
Jan 15 22:07:41 ip-10-0-1-73 sshd[3712]: input_userauth_request: invalid user admin [preauth]
Jan 15 22:07:42 ip-10-0-1-73 sshd[3712]: Connection reset by 111.70.9.103 port 55300 [preauth]
Jan 15 22:14:36 ip-10-0-1-73 sshd[4087]: error: maximum authentication attempts exceeded for root from 125.137.36.18 port 62826 ssh2 [preauth]
Jan 15 22:14:36 ip-10-0-1-73 sshd[4087]: Disconnecting: Too many authentication failures [preauth]
Jan 15 22:14:40 ip-10-0-1-73 sshd[4093]: Connection reset by 125.137.36.18 port 62892 [preauth]
Jan 15 22:16:47 ip-10-0-1-73 sshd[4200]: reverse mapping checking getaddrinfo for h92-192-72-105.seed.net.tw [192.72.105.92] failed - POSSIBLE BREAK-IN ATTEMPT!
Jan 15 22:16:49 ip-10-0-1-73 sshd[4200]: Connection reset by 192.72.105.92 port 60087 [preauth]
```