### PR TITLE
Bump git to v2.39.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,7 +48,9 @@ steps:
 
   - id: "test-windows-amd64"
     name: ":cloudformation: :windows: AMD64 Test"
-    command: "docker info"
+    command:
+      - git --version
+      - docker info
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-windows-amd64-${BUILDKITE_BUILD_NUMBER}"
@@ -87,7 +89,9 @@ steps:
 
   - id: "test-linux-amd64"
     name: ":cloudformation: :linux: AMD64 Test"
-    command: "goss validate --format documentation"
+    command:
+      - git --version
+      - goss validate --format documentation
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
@@ -126,12 +130,14 @@ steps:
 
   - id: "test-linux-arm64"
     name: ":cloudformation: :linux: ARM64 Test"
-    command: "goss validate --format documentation"
+    command:
+      - git --version
+      - goss validate --format documentation
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-arm64-${BUILDKITE_BUILD_NUMBER}"
-    depends_on: 
+    depends_on:
       - "launch-linux-arm64"
 
   - id: "delete-linux-arm64"

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -13,7 +13,6 @@ esac
 
 echo "Installing dependencies..."
 sudo yum update -y -q
-sudo yum install -y -q git-core
 
 echo "Creating buildkite-agent user and group..."
 sudo useradd --base-dir /var/lib --uid 2000 buildkite-agent

--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -22,5 +22,21 @@ sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 echo "Configuring awscli to use v4 signatures..."
 sudo aws configure set s3.signature_version s3v4
 
+# https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
+GIT_VERSION=2.39.1
+echo "Installing git $GIT_VERSION from source"
+sudo yum -y groupinstall "Development Tools"
+pushd "$(mktemp -d)"
+curl -sSL "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz" | tar xJ
+pushd git-"$GIT_VERSION"
+make configure
+./configure --prefix=/usr
+make all
+sudo make install
+git --version
+sudo yum -y groupremove "Development Tools"
+popd
+popd
+
 echo "Installing goss for system validation..."
 curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.20 sudo sh

--- a/packer/windows/scripts/install-utils.ps1
+++ b/packer/windows/scripts/install-utils.ps1
@@ -12,7 +12,7 @@ choco install -y awscli --version=1.18.11
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing Git for Windows"
-choco install -y git --version 2.31.0
+choco install -y git --version 2.39.1
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Write-Output "Installing nssm"


### PR DESCRIPTION
In response to [some recent CVEs in git](https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2), we are updating the version of git installed on windows and linux to be v2.39.1.

Unfortunately for the linux AMIs, the version of the git-core pacakge avaliable in the default Amazon Linux 2 repos had not been updated to v2.39.1, so we are installing it from source.