### PR TITLE
Update changelog for v5.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.16.0](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v5.16.0) (2023-01-19)
+[Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.15.0...v5.16.0)
+
+### Security
+- Git is updated to v2.39.1 to address [recent vulnerabilities](https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/) [#1077](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1077) (@triarius)
+
+### Added
+- Access logs are now pushed to Cloudwatch for Linux instances [#1075](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1075) (@moskyb)
+
+### Changed
+- Bump buildkite-agent to v3.43.0 [#1079](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1079) (@DrJosh9000)
+
+
 ## [v5.15.0](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v5.15.0) (2023-01-06)
 [Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.14.0...v5.15.0)
 


### PR DESCRIPTION
## [v5.16.0](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v5.16.0) (2023-01-19)
[Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.15.0...v5.16.0)

### Security
- Git is updated to v2.39.1 to address [recent vulnerabilities](https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/) [#1077](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1077) (@triarius)

### Added
- Access logs are now pushed to Cloudwatch for Linux instances [#1075](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1075) (@moskyb)

### Changed
- Bump buildkite-agent to v3.43.0 [#1079](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1079) (@DrJosh9000)