### PR TITLE
Bump buildkite-agent to v3.43.1

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.43.0
+AGENT_VERSION=3.43.1
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.43.0"
+$AGENT_VERSION = "3.43.1"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
[v3.43.1](https://github.com/buildkite/agent/releases/tag/v3.43.1) fixes a critical bug which makes any acquired job that runs for more than ~4.5 minutes fail