### PR TITLE
Add changelog for 5.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v5.16.1](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v5.16.1) (2023-01-20)
+[Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.16.0...v5.16.1)
+
+### Changed
+- Bump buildkite-agent to v3.43.1 [#1083](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1083) (@moskyb)
+
 ## [v5.16.0](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v5.16.0) (2023-01-19)
 [Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.15.0...v5.16.0)
 


### PR DESCRIPTION
## [5.16.1](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/5.16.1) (2023-01-20)
[Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.16.0...5.16.1)

### Changed
- Bump buildkite-agent to v3.43.1 [#1083](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1083) (@moskyb)