### PR TITLE
correct invalid SSM policy action

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -913,7 +913,7 @@ Resources:
               - ec2messages:FailMessage
               - ec2messages:GetEndpoint
               - ec2messages:GetMessages
-              - ec2messages:SendRepl
+              - ec2messages:SendReply
             Resource: "*"
       Roles:
         - !Ref IAMRole


### PR DESCRIPTION
`ec2messages:SendRepl` isn't a valid policy action. We've been getting error messages about invalid IAM policy in some of our accounts. I don't have the inside story from AWS here but I wonder if they have started being more strict on these

https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html

Note this has not been tested by me yet, but looks more correct than the current state :-)