### PR TITLE
Build git 2.39.1 with rpm

### DIFF
--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -22,20 +22,32 @@ sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 echo "Configuring awscli to use v4 signatures..."
 sudo aws configure set s3.signature_version s3v4
 
-# https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source
 GIT_VERSION=2.39.1
-echo "Installing git $GIT_VERSION from source"
-sudo yum -y groupinstall "Development Tools"
+echo "Installing git $GIT_VERSION"
+sudo yum install -y rpm-build yum-utils
+sudo amazon-linux-extras install epel -y
+
 pushd "$(mktemp -d)"
-curl -sSL "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz" | tar xJ
-pushd git-"$GIT_VERSION"
-make configure
-./configure --prefix=/usr
-make all
-sudo make install
-git --version
-sudo yum -y groupremove "Development Tools"
+yumdownloader --source git-2.38.1
+rpm -ivh git-2.38.1-1.amzn2.0.1.src.rpm
 popd
+
+pushd "$HOME/rpmbuild/SOURCES"
+curl -sSLOJ "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz"
+curl -sSLOJ "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.sign"
+popd
+
+pushd "$HOME/rpmbuild/SPECS"
+# we don't want to build with docs, it pulls in a lot of dependencies we do not want
+sed -i '/^%if %{with docs}$/,/^# endif with docs$/d' git.spec
+# bump the version
+sed -i 's/tarball_version 2.38.1/tarball_version '"${GIT_VERSION}"'/;s/Version:        2.38.1/Version:        '"${GIT_VERSION}/" git.spec
+sudo yum-builddep -y git.spec
+rpmbuild -ba --nocheck --nodeps --without docs --without tests git.spec
+popd
+
+pushd "$HOME/rpmbuild/RPMS"
+sudo yum localinstall -y noarch/* "$(uname -m)"/*
 popd
 
 echo "Installing goss for system validation..."

--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -38,10 +38,17 @@ curl -sSLOJ "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERS
 popd
 
 pushd "$HOME/rpmbuild/SPECS"
-# we don't want to build with docs, it pulls in a lot of dependencies we do not want
+# We don't want to build with docs, it pulls in a lot of dependencies we do not want
+# While this can be achieved just by passing --without docs into `rpmbuild`, as we do below,
+# a similar flag does not exist on `yum-builddep`, so we will just remove the blocks entirely
 sed -i '/^%if %{with docs}$/,/^# endif with docs$/d' git.spec
+
 # bump the version
 sed -i 's/tarball_version 2.38.1/tarball_version '"${GIT_VERSION}"'/;s/Version:        2.38.1/Version:        '"${GIT_VERSION}/" git.spec
+
+# some systems will have openssl11-devel installed, but it conflicts with openssl-devel
+sed -i 's/BuildRequires:  openssl-devel/BuildRequires:  openssl11-devel/' git.spec
+
 sudo yum-builddep -y git.spec
 rpmbuild -ba --nocheck --nodeps --without docs --without tests git.spec
 popd


### PR DESCRIPTION
We started to build git from source to update it to a version that was not vulrenable to [CVE-2022-23521](https://nvd.nist.gov/vuln/detail/CVE-2022-23521), as the version in the Amazon Linux 2 core repo was not (and is still not) updated to a non vulrenable version.

However, even though we followed the [official instructions to build it from source](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git#_installing_from_source), there were was a discripency with the expected path for the system git config was [surfaced](https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1085#issuecomment-1408595131) to us. Essentially, configuring the build with the `/usr` prefix moves the expected path for the system config from `/etc/gitconfig` to `/usr/etc/gitconfig`.

While we tried to build it with a `/` prefix, that build failed: https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/2982 with the message `git: 'remote-https' is not a git command. See 'git --help'.` when trying to checkout a repo in tests.

Rather than debugging this, in this PR we download the RPM source for the git package from the Amazon Linux 2 repos and bump the version ourselves. This has been confirmed to preserve the system gitconfig path. There were a few wrinkles along the way:

1. Building with docs pulled in some x11 packages. We think its not appropriate to have these on a essentially headless system like the elastic-ci-stack. The usefulness of docs on such a system is also questionable, so we elected to build without docs.
2. While `rpmbuild` has a system to make parts of the build, like docs optional, this did not extend to the tool we use to install build dependencies, yum-builddep. So we were forced to remove the optional docs build dependencies. We did this with `sed` in a way that removes all optional docs blocks from the rpm. It should not be a problem as the would be ignored by `rpmbuild --without docs` anyway.
3. On arm64 instances, the build dep of `openssl-devel` (which resolved to `1:openssl-devel-1.0.2k-24.amzn2.0.4.aarch64`) would conflict with a previously installed `openssl11-devel` package. Since git should be able to compile when built with either version of openssl, we replace the `openssl-devel` build dep with `openssl11-devel`.