### PR TITLE
Return to installing git from the AL2 repos

### DIFF
--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -22,40 +22,5 @@ sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 echo "Configuring awscli to use v4 signatures..."
 sudo aws configure set s3.signature_version s3v4
 
-GIT_VERSION=2.39.1
-echo "Installing git $GIT_VERSION"
-sudo yum install -y rpm-build yum-utils
-sudo amazon-linux-extras install epel -y
-
-pushd "$(mktemp -d)"
-yumdownloader --source git-2.38.1
-rpm -ivh git-2.38.1-1.amzn2.0.1.src.rpm
-popd
-
-pushd "$HOME/rpmbuild/SOURCES"
-curl -sSLOJ "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz"
-curl -sSLOJ "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.sign"
-popd
-
-pushd "$HOME/rpmbuild/SPECS"
-# We don't want to build with docs, it pulls in a lot of dependencies we do not want
-# While this can be achieved just by passing --without docs into `rpmbuild`, as we do below,
-# a similar flag does not exist on `yum-builddep`, so we will just remove the blocks entirely
-sed -i '/^%if %{with docs}$/,/^# endif with docs$/d' git.spec
-
-# bump the version
-sed -i 's/tarball_version 2.38.1/tarball_version '"${GIT_VERSION}"'/;s/Version:        2.38.1/Version:        '"${GIT_VERSION}/" git.spec
-
-# some systems will have openssl11-devel installed, but it conflicts with openssl-devel
-sed -i 's/BuildRequires:  openssl-devel/BuildRequires:  openssl11-devel/' git.spec
-
-sudo yum-builddep -y git.spec
-rpmbuild -ba --nocheck --nodeps --without docs --without tests git.spec
-popd
-
-pushd "$HOME/rpmbuild/RPMS"
-sudo yum localinstall -y noarch/* "$(uname -m)"/*
-popd
-
 echo "Installing goss for system validation..."
 curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.20 sudo sh


### PR DESCRIPTION
https://alas.aws.amazon.com/AL2/ALAS-2023-1923.html has dropped so we
can go back to installing git from the repos.

And I checked it's been updated for the repo that the docker equivalent is using at least.

```
🕙 13:20:33 ❯ docker run --rm -it amazonlinux:latest yum info git
Loaded plugins: ovl, priorities
amzn2-core                                                                                                                                                                                                                                                                                              | 3.7 kB  00:00:00
(1/3): amzn2-core/2/x86_64/group_gz                                                                                                                                                                                                                                                                     | 2.5 kB  00:00:00
(2/3): amzn2-core/2/x86_64/updateinfo                                                                                                                                                                                                                                                                   | 552 kB  00:00:00
(3/3): amzn2-core/2/x86_64/primary_db                                                                                                                                                                                                                                                                   |  68 MB  00:00:05
Available Packages
Name        : git
Arch        : x86_64
Version     : 2.39.1
Release     : 1.amzn2.0.1
Size        : 65 k
Repo        : amzn2-core/2/x86_64
Summary     : Fast Version Control System
URL         : https://git-scm.com/
License     : BSD-3-Clause AND GPL-2.0-only AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT
Description : Git is a fast, scalable, distributed revision control system with an
            : unusually rich command set that provides both high-level operations
            : and full access to internals.
            :
            : The git rpm installs common set of tools which are usually using with
            : small amount of dependencies. To install all git packages, including
            : tools for integrating with other SCMs, install the git-all meta-package.
```