### PR TITLE
Add support for c7gn, m7g, and r7g instance type classes to use the arm64 AMI

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -649,6 +649,7 @@ Conditions:
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gd" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c6gn" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c7g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "c7gn" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "g5g" ]
         - !Or
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "Im4gn" ]
@@ -656,9 +657,11 @@ Conditions:
         - !Or
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6g" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m6gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "m7g" ]
         - !Or
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6g" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r6gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r7g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "t4g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "x2gd" ]
 


### PR DESCRIPTION
Otherwise they will launched with the amd64 ami and the stack will fail to
launch and be rolled back.