### PR TITLE
Explicitly Disable Public Access For Managed Secrets Buckets

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -933,6 +933,11 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         !If
         - EnforceSecretsBucketEncryption
@@ -985,6 +990,11 @@ Resources:
         DestinationBucketName: !Ref ManagedSecretsLoggingBucket
       VersioningConfiguration:
         Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - !If
           - UseCostAllocationTags

--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -205,7 +205,8 @@ Resources:
                 "s3:PutBucketVersioning",
                 "s3:PutEncryptionConfiguration",
                 "s3:PutBucketPolicy",
-                "s3:DeleteBucketPolicy"
+                "s3:DeleteBucketPolicy",
+                "s3:PutBucketPublicAccessBlock"
               ],
               "Resource": "arn:aws:s3:::*"
             },


### PR DESCRIPTION
We don't encourage anyone to create objects in these buckets that have public ACLs.
However, I don't think there is a use case for public access for the entire bucket though, so let's disable it.