### PR TITLE
Fix error with docker experimental CLI

### DIFF
--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -10,8 +10,11 @@ BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY=$(mktemp -d)
 export BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY
 export DOCKER_CONFIG="$BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY"
 
-if [ "${BUILDKITE_DOCKER_EXPERIMENTAL:-false}" = "true" ]
-then
+if [ "${BUILDKITE_DOCKER_EXPERIMENTAL:-false}" = "true" ]; then
+  if [ ! -f "${DOCKER_CONFIG}/config.json" ]; then
+    echo "{}" > "${DOCKER_CONFIG}/config.json"
+  fi
+
   #shellcheck disable=SC2094 # Redirections to the same command are processed in order
   cat <<< "$(jq '.experimental="enabled"' "${DOCKER_CONFIG}/config.json")" > "${DOCKER_CONFIG}/config.json"
 fi


### PR DESCRIPTION
The elastic stack assumed that when docker experimental CLI was enabled, that there was already a docker config.json file. This meant that if one wasn't present, the elastic stack environment hook would fail every time