### PR TITLE
Parameterise ASG Termination Policies

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -97,6 +97,7 @@ Metadata:
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
         - InstanceCreationTimeout
+        - TerminationPolicies
 
       - Label:
           default: Cost Allocation Configuration
@@ -331,6 +332,11 @@ Parameters:
     Description: Timeout period for Autoscaling Group Creation Policy
     Type: String
     Default: ""
+
+  TerminationPolicies:
+    Description: Optional - Autoscaling Group termination policies
+    Type: CommaDelimitedList
+    Default: "OldestLaunchConfiguration,ClosestToNextInstanceHour"
 
   RootVolumeSize:
     Description: Size of each instance's root EBS volume (in GB)
@@ -1239,9 +1245,7 @@ Resources:
             - GroupTerminatingInstances
             - GroupPendingInstances
             - GroupDesiredCapacity
-      TerminationPolicies:
-        - OldestLaunchConfiguration
-        - ClosestToNextInstanceHour
+      TerminationPolicies: !Ref TerminationPolicies
       NewInstancesProtectedFromScaleIn: true
     CreationPolicy:
       ResourceSignal:


### PR DESCRIPTION
This change adds a Parameter for setting the ASG Termination Policies, with defaults to keep it backward-compatible.

FWIW, our particular use case for this is so we can proritise the `NewestInstance` policy, meaning that we keep instances for longer in order to maintain a warm docker cache (our queue isn't busy enough to justify a dedicated queue for this).