### PR TITLE
fix: remove ACL from logging bucket

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -944,6 +944,11 @@ Resources:
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         !If
         - EnforceSecretsBucketEncryption
@@ -1013,6 +1018,11 @@ Resources:
         DestinationBucketName: !Ref ManagedSecretsLoggingBucket
       VersioningConfiguration:
         Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - !If
           - UseCostAllocationTags

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -970,7 +970,8 @@ Resources:
         Statement:
         - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
           Effect: Allow
-          Principal: 'logging.s3.amazonaws.com'
+          Principal:
+            Service: 'logging.s3.amazonaws.com'
           Action:
           - 's3:PutObject'
           Resource:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -944,12 +944,6 @@ Resources:
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
       BucketEncryption:
         !If
         - EnforceSecretsBucketEncryption
@@ -967,23 +961,39 @@ Resources:
 
   ManagedSecretsLoggingBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Condition: EnforceSecretsBucketEncryption
+    Condition: CreateSecretsBucket
     Properties:
       Bucket: !Ref ManagedSecretsLoggingBucket
       PolicyDocument:
         Id: ManagedSecretsLoggingBucketPolicy
         Version: "2012-10-17"
         Statement:
-        - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
-          Effect: Deny
-          Principal: '*'
-          Action: 's3:*'
+        - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
+          Effect: Allow
+          Principal: 'logging.s3.amazonaws.com'
+          Action:
+          - 's3:PutObject'
           Resource:
           - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
           - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
           Condition:
-            Bool:
-              'aws:SecureTransport': false
+            ArnLike:
+              'aws:SourceArn': !GetAtt 'ManagedSecretsBucket.Arn'
+            StringEquals:
+              'aws:SourceAccount': !Ref 'AWS::AccountId'
+        - !If
+          - EnforceSecretsBucketEncryption
+          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+            - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
+            - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': false
+          - !Ref "AWS::NoValue"
 
   ManagedSecretsBucket:
     Type: AWS::S3::Bucket
@@ -1002,11 +1012,6 @@ Resources:
         DestinationBucketName: !Ref ManagedSecretsLoggingBucket
       VersioningConfiguration:
         Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
       Tags:
         - !If
           - UseCostAllocationTags


### PR DESCRIPTION
With the new defaults from AWS stated in https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html we shouldn't rely on ACLs nor there's a need to manually update public access configuration as these will now be **_ON_** by default. 

Removing these two configurations should leave the buckets with the recommended AWS security settings.

**This issue is blocking new clients to quickly bootstrap Buildkite in their account**

Fixes: #1108