### PR TITLE
Fix ACLs can no longer be created for Managed Secrets Logging Bucket

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -944,6 +944,11 @@ Resources:
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         !If
         - EnforceSecretsBucketEncryption
@@ -1001,6 +1006,11 @@ Resources:
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       BucketEncryption:
         !If
         - EnforceSecretsBucketEncryption

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -970,7 +970,8 @@ Resources:
         Statement:
         - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
           Effect: Allow
-          Principal: 'logging.s3.amazonaws.com'
+          Principal:
+            Service: 'logging.s3.amazonaws.com'
           Action:
           - 's3:PutObject'
           Resource:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -944,12 +944,6 @@ Resources:
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
       BucketEncryption:
         !If
         - EnforceSecretsBucketEncryption
@@ -967,23 +961,39 @@ Resources:
 
   ManagedSecretsLoggingBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Condition: EnforceSecretsBucketEncryption
+    Condition: CreateSecretsBucket
     Properties:
       Bucket: !Ref ManagedSecretsLoggingBucket
       PolicyDocument:
         Id: ManagedSecretsLoggingBucketPolicy
         Version: "2012-10-17"
         Statement:
-        - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
-          Effect: Deny
-          Principal: '*'
-          Action: 's3:*'
+        - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
+          Effect: Allow
+          Principal: 'logging.s3.amazonaws.com'
+          Action:
+          - 's3:PutObject'
           Resource:
           - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
           - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
           Condition:
-            Bool:
-              'aws:SecureTransport': false
+            ArnLike:
+              'aws:SourceArn': !GetAtt 'ManagedSecretsBucket.Arn'
+            StringEquals:
+              'aws:SourceAccount': !Ref 'AWS::AccountId'
+        - !If
+          - EnforceSecretsBucketEncryption
+          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+            - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
+            - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': false
+          - !Ref "AWS::NoValue"
 
   ManagedSecretsBucket:
     Type: AWS::S3::Bucket
@@ -1002,11 +1012,6 @@ Resources:
         DestinationBucketName: !Ref ManagedSecretsLoggingBucket
       VersioningConfiguration:
         Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
       Tags:
         - !If
           - UseCostAllocationTags


### PR DESCRIPTION
This reimplements #1109 with a fix to the `Principal` value. Thank you to @saviogl for finding and (very nearly) fixing the original issue!

Fixes: #1108