### PR TITLE
Update description of BuildkiteAdditionalSudoPermissions parameter

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -201,7 +201,7 @@ Parameters:
     Default: "false"
 
   BuildkiteAdditionalSudoPermissions:
-    Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo.
+    Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo. Note that the commands should be fully qualified paths to executables.
     Type: String
     Default: ""
 


### PR DESCRIPTION
The previous wording lead customers to believe that the command could be
specified with just its name. However, `sudoers(5)` requires that the
commands be specified with fully qualified paths. This lead some users
to believe that the stack was generating an invalid line in a sudoers
file when the error was the failure to fully qualify the path.