### PR TITLE
Bumping python from 3.7 to 3.10

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1314,7 +1314,7 @@ Resources:
               cfnresponse.send(event, context, cfnresponse.FAILED, {}, "CustomResourcePhysicalID")
       Handler: index.handler
       Role: !GetAtt AsgProcessSuspenderRole.Arn
-      Runtime: 'python3.7'
+      Runtime: 'python3.10'
 
   AzRebalancingSuspender:
     Type: AWS::CloudFormation::CustomResource


### PR DESCRIPTION
An old Python version was being used (3.7) for the AZ Rebalancing Lambda

This PR in particular is looking at [AZ Rebalancing Autoscaling Lambda](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/aws-stack.yml#L1295) - it was picked up that 3.7 is set as the Runtime

https://3.basecamp.com/3453178/buckets/23112918/card_tables/cards/6126980695#__recording_6127034819

Line 1295 to 1317:
https://github.com/buildkite/elastic-ci-stack-for-aws/blob/master/templates/aws-stack.yml#L1295