### PR TITLE
Default IMDSv2Tokens Parameter to required

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,7 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
       - "test-windows-amd64"
+    allow_dependency_failure: true
 
   - id: "packer-linux-amd64"
     name: ":packer: :linux: AMD64"
@@ -106,6 +107,7 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
       - "test-linux-amd64"
+    allow_dependency_failure: true
 
   - id: "packer-linux-arm64"
     name: ":packer: :linux: ARM64"
@@ -147,6 +149,7 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
       - "test-linux-arm64"
+    allow_dependency_failure: true
 
   - id: "delete-service-role-stack"
     name: ":aws-iam: :cloudformation: Delete"

--- a/goss.yaml
+++ b/goss.yaml
@@ -165,3 +165,19 @@ command:
     timeout: 30000
     stdout:
     - x86_64
+
+  docker run --rm -t alpine:latest wget -q http://169.254.169.254/latest/meta-data/instance-id:
+    timeout: 30000
+    exit-status: 1
+    stdout:
+    - '/^wget: server returned error: HTTP/1.1 401 Unauthorized$/'
+
+  test-IMDSv2-from-docker:
+    timeout: 30000
+    exec: >-
+      docker run --rm --entrypoint ash curlimages/curl:8.1.1 -c
+      'TOKEN=$(curl -s -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds:10" http://169.254.169.254/latest/api/token)
+      && curl -sf -H "X-aws-ec2-metadata-token:$TOKEN" http://169.254.169.254/latest/meta-data/instance-id'
+    exit-status: 0
+    stdout:
+    - /^i-/

--- a/goss.yaml
+++ b/goss.yaml
@@ -127,7 +127,7 @@ command:
 
   # Check docker userns is enabled
   # Note that goss will evaluate the first layer of templating in the `--format` argument, and docker will evaluate the second
-  docker info --format='{{ `{{range .SecurityOptions}}{{.}}{{end}}` }}'`:
+  docker info --format=$'{{ `{{range .SecurityOptions}}{{.}}\n{{end}}` }}'`:
     exit-status: 0
     timeout: 30000
     stdout:

--- a/goss.yaml
+++ b/goss.yaml
@@ -127,7 +127,7 @@ command:
 
   # Check docker userns is enabled
   # Note that goss will evaluate the first layer of templating in the `--format` argument, and docker will evaluate the second
-  docker info --format=$'{{ `{{range .SecurityOptions}}{{.}}\n{{end}}` }}'`:
+  docker info --format=$'{{ `{{range .SecurityOptions}}{{.}}\n{{end}}` }}':
     exit-status: 0
     timeout: 30000
     stdout:

--- a/goss.yaml
+++ b/goss.yaml
@@ -126,18 +126,21 @@ command:
     exit-status: 0
 
   # Check docker userns is enabled
-  docker info --format='{{range .SecurityOptions}}{{ if eq . "name=userns" }}{{.}}{{end}}{{end}}':
+  # Note that goss will evaluate the first layer of templating in the `--format` argument, and docker will evaluate the second
+  docker info --format='{{ `{{range .SecurityOptions}}{{.}}{{end}}` }}'`:
     exit-status: 0
     timeout: 30000
     stdout:
-    - name=userns
+    - /^name=userns$/
 
   # Check docker plugins are installed
-  docker info --format='{{range .ClientInfo.Plugins}}{{if or (eq .Name "buildx") (eq .Name "compose")}}{{ .Name }},{{end}}{{end}}':
+  # Note that goss will evaluate the first layer of templating in the `--format` argument, and docker will evaluate the second
+  docker info --format=$'{{ `{{range .ClientInfo.Plugins}}{{.Name}}\n{{end}}` }}':
     exit-status: 0
     timeout: 30000
     stdout:
-    - buildx,compose,
+    - /^buildx$/
+    - /^compose$/
 
   # Check that docker containers can run
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker:latest version:

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -25,6 +25,12 @@ on_error() {
 
 trap 'on_error $LINENO' ERR
 
+case $(uname -m) in
+  x86_64)    ARCH=amd64;;
+  aarch64)   ARCH=arm64;;
+  *)         ARCH=unknown;;
+esac
+
 # even though the token is only vaild for 60s, let's not leak it into the logs
 set +x
 token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
@@ -91,14 +97,9 @@ set_unless_present "AWS_REGION" "$AWS_REGION"
 EOF
 
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]]; then
-  if [[ "$(uname -m)" == "aarch64" ]]; then
-    AGENT_ARCH="arm64"
-  else
-    AGENT_ARCH="amd64"
-  fi
   echo "Downloading buildkite-agent edge..."
   curl -Lsf -o /usr/bin/buildkite-agent-edge \
-    "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-${AGENT_ARCH}"
+    "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-${ARCH}"
   chmod +x /usr/bin/buildkite-agent-edge
   buildkite-agent-edge --version
 fi

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -382,7 +382,7 @@ Parameters:
     AllowedValues:
       - optional
       - required
-    Default: optional
+    Default: required
 
   InstanceRoleName:
     Type: String


### PR DESCRIPTION
The previous default was optional. We would like to remove this parameter eventually, and make it required.

So let's make it required by default in v6, and delete it later.

Requiring IMDSv2 tokens will break a lot of handcrafted scripts, but they have been out for a while and I believe most official AWS libraries support them: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/use-a-supported-sdk-version-for-imdsv2.html