### PR TITLE
Remove `SpotPrice` parameter and add parameter `SpotAllocationStrategy`

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -92,6 +92,7 @@ Metadata:
         - MinSize
         - MaxSize
         - OnDemandPercentage
+        - SpotAllocationStrategy
         - ScaleOutFactor
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
@@ -302,6 +303,16 @@ Parameters:
     Default: 100
     MinValue: 0
     MaxValue: 100
+
+  SpotAllocationStrategy:
+    Description: The strategy for allocating Spot Instances when launching or replacing instances. If choosing `capacity-optimized-prioritized`, the order you specify in InstanceType will be the priority.
+    Type: String
+    Default: price-capacity-optimized
+    AllowedValues:
+      - price-capacity-optimized
+      - capacity-optimized
+      - lowest-price
+      - capacity-optimized-prioritized
 
   ScaleOutFactor:
     Description: A decimal factor to apply to scale out changes to speed up or slow down scale-out
@@ -1214,7 +1225,7 @@ Resources:
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
-          SpotAllocationStrategy: capacity-optimized
+          SpotAllocationStrategy: !Ref SpotAllocationStrategy
         LaunchTemplate:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref AgentLaunchTemplate

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -68,7 +68,6 @@ Metadata:
         - EnableInstanceStorage
         - AgentsPerInstance
         - KeyName
-        - SpotPrice
         - SecretsBucket
         - SecretsBucketRegion
         - SecretsBucketEncryption
@@ -285,11 +284,6 @@ Parameters:
     MinLength: 1
     AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
-
-  SpotPrice:
-    Description: Maximum spot price to use for the instances, in instance cost per hour. Values >0 will result in 100% of instances being spot. 0 means only use normal (non-spot) instances. This parameter is deprecated - we recommend setting to 0 and using OnDemandPercentage to opt into spot instances.
-    Type: String
-    Default: 0
 
   MaxSize:
     Description: Maximum number of instances
@@ -552,9 +546,6 @@ Outputs:
       Name: !Sub '${AWS::StackName}-InstanceRoleName'
 
 Conditions:
-    SpotPriceSet:
-      !Not [ !Equals [ !Ref SpotPrice, 0 ] ]
-
     CreateVpcResources:
       !Equals [ !Ref VpcId, "" ]
 
@@ -1222,9 +1213,8 @@ Resources:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       MixedInstancesPolicy:
         InstancesDistribution:
-          OnDemandPercentageAboveBaseCapacity: !If [ SpotPriceSet, 0, !Ref OnDemandPercentage ]
+          OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
           SpotAllocationStrategy: capacity-optimized
-          SpotMaxPrice: !If [SpotPriceSet, !Ref SpotPrice, !Ref "AWS::NoValue"]
         LaunchTemplate:
           LaunchTemplateSpecification:
             LaunchTemplateId: !Ref AgentLaunchTemplate

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -307,7 +307,7 @@ Parameters:
   SpotAllocationStrategy:
     Description: The strategy for allocating Spot Instances when launching or replacing instances. If choosing `capacity-optimized-prioritized`, the order you specify in InstanceType will be the priority.
     Type: String
-    Default: price-capacity-optimized
+    Default: capacity-optimized
     AllowedValues:
       - price-capacity-optimized
       - capacity-optimized


### PR DESCRIPTION
We think using % of on demand and a spot allocation strategy is the more modern way of controlling the proportion of spot instances used. We have wanted to deprecate `SpotPrice` for some time now: https://github.com/buildkite/elastic-ci-stack-for-aws/issues/792

I've chosen to keep the default SpotAllocationStrategy to be `capacity-optimized` as it was in v5.

Make `capacity-optimized` the default spot allocation strategy

Amazon's recommended strategy is `price-capacity-optimized`: https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html but the default strategy for a InstancesDistribution is `lowest-price`.
In the elastic ci stack v5, we overrode the default and set it to `capacity-optimized`.

For a CI system, I think the strategy with the lowest risk of interruption is preferable.
There are two distinct reasons for this:
- Interrupting a CI job has a cost in developer time. Usually, developers are
  more expensive than instances.
- The instances carry state, e.g. the checkout dir and docker caches.
  Loosing this state costs time on subsequent jobs, which means those
  instance could be running for longer, and developers could be waiting
  for longer.

This is clearly a tricky balancing act, so giving users the freedom to
select a different strategy is a good idea, which is why I've decided to expose it as a parameter.