### PR TITLE
Enable ansi-timestamps iff BuildkiteAgentTimestampLines is false

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -162,7 +162,7 @@ fi
 chown buildkite-agent: "${BUILDKITE_AGENT_BUILD_PATH}"
 
 # Either you can have timestamp-lines xor ansi-timestamps.
-# There's no technical reason you can't have both, its a pragmatic desicison to
+# There's no technical reason you can't have both, its a pragmatic decision to
 # simplify the avaliable parameters on the stack
 if [[ "$BUILDKITE_AGENT_TIMESTAMP_LINES" == "true" ]]; then
   BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS="true"

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -161,6 +161,15 @@ then
 fi
 chown buildkite-agent: "${BUILDKITE_AGENT_BUILD_PATH}"
 
+# Either you can have timestamp-lines xor ansi-timestamps.
+# There's no technical reason you can't have both, its a pragmatic desicison to
+# simplify the avaliable parameters on the stack
+if [[ "$BUILDKITE_AGENT_TIMESTAMP_LINES" == "true" ]]; then
+  BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS="true"
+else
+  BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS="false"
+fi
+
 set +x # Don't leak the agent token into logs
 echo "Setting \$BUILDKITE_AGENT_TOKEN to the value stored in the SSM Parameter $BUILDKITE_AGENT_TOKEN_PATH"
 BUILDKITE_AGENT_TOKEN="$(aws ssm get-parameter --name "${BUILDKITE_AGENT_TOKEN_PATH}" --with-decryption --query Parameter.Value --output text)"
@@ -171,6 +180,7 @@ name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%spawn"
 token="${BUILDKITE_AGENT_TOKEN}"
 tags=$(IFS=, ; echo "${agent_metadata[*]}")
 tags-from-ec2-meta-data=true
+no-ansi-timestamps=${BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS}
 timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path=/etc/buildkite-agent/hooks
 build-path=${BUILDKITE_AGENT_BUILD_PATH}

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -116,7 +116,7 @@ If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
 }
 
 # Either you can have timestamp-lines xor ansi-timestamps.
-# There's no technical reason you can't have both, its a pragmatic desicison to
+# There's no technical reason you can't have both, its a pragmatic decision to
 # simplify the avaliable parameters on the stack
 If ($Env:BUILDKITE_AGENT_TIMESTAMP_LINES -eq "true") {
   $Env:BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS = "true"

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -115,6 +115,15 @@ If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
   $Env:BUILDKITE_AGENT_GIT_MIRRORS_PATH = "C:\buildkite-agent\git-mirrors"
 }
 
+# Either you can have timestamp-lines xor ansi-timestamps.
+# There's no technical reason you can't have both, its a pragmatic desicison to
+# simplify the avaliable parameters on the stack
+If ($Env:BUILDKITE_AGENT_TIMESTAMP_LINES -eq "true") {
+  $Env:BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS = "true"
+} Else {
+  $Env:BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS = "false"
+}
+
 # Get token from ssm param (if we have a path)
 If ($null -ne $Env:BUILDKITE_AGENT_TOKEN_PATH -and $Env:BUILDKITE_AGENT_TOKEN_PATH -ne "") {
   $Env:BUILDKITE_AGENT_TOKEN = $(aws ssm get-parameter --name $Env:BUILDKITE_AGENT_TOKEN_PATH --with-decryption --output text --query Parameter.Value --region $Env:AWS_REGION)
@@ -126,6 +135,7 @@ name="${Env:BUILDKITE_STACK_NAME}-${Env:INSTANCE_ID}-%spawn"
 token="${Env:BUILDKITE_AGENT_TOKEN}"
 tags=$agent_metadata
 tags-from-ec2-meta-data=true
+no-ansi-timestamps=${Env:BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS}
 timestamp-lines=${Env:BUILDKITE_AGENT_TIMESTAMP_LINES}
 hooks-path="C:\buildkite-agent\hooks"
 build-path="C:\buildkite-agent\builds"


### PR DESCRIPTION
Fixes: [agent/#2149](https://github.com/buildkite/agent/issues/2149)

I've tested it with `BuildkiteAgentTimestampLines=true` for linux/amd64 here:: https://buildkite.com/nepas-test-org/test-pipeline/builds/283#01889f0b-68e2-4180-92ce-41facbb96279

It's run with `BuildkiteAgentTimestampLines=false` in the CI jobs for linux/amd64, linux/arm64 and windows/amd64.