### PR TITLE
Don't (re)install docker (on Windows)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -51,6 +51,7 @@ steps:
     command:
       - git --version
       - docker info
+      - docker run --rm mcr.microsoft.com/windows/nanoserver:ltsc2019 cmd.exe /c echo hello
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-windows-amd64-${BUILDKITE_BUILD_NUMBER}"

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -1,19 +1,10 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$docker_version="20.10.9"
 $docker_compose_version="1.29.2"
 
-Write-Output "Upgrading DockerMsftProvider module"
-Update-Module -Name DockerMsftProvider -Force
-
-Write-Output "Printing available docker versions"
-Find-Package -providerName DockerMsftProvider -AllVersions
-
-Write-Output "Installing docker enterprise edition"
-Stop-Service docker
-Install-Package -Name docker -ProviderName DockerMsftProvider -Force -RequiredVersion $docker_version
-Start-Service docker
+Write-Output "Check that docker is installed"
+docker --version
 
 Write-Output "Installing docker-compose"
 choco install -y docker-compose --version $docker_compose_version


### PR DESCRIPTION
The way we were installing Docker EE has stopped working. But, it seems to already be installed in the base AMI. 