### PR TITLE
Default InstanceName to stack name

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -505,7 +505,7 @@ Parameters:
   InstanceName:
     Type: String
     Description: Optional - Customise the EC2 instance Name tag
-    Default: "buildkite-agent"
+    Default: ""
 
 Rules:
   HasToken:
@@ -676,6 +676,9 @@ Conditions:
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "r7g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "t4g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceType ] ], "x2gd" ]
+
+    UseStackNameForInstanceName:
+      !Equals [ !Ref InstanceName, "" ]
 
 Mappings:
   ECRManagedPolicy:
@@ -1108,7 +1111,7 @@ Resources:
                 - Key: Role
                   Value: buildkite-agent
                 - Key: Name
-                  Value: !Ref InstanceName
+                  Value: !If [ UseStackNameForInstanceName, !Ref AWS::StackName, !Ref InstanceName ]
                 - Key: BuildkiteAgentRelease
                   Value: !Ref BuildkiteAgentRelease
                 - Key: BuildkiteQueue


### PR DESCRIPTION
When the InstanceName parameter is the empty string, use the stack name instead.