### PR TITLE
Pull docker image used for qemu binfmt in packer

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -242,7 +242,7 @@ docker run \
   --privileged \
   --userns=host \
   --rm \
-  "tonistiigi/binfmt:qemu-v${QEMU_BINFMT_VERSION}" \
+  "tonistiigi/binfmt:${QEMU_BINFMT_TAG}" \
     --install all
 
 systemctl enable --now buildkite-agent

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -31,6 +31,9 @@ case $(uname -m) in
   *)         ARCH=unknown;;
 esac
 
+# shellcheck disable=SC1091
+source /usr/local/lib/bk-install-elastic-stack.sh
+
 # even though the token is only vaild for 60s, let's not leak it into the logs
 set +x
 token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
@@ -234,7 +237,6 @@ if ! docker ps; then
 fi
 
 # See https://docs.docker.com/build/building/multi-platform/
-QEMU_BINFMT_VERSION=7.0.0-28
 echo Installing qemu binfmt for multiarch...
 docker run \
   --privileged \

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -53,7 +53,9 @@ docker-compose version
 
 # See https://docs.docker.com/build/building/multi-platform/
 QEMU_BINFMT_VERSION=7.0.0-28
+QEMU_BINFMT_DIGEST=sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
+QEMU_BINFMT_TAG="qemu-v${QEMU_BINFMT_VERSION}@${QEMU_BINFMT_DIGEST}"
 sudo mkdir -p /usr/local/lib
-echo "QEMU_BINFMT_VERSION=${QEMU_BINFMT_VERSION}" | sudo tee -a /usr/local/lib/bk-install-elastic-stack.sh
+echo "QEMU_BINFMT_TAG=\"$QEMU_BINFMT_TAG\"" | sudo tee -a /usr/local/lib/bk-install-elastic-stack.sh
 echo Pulling qemu binfmt for multiarch...
-sudo docker pull "tonistiigi/binfmt:qemu-v${QEMU_BINFMT_VERSION}"
+sudo docker pull "tonistiigi/binfmt:${QEMU_BINFMT_TAG}"

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -51,6 +51,9 @@ docker compose version
 sudo ln -s "${DOCKER_CLI_DIR}/docker-compose" /usr/bin/docker-compose
 docker-compose version
 
+# See https://docs.docker.com/build/building/multi-platform/
 QEMU_BINFMT_VERSION=7.0.0-28
-echo Installing qemu binfmt for multiarch...
+sudo mkdir -p /usr/local/lib
+echo "QEMU_BINFMT_VERSION=${QEMU_BINFMT_VERSION}" | sudo tee -a /usr/local/lib/bk-install-elastic-stack.sh
+echo Pulling qemu binfmt for multiarch...
 sudo docker pull "tonistiigi/binfmt:qemu-v${QEMU_BINFMT_VERSION}"

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -50,3 +50,7 @@ docker compose version
 
 sudo ln -s "${DOCKER_CLI_DIR}/docker-compose" /usr/bin/docker-compose
 docker-compose version
+
+QEMU_BINFMT_VERSION=7.0.0-28
+echo Installing qemu binfmt for multiarch...
+sudo docker pull "tonistiigi/binfmt:qemu-v${QEMU_BINFMT_VERSION}"


### PR DESCRIPTION
We use a method documented by docker to install some tools necessary for building (and running) multiarch docker images. See https://docs.docker.com/build/building/multi-platform/

Previously we did this entirely in the startup script `packer/linux/scripts/install-docker.sh`. However, as was revealed in dogfooding, launching many instances at the same time could cause the startup script to fail due to docker hub rate limits. Instead, we can pull the image when the AMI is being built by packer, and then run the installation in the startup script.

Why not pull and run when building the AMI? Running multiarch images in CI failed when I tried to do that: https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/3275