### PR TITLE
Allow the MaxSize to be 0

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -290,12 +290,13 @@ Parameters:
     Description: Maximum number of instances
     Type: Number
     Default: 10
-    MinValue: 1
+    MinValue: 0
 
   MinSize:
     Description: Minimum number of instances
     Type: Number
     Default: 0
+    MinValue: 0
 
   OnDemandPercentage:
     Description: Percentage of total instances that should launch as OnDemand. Default is 100% OnDemand - reduce this to use some Spot Instances when they're available and cheaper than the OnDemand price. A value of 70 means 70% OnDemand and 30% Spot Instances.


### PR DESCRIPTION
This is useful for users that are doing blue-green deployments and want the
(eg blue) stack to be able to be scaled in to 0 instances while the green
stack is fully scaled out.