### PR TITLE
Backport dexperimentifing git-mirrors

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -128,18 +128,11 @@ fi
 
 # Enable git-mirrors
 BUILDKITE_AGENT_GIT_MIRRORS_PATH=""
-if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT}" == "true" ]] ; then
-  if [[ -z "$BUILDKITE_AGENT_EXPERIMENTS" ]] ; then
-    BUILDKITE_AGENT_EXPERIMENTS="git-mirrors"
-  else
-    BUILDKITE_AGENT_EXPERIMENTS+=",git-mirrors"
-  fi
-
+if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS}" == "true" ]]; then
   BUILDKITE_AGENT_GIT_MIRRORS_PATH="/var/lib/buildkite-agent/git-mirrors"
   mkdir -p "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
 
-  if [ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]
-  then
+  if [[ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]]; then
     EPHEMERAL_GIT_MIRRORS_PATH="/mnt/ephemeral/git-mirrors"
     mkdir -p "${EPHEMERAL_GIT_MIRRORS_PATH}"
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -105,13 +105,7 @@ If (Test-Path Env:BUILDKITE_AGENT_TAGS) {
 }
 
 # Enable git-mirrors
-If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT -eq "true") {
-  If ([string]::IsNullOrEmpty($Env:BUILDKITE_AGENT_EXPERIMENTS)) {
-    $Env:BUILDKITE_AGENT_EXPERIMENTS = "git-mirrors"
-  }
-  Else {
-    $Env:BUILDKITE_AGENT_EXPERIMENTS += ",git-mirrors"
-  }
+If ($Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS -eq "true") {
   $Env:BUILDKITE_AGENT_GIT_MIRRORS_PATH = "C:\buildkite-agent\git-mirrors"
 }
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -488,7 +488,7 @@ Parameters:
 
   EnableAgentGitMirrorsExperiment:
     Type: String
-    Description: Enables the git-mirrors experiment in the agent
+    Description: Enables git-mirrors in the agent
     AllowedValues:
       - "true"
       - "false"
@@ -1141,7 +1141,7 @@ Resources:
                   $Env:BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}"
                   $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
                   $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
-                  $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT="${EnableAgentGitMirrorsExperiment}"
+                  $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${EnableAgentGitMirrorsExperiment}"
                   $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
                   $Env:BUILDKITE_ENV_FILE_URL="${AgentEnvFileUrl}"
                   $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
@@ -1191,7 +1191,7 @@ Resources:
                   BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}" \
                   BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
                   BUILDKITE_QUEUE="${BuildkiteQueue}" \
-                  BUILDKITE_AGENT_ENABLE_GIT_MIRRORS_EXPERIMENT="${EnableAgentGitMirrorsExperiment}" \
+                  BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${EnableAgentGitMirrorsExperiment}" \
                   BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
                   BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \


### PR DESCRIPTION
This keeps the parameter name the same, but otherwise is the same as https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1123