### PR TITLE
Handle hard failures (eg. kernel panic) during bootstrap

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1166,6 +1166,11 @@ Resources:
                   Content-Type: multipart/mixed; boundary="==BOUNDARY=="
                   MIME-Version: 1.0
                   --==BOUNDARY==
+                  Content-Type: text/cloud-config; charset="us-ascii"
+                  #cloud-config
+                  cloud_final_modules:
+                    - [scripts-user, always]
+                  --==BOUNDARY==
                   Content-Type: text/cloud-boothook; charset="us-ascii"
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
                     /usr/local/bin/bk-mount-instance-storage.sh


### PR DESCRIPTION
This change configures cloud-init to run the bootstrap script on every boot so that we can check for previous failed attempts and mark the instance as unhealthy.

This caters for the scenario where the kernel panics during a bootstrap attempt which leaves the instance non-operational on reboot but marked healthy.