### PR TITLE
Increase cancel grace period to 60s

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -188,6 +188,7 @@ no-color=true
 disconnect-after-idle-timeout=${BUILDKITE_SCALE_IN_IDLE_PERIOD}
 disconnect-after-job=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
 tracing-backend=${BUILDKITE_AGENT_TRACING_BACKEND}
+cancel-grace-period=60
 EOF
 
 if [[ "${BUILDKITE_ENV_FILE_URL}" != "" ]]; then


### PR DESCRIPTION
It was found on Amazon Linux 2023 that the default 10s grace period was
insufficient to allow the bootstrap to tear down cleanly when a job is
cancelled from the Buildkite API.