### PR TITLE
Create script to prepend `--compatibility` flag to docker-compose

### DIFF
--- a/packer/linux/conf/bin/docker-compose
+++ b/packer/linux/conf/bin/docker-compose
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Prepends --compatibility flag to arguments to docker-compose if not present
+# Prepends the --compatibility flag to arguments to docker-compose if not present
+# Don't install this to /usr/bin/docker-compose or it will call itself recurively
+# an unbounded number of times
 
 set -Eeuo pipefail
 

--- a/packer/linux/conf/bin/docker-compose
+++ b/packer/linux/conf/bin/docker-compose
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Prepends --compatibility flag to arguments to docker-compose if not present
+
+set -Eeuo pipefail
+
+has_compatibility_flag=false
+
+for arg in "$@"; do
+  if [[ $arg == "--compatibility" ]]; then
+    has_compatibility_flag=true
+    break
+  fi
+done
+
+if ! $has_compatibility_flag; then
+  set -- "--compatibility" "$@"
+fi
+
+exec /usr/bin/docker-compose "$@"

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_COMPOSE_V2_VERSION=2.18.1
-DOCKER_BUILDX_VERSION="0.10.5"
+DOCKER_COMPOSE_V2_VERSION=2.19.1
+DOCKER_BUILDX_VERSION="0.11.0"
 MACHINE=$(uname -m)
 
 echo Installing docker...

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -48,7 +48,10 @@ sudo curl --location --fail --silent --output "${DOCKER_CLI_DIR}/docker-compose"
 sudo chmod +x "${DOCKER_CLI_DIR}/docker-compose"
 docker compose version
 
+echo "Making docker compose v2 compatible w/ docker-compose v1..."
 sudo ln -s "${DOCKER_CLI_DIR}/docker-compose" /usr/bin/docker-compose
+sudo cp /tmp/conf/bin/docker-compose /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
 docker-compose version
 
 # See https://docs.docker.com/build/building/multi-platform/


### PR DESCRIPTION
Making /usr/bin/docker-compose a symlink or copy of the docker compose plugin binary is something that is increasingly popular. Indeed, this is now the only way to install a standalone `docker-compose` executable on Linux that's documented by docker: https://docs.docker.com/compose/install/standalone/#on-linux

So we did this in Elastic CI Stack for AWS v6 as well.

Unfortunately, this breaks certain workflows in the docker-compose plugin, which assumes that the `docker-compose` in the $PATH is docker-compose v1.

Arguably, the docker-compose plugin should default to v2 as v1 is EOL, but that is a breaking change. In the interim, we can prepend `--compatibility` to the docker-compose command to ensure that the plugin works as expected.

While I was in the area, I bumped the versions of docker compose and buildx.