### PR TITLE
Rename `EventScheduleRate` to `ScalerEventScheduleRate` and include it in the changelog for v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [v6.0.0](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v6.0.0) (2023-07-25)
+## [v6.0.0](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v6.0.0) (2023-07-26)
 [Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v5.22.2...v6.0.0)
 
 ### Changed
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rename the parameter `SecurityGroupId` to `SecurityGroupIds` [#1128](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1128) (@triarius)
 - Rename the parameter `EnableAgentGitMirrorsExperiment` to `BuildkiteAgentEnableGitMirrors` [#1123](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1123) (@triarius)
 - Enable the `ansi-timestamps` setting if and only if `BuildkiteAgentTimestampLines` parameter is `"false"` [#1132](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1132) (@triarius)
+- Bump buildkite-agent-scaler to v1.5.0 [#1169](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1169) (@tomellis91)
 - Bump docker compose to v2.20.2 [#1150](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1150) (@triarius)
 - Bump buildx to v0.11.2 [#1150](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1150) (@triarius)
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support running and building multi-platform docker images [#1139](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1139) [#1122](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1122) [#1149](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1149) (@triarius)
 - Support i4g instance types [#1138](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1138) (@triarius)
 - Added the parameter `SpotAllocationStrategy` [#1130](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1130) (@triarius)
+- Added the parameter `ScalerEventScheduleRate` to control rate at which buildkite-agent-scaler is invoked [#1169](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1169) (@tomellis91)
 
 ### Fixed
 - Guard against `BUILDKITE_AGENT_ENABLE_GIT_MIRRORS` not being set in startup script [#1135](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1135) (@triarius)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1><img alt="Elastic CI Stack for AWS" src="images/banner.png?raw=true"></h1>
 
-![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=master)
+![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=main)
 
 ## Buildkite Elastic CI Stack for AWS
 
@@ -127,7 +127,7 @@ default VPC:
 
 We provide support for security and bug fixes on the current major release only.
 
-If there are any changes in the master branch since the last tagged release, we
+If there are any changes in the main branch since the last tagged release, we
 aim to publish a new tagged release of this template at the end of each month.
 
 ### AWS Regions
@@ -146,7 +146,7 @@ We build and deploy the following AMIs to all our supported regions:
 
 ### Buildkite Agent
 
-The Elastic CI Stack template [published from the master branch](https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml)
+The Elastic CI Stack template [published from the main branch](https://s3.amazonaws.com/buildkite-aws-stack/latest/aws-stack.yml)
 tracks the latest Buildkite Agent release.
 
 You may wish to preview any updates to your stack from this template

--- a/docs/updating-agent.md
+++ b/docs/updating-agent.md
@@ -1,9 +1,9 @@
 # Updating the Agent
 
-The `buildkite-agent` is built in to the AMIs by the Packer build. The agent 
+The `buildkite-agent` is built in to the AMIs by the Packer build. The agent
 binary is downloaded from download.buildkite.com.
 
-Once you have [released](https://github.com/buildkite/agent/blob/master/RELEASE.md) an updated
+Once you have [released](https://github.com/buildkite/agent/blob/-/RELEASE.md) an updated
 version of the agent, you can incorporate it into the Elastic CI Stack
 for AWS template.
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -97,7 +97,7 @@ Metadata:
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
         - InstanceCreationTimeout
-        - EventScheduleRate
+        - ScalerEventScheduleRate
 
       - Label:
           default: Cost Allocation Configuration
@@ -299,8 +299,8 @@ Parameters:
     Default: 0
     MinValue: 0
 
-  EventScheduleRate:
-    Description: How often the Event Schedule is triggered (in minutes)
+  ScalerEventScheduleRate:
+    Description: How often the event schedule for buildkite-agent-scaler is triggered (in minutes)
     Type: String
     Default: "1"
 
@@ -1380,4 +1380,4 @@ Resources:
         AgentAutoScaleGroup: !Ref AgentAutoScaleGroup
         ScaleOutFactor: !Ref ScaleOutFactor
         ScaleOutForWaitingJobs: !Ref ScaleOutForWaitingJobs
-        EventScheduleRate: !Ref EventScheduleRate
+        EventScheduleRate: !Ref ScalerEventScheduleRate


### PR DESCRIPTION
It's not clear from the previous name that this only affects buildkite-agent-scaler.

Also rename some occurrences of master to main.