### PR TITLE
Disable pager for aws-cli v2 for the buildkite-agent user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ bump-agent-version:
 	git commit -m "Bump buildkite-agent to v$(AGENT_VERSION)"
 
 validate: build/aws-stack.yml
-	aws cloudformation validate-template \
+	aws --no-cli-pager cloudformation validate-template \
 		--output text \
 		--template-body "file://$(PWD)/build/aws-stack.yml"
 

--- a/packer/linux/conf/aws/config
+++ b/packer/linux/conf/aws/config
@@ -1,0 +1,2 @@
+[default]
+cli_pager=

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -11,6 +11,10 @@ echo "Creating buildkite-agent user and group..."
 sudo useradd --base-dir /var/lib --uid 2000 buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
+sudo mkdir -p /var/lib/buildkite-agent/.aws
+sudo cp /tmp/conf/aws/config /var/lib/buildkite-agent/.aws/config
+sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
+
 AGENT_VERSION=3.50.3
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \


### PR DESCRIPTION
It can cause jobs to hang if he cli returns results that are shown in a 
client side pager (like less). This method of disabling the pager is 
described in
https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-pagination.html#cli-usage-pagination-clientside

I've also manually disabled it at certain places in the CI for this pipeline as it was in this pipeline that the issue first appeared to our knowledge.