### PR TITLE
Use windows server 2019 base image and docker ce

### DIFF
--- a/packer/windows/buildkite-ami.json
+++ b/packer/windows/buildkite-ami.json
@@ -8,14 +8,14 @@
       "region": "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "Windows_Server-2019-English-Full-Containers*",
+          "name": "Windows_Server-2019-English-Full-*",
           "virtualization-type": "hvm"
         },
         "owners": ["amazon"],
         "most_recent": true
       },
       "instance_type": "m5.xlarge",
-      "user_data_file":"scripts/ec2-userdata.ps1",
+      "user_data_file": "scripts/ec2-userdata.ps1",
       "communicator": "winrm",
       "winrm_username": "Administrator",
       "winrm_use_ssl": true,

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -3,7 +3,9 @@ $ErrorActionPreference = "Stop"
 
 $docker_compose_version="1.29.2"
 
-Write-Output "Check that docker is installed"
+Write-Output "Install docker"
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1" -o install-docker-ce.ps1
+.\install-docker-ce.ps1
 docker --version
 
 Write-Output "Installing docker-compose"


### PR DESCRIPTION
The series of AMIs we used to base the windows elastic stack off of has been yanked. It had docker installed by default. In this PR, we use a more standard window AMI and install docker CE using a script maintained by Microsoft that is documented here: https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=dockerce#windows-server-1