### PR TITLE
Add missing authorized keys systemd units

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -8,6 +8,12 @@ file:
     owner: buildkite-agent
     group: buildkite-agent
 
+  /etc/systemd/system/refresh_authorized_keys.service:
+    exists: true
+
+  /etc/systemd/system/refresh_authorized_keys.timer:
+    exists: true
+
   /var/lib/buildkite-agent/builds:
     filetype: directory
     exists: true
@@ -127,6 +133,13 @@ command:
 
   wget --version:
     exit-status: 0
+
+  # Check refresh authorized keys gear is present, but disabled.
+  # disabled: The unit file is not enabled, but contains an [Install] section with installation instructions.
+  systemctl is-enabled refresh_authorized_keys.timer:
+    exit-status: 1
+    stdout:
+    - /disabled/
 
   systemctl is-enabled docker-gc.timer:
     exit-status: 0

--- a/packer/linux/conf/ssh/systemd/refresh_authorized_keys.service
+++ b/packer/linux/conf/ssh/systemd/refresh_authorized_keys.service
@@ -1,10 +1,6 @@
 [Unit]
 Description=Download ssh authorized_keys file from s3
-Wants=refresh_authorized_keys.service
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/refresh_authorized_keys
-
-[Install]
-WantedBy=multi-user.target

--- a/packer/linux/scripts/install-buildkite-utils.sh
+++ b/packer/linux/scripts/install-buildkite-utils.sh
@@ -25,3 +25,6 @@ sudo curl -Lf -o /usr/bin/lifecycled \
 sudo chmod +x /usr/bin/lifecycled
 sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
   https://raw.githubusercontent.com/buildkite/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit
+
+echo "Adding authorized keys systemd units..."
+sudo cp /tmp/conf/ssh/systemd/* /etc/systemd/system


### PR DESCRIPTION
Fixes #1183 — I don't think the systemd units responsible for refreshing authorized keys are being copied into the right place when the AMI is baked. This copies the approach of install-docker:

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/804061df748b42d3d40d5378892d84b2ff8e71ec/packer/linux/scripts/install-docker.sh#L19-L21