### PR TITLE
Cherrypick bump buildkite-agent to v3.50.4

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-AGENT_VERSION=3.50.3
+AGENT_VERSION=3.50.4
 
 MACHINE="$(uname -m)"
 

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.50.3"
+$AGENT_VERSION = "3.50.4"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
This puts the good release of the agent on the v5.22 branch