### PR TITLE
Fix `mdadm` is not installed

### DIFF
--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -17,6 +17,7 @@ sudo dnf install -yq \
   awscli-2 \
   git \
   jq \
+  mdadm \
   nvme-cli \
   pigz \
   python \


### PR DESCRIPTION
This is required for `EnableInstanceStorage` on instances with multiple NVMe disks. It's not required for instances with just 1 NVMe disk.

Fixes: #1176