### PR TITLE
fix: Add Missing Service Role Permissions

### DIFF
--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -181,7 +181,8 @@ Resources:
                 "lambda:RemovePermission",
                 "lambda:DeleteFunction",
                 "lambda:InvokeFunction",
-                "lambda:TagResource"
+                "lambda:TagResource",
+                "lambda:UpdateFunctionConfiguration"
               ],
               "Resource": "arn:aws:lambda:*:*:function:*"
             },
@@ -276,6 +277,7 @@ Resources:
                 "autoscaling:DescribeScalingProcessTypes",
                 "autoscaling:DescribeScheduledActions",
                 "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
                 "autoscaling:DescribeLifecycleHooks",
                 "autoscaling:SetDesiredCapacity",
                 "autoscaling:PutLifecycleHook",
@@ -283,6 +285,7 @@ Resources:
                 "autoscaling:SetInstanceProtection",
                 "autoscaling:CreateAutoScalingGroup",
                 "autoscaling:EnableMetricsCollection",
+                "autoscaling:DisableMetricsCollection",
                 "autoscaling:UpdateAutoScalingGroup",
                 "autoscaling:DeleteAutoScalingGroup",
                 "autoscaling:PutScalingPolicy",


### PR DESCRIPTION
We required these extra permissions when we made the switch to using the service role. I'm not sure what permutation of parameters added these extra requirements, but I don't think it would be unique for our org.