### PR TITLE
Fix instance storage mount script fails when instance storage not available

### DIFF
--- a/packer/linux/conf/bin/bk-mount-instance-storage.sh
+++ b/packer/linux/conf/bin/bk-mount-instance-storage.sh
@@ -14,7 +14,7 @@ if [[ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" != "true" ]]; then
 fi
 
 #shellcheck disable=SC2207
-devices=($(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -f1 -d' '))
+devices=($(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -f1 -d' ' || true))
 
 if [[ -z "${devices[*]}" ]]; then
   echo No NVMe drives to mount. >&2

--- a/packer/linux/conf/bin/bk-mount-instance-storage.sh
+++ b/packer/linux/conf/bin/bk-mount-instance-storage.sh
@@ -9,15 +9,16 @@ exec > >(tee -a /var/log/elastic-stack.log | logger -t user-data -s 2>/dev/conso
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html
 
 if [[ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" != "true" ]]; then
-  echo "Skipping mounting instance storage"
+  echo Skipping mounting instance storage >&2
   exit 0
 fi
 
 #shellcheck disable=SC2207
 devices=($(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -f1 -d' '))
 
-if [ -z "${devices[*]}" ]; then
-  echo "No Instance Storage NVMe drives to mount" >&2
+if [[ -z "${devices[*]}" ]]; then
+  echo No NVMe drives to mount. >&2
+  echo Please check that your instance type supports instance storage >&2
   exit 0
 fi
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -480,7 +480,10 @@ Parameters:
 
   EnableInstanceStorage:
     Type: String
-    Description: Mount available NVMe Instance Storage at /mnt/ephemeral
+    Description: >
+      Mount available NVMe Instance Storage at /mnt/ephemeral, and use it to store docker images and
+      containers, and the build working directory. You must ensure that the instance types have
+      instance storage available for this to have any effect. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-store-volumes.html
     AllowedValues:
       - "true"
       - "false"


### PR DESCRIPTION
It's understandable for it to fail, but the result is that users that have misconfigured their stacks to use instance storage on an instance type that doesn't support it will experiance flapping instances.

Now, we will allow them to misconfigure their stack. Maybe later, we can feed a warning into the job logs, but there is presently no mechanism to do so in the agent.