### PR TITLE
Disable idle timeout for scale-in protected instances

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -65,6 +65,14 @@ PLUGINS_ENABLED=()
 [[ $ECR_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("ecr")
 [[ $DOCKER_LOGIN_PLUGIN_ENABLED == "true" ]] && PLUGINS_ENABLED+=("docker-login")
 
+# Check whether this instance is protected from scale-in
+SCALE_IN_PROTECTION="$(aws autoscaling describe-auto-scaling-instances --instance-id "${INSTANCE_ID}" --query 'AutoScalingInstances[0].ProtectedFromScaleIn')"
+
+# If so, disable the idle timeout for the agent.
+if [[ "${SCALE_IN_PROTECTION}" = 'true' ]]; then
+  export BUILDKITE_SCALE_IN_IDLE_PERIOD=0
+fi
+
 # cfn-env is sourced by the environment hook in builds
 
 # We will create it in two steps so that we don't need to go crazy with quoting and escaping. The

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -35,6 +35,14 @@ If ($Env:SECRETS_PLUGIN_ENABLED -eq "true") { $PLUGINS_ENABLED += "secrets" }
 If ($Env:ECR_PLUGIN_ENABLED -eq "true") { $PLUGINS_ENABLED += "ecr" }
 If ($Env:DOCKER_LOGIN_PLUGIN_ENABLED -eq "true") { $PLUGINS_ENABLED += "docker-login" }
 
+# Check whether this instance is protected from scale-in.
+${SCALE_IN_PROTECTION} = (aws autoscaling describe-auto-scaling-instances --instance-id "${Env:INSTANCE_ID}" --query 'AutoScalingInstances[0].ProtectedFromScaleIn')
+
+# If so, disable the idle timeout for the agent.
+If (${SCALE_IN_PROTECTION} -eq 'true') {
+  ${Env:BUILDKITE_SCALE_IN_IDLE_PERIOD} = 0
+}
+
 # cfn-env is sourced by the environment hook in builds
 
 # There's a confusing situation here, because this is PowerShell, writing out a script which will be


### PR DESCRIPTION
Setting MinSize prevents AWS from scaling in below a number of agents. This doesn't prevent the agent terminating, which causes the terminate-instance script to run. That's fine, but... the agent can terminate for a variety of reasons, the most common being the idle timeout.

If MinSize > 0, and there are few jobs, then after ScaleInIdlePeriod (which becomes agent's disconnect-after-idle-timeout) the agent terminates (taking the instance with it). Then a new instance is spun up, it times out, and terminates. Lather, rinse, repeat. 

Arguably the intention of MinSize is to ensure some minimum capacity is always ready. So the idle timeout shouldn't apply to MinSize of the instances running.
