### PR TITLE
Add BuildkiteFailureToTerminateInstanceBehavior

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -131,6 +131,15 @@ if [[ "${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" != "" ]]; then
   chmod 440 /etc/sudoers.d/buildkite-agent-additional
 fi
 
+case "${BUILDKITE_FAILURE_TO_TERMINATE_INSTANCE_BEHAVIOR}" in
+  restart-agent)
+    ln -sf /usr/local/bin/terminate-instance-or-restart-agent /usr/local/bin/exec-stop-post
+    ;;
+  mark-unhealthy)
+    ln -sf /usr/local/bin/terminate-instance-or-mark-unhealthy /usr/local/bin/exec-stop-post
+    ;;
+esac
+
 # Choose the right agent binary
 ln -sf "/usr/bin/buildkite-agent-${BUILDKITE_AGENT_RELEASE}" /usr/bin/buildkite-agent
 

--- a/packer/linux/conf/buildkite-agent/scripts/exec-stop-post
+++ b/packer/linux/conf/buildkite-agent/scripts/exec-stop-post
@@ -1,0 +1,1 @@
+terminate-instance

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -6,10 +6,20 @@ echo "sleeping for 10 seconds before terminating instance to allow agent logs to
 
 sleep 10
 
+terminate_failed() {
+  echo "terminate-instance: ASG could not decrement (we're already at MinSize)"
+  echo "terminate-instance: Restarting buildkite-agent service"
+  systemctl start buildkite-agent.service
+}
+
 token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
 instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
 region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
 
 echo "requesting instance termination..."
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity"
+aws autoscaling terminate-instance-in-auto-scaling-group \
+  --region "$region" \
+  --instance-id "$instance_id" \
+  --should-decrement-desired-capacity \
+  || terminate_failed

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance-or-mark-unhealthy
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance-or-mark-unhealthy
@@ -2,17 +2,18 @@
 
 set -euo pipefail
 
-echo "sleeping for 10 seconds before terminating instance to allow agent logs to drain to cloudwatch..."
-
-sleep 10
-
 token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
 instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
 region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
 
-echo "requesting instance termination..."
+terminate_failed() {
+  echo "terminate-instance: ASG could not decrement (we're already at MinSize)"
+  echo "terminate-instance: Marking unhealthy"
+  aws autoscaling set-instance-health \
+    --instance-id "${instance_id}" \
+    --region "${region}" \
+    --health-status Unhealthy \
+    --no-should-respect-grace-period
+}
 
-aws autoscaling terminate-instance-in-auto-scaling-group \
-  --instance-id "${instance_id}" \
-  --region "${region}" \
-  --should-decrement-desired-capacity
+/usr/local/bin/terminate-instance || terminate_failed

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance-or-restart-agent
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance-or-restart-agent
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+terminate_failed() {
+  echo "terminate-instance: ASG could not decrement (we're already at MinSize)"
+  echo "terminate-instance: Restarting buildkite-agent service"
+  systemctl start buildkite-agent.service
+}
+
+/usr/local/bin/terminate-instance || terminate_failed

--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -14,7 +14,7 @@ Environment="USER=buildkite-agent"
 # The =- (rather than just = ) in the line below means that systemd won't complain if it can't find the file
 EnvironmentFile=-/var/lib/buildkite-agent/env
 ExecStart=/usr/bin/buildkite-agent start
-ExecStopPost=/usr/local/bin/terminate-instance
+ExecStopPost=/usr/local/bin/exec-stop-post
 RestartSec=5
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -93,6 +93,24 @@ If ($Env:BUILDKITE_AGENT_RELEASE -eq "edge") {
 
 Copy-Item -Path C:\buildkite-agent\bin\buildkite-agent-${Env:BUILDKITE_AGENT_RELEASE}.exe -Destination C:\buildkite-agent\bin\buildkite-agent.exe
 
+Switch (${Env:BUILDKITE_FAILURE_TO_TERMINATE_INSTANCE_BEHAVIOR}) {
+  "restart-agent" {
+    Copy-Item `
+      -Path C:\buildkite-agent\bin\terminate-instance-or-restart-agent.ps1 `
+      -Destination C:\buildkite-agent\bin\exit-post.ps1
+  }
+  "mark-unhealthy" {
+    Copy-Item `
+      -Path C:\buildkite-agent\bin\terminate-instance-or-mark-unhealthy.ps1 `
+      -Destination C:\buildkite-agent\bin\exit-post.ps1
+  }
+  default {
+    Copy-Item `
+      -Path C:\buildkite-agent\bin\terminate-instance.ps1 `
+      -Destination C:\buildkite-agent\bin\exit-post.ps1
+  }
+}
+
 $agent_metadata=@(
   "queue=${Env:BUILDKITE_QUEUE}"
   "docker=${DOCKER_VERSION}"
@@ -232,7 +250,7 @@ nssm set buildkite-agent AppExit Default Restart
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppRestartDelay 10000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
-nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
+nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\exit-post.ps1"
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 Restart-Service buildkite-agent

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance-or-mark-unhealthy.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance-or-mark-unhealthy.ps1
@@ -16,4 +16,10 @@ if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will term
 }
 else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at MinSize)"
+  Write-Output "terminate-instance: Marking unhealthy"
+  aws autoscaling set-instance-health `
+    --instance-id "$InstanceId" `
+    --region "$Region" `
+    --health-status Unhealthy `
+    --no-should-respect-grace-period
 }

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance-or-restart-agent.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance-or-restart-agent.ps1
@@ -16,4 +16,6 @@ if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will term
 }
 else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at MinSize)"
+  Write-Output "terminate-instance: Restarting buildkite-agent service"
+  Restart-Service buildkite-agent
 }

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -44,6 +44,7 @@ Metadata:
         - BuildkiteAgentEnableGitMirrors
         - BuildkiteAgentTracingBackend
         - BuildkiteTerminateInstanceAfterJob
+        - BuildkiteFailureToTerminateInstanceBehavior
         - BuildkiteAdditionalSudoPermissions
         - BuildkiteWindowsAdministrator
         - BuildkiteAgentScalerServerlessARN
@@ -201,6 +202,15 @@ Parameters:
       - "true"
       - "false"
     Default: "false"
+
+  BuildkiteFailureToTerminateInstanceBehavior:
+    Description: Optional - what to do if the instance cannot self-terminate after the agent exits (e.g. because there are MinSize instances remaining). 'restart-agent' starts the agent service again. 'mark-unhealthy' marks the instance as unhealthy immediately.
+    Type: String
+    AllowedValues:
+      - ""
+      - "mark-unhealthy"
+      - "restart-agent"
+    Default: ""
 
   BuildkiteAdditionalSudoPermissions:
     Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo. Note that the commands should be fully qualified paths to executables.
@@ -1177,6 +1187,7 @@ Resources:
                   $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
                   $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
                   $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
+                  $Env:BUILDKITE_FAILURE_TO_TERMINATE_INSTANCE_BEHAVIOR="${BuildkiteFailureToTerminateInstanceBehavior}"
                   $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
                   $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
                   $Env:AWS_DEFAULT_REGION="${AWS::Region}"
@@ -1235,6 +1246,7 @@ Resources:
                   BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
                   BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
                   BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
+                  BUILDKITE_FAILURE_TO_TERMINATE_INSTANCE_BEHAVIOR="${BuildkiteFailureToTerminateInstanceBehavior}" \
                   BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
                   AWS_DEFAULT_REGION="${AWS::Region}" \
                   SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}" \


### PR DESCRIPTION
When the agent exits, systemd (or the moral equivalent on Windows) runs terminate-instance{,.ps1}, which runs `aws autoscaling terminate-instance-in-auto-scaling-group`. 

If terminating the current instance would drop the number of instances below MinSize, the `aws autoscaling` call fails. (The Windows script at least acknowledges this possibility.) But then the instance just hangs around for a while doing nothing.

~~Restarting the agent service if the terminate call fails seems like a better behaviour in all cases, but if we feel that it needs a parameter, I can add that.~~ 

This PR adds a parameter allowing the termination-failure behaviour to be changed.