### PR TITLE
Fix ami_source_filter

### DIFF
--- a/packer/linux/buildkite-ami.json
+++ b/packer/linux/buildkite-ami.json
@@ -11,7 +11,7 @@
       "region": "{{user `region`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "al2023-ami-minimal-2023.0.*.*-kernel-*",
+          "name": "al2023-ami-minimal-*",
           "architecture": "{{user `arch`}}",
           "virtualization-type": "hvm"
         },


### PR DESCRIPTION
At some point in the last couple of days, `al2023-ami-minimal-2023.0.*.*-kernel-*` stopped matching anything.

Is there a better filter?