### PR TITLE
fix: allow hyphen in InstanceTypes

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -285,7 +285,7 @@ Parameters:
     Type: String
     Default: t3.large
     MinLength: 1
-    AllowedPattern: "^[\\w\\.]+(,[\\w\\.]*){0,3}$"
+    AllowedPattern: "^[\\w-\\.]+(,[\\w\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
 
   MaxSize:


### PR DESCRIPTION
## what
- allow hyphen in InstanceTypes input

## why
- I want to add the instance type `m7a.metal-48xl` which currently fails
- Once this is fixed, can we also have it brought back to the 5.x branch?

## references
- Closes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1227
- See regexr test https://regexr.com/7krdq