### PR TITLE
Add `lambda:UpdateFunctionCode` to service role

### DIFF
--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -182,7 +182,8 @@ Resources:
                 "lambda:DeleteFunction",
                 "lambda:InvokeFunction",
                 "lambda:TagResource",
-                "lambda:UpdateFunctionConfiguration"
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:UpdateFunctionCode"
               ],
               "Resource": "arn:aws:lambda:*:*:function:*"
             },


### PR DESCRIPTION
When upgrading a stack using the service role, and the version of the autoscaler lambda
changes, this permission is needed.