### PR TITLE
Bump docker-compose to v2.22.0

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_COMPOSE_V2_VERSION=2.20.3
+DOCKER_COMPOSE_V2_VERSION=2.22.0
 DOCKER_BUILDX_VERSION=0.11.2
 MACHINE=$(uname -m)
 


### PR DESCRIPTION
Version v2.21.0 includes a "fix for incorrect proxy variables during build" - https://github.com/docker/compose/pull/10908. Thought I may as well go for the latest at time of writing.
