### PR TITLE
Updated Agent Scaler version to 1.7.0

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -183,7 +183,7 @@ Parameters:
   BuildkiteAgentScalerVersion:
     Description: Version of the buildkite-agent-scaler to use
     Type: String
-    Default: "1.6.0"
+    Default: "1.7.0"
 
   BuildkiteAgentTracingBackend:
     Description: The tracing backend to use for CI tracing. See https://buildkite.com/docs/agent/v3/tracing


### PR DESCRIPTION
This change introduces a fix to AWS Lambda functions being migrated from the go 1.x runtime to the new Custom Runtime on Amazon Linux 2, see [this post](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/).

The changes to the Agent Scaler can be found in https://github.com/buildkite/buildkite-agent-scaler/pull/108 to support this new Elastic Stack version.

Fixes #1203.

**Note**: Customers upgrading existing stacks may not be able to upgrade to the new version, there are more details in the following comments: https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1172#issuecomment-1697304023, https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1172#issuecomment-1698421029

The current method of solving this issue is to run this command via the AWS CLI: `aws cloudformation update-stack`