### PR TITLE
fix: wrap quotes around AWS::StackName

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1130,7 +1130,7 @@ Resources:
                 - Key: Role
                   Value: buildkite-agent
                 - Key: Name
-                  Value: !If [ UseStackNameForInstanceName, !Ref AWS::StackName, !Ref InstanceName ]
+                  Value: !If [ UseStackNameForInstanceName, !Ref "AWS::StackName", !Ref InstanceName ]
                 - Key: BuildkiteAgentRelease
                   Value: !Ref BuildkiteAgentRelease
                 - Key: BuildkiteQueue


### PR DESCRIPTION
## Purpose 🎯 
- Fixes an error encountered when we attempt to unmarshal the YAML template via our internal tooling
- After experimentation, I discovered that one I wrapped quotes around `AWS::StackName` our tooling was able to parse the template successfully

## Context 🧠 
- We perform some wrangling of CFN parameters via an internal CLI tool. As part of this process, the tool parses a YAML template to figure out which parameters are required as input
- Discovered this yaml parsing error when I was attempting to smoke test our upgrade to the `v6` elastic stack
- My best guess is that the yaml unmarshalling process doesn't like `::` unless it's quoted and/or escaped? 🤷 