### PR TITLE
fix: re-add rsyslog

### DIFF
--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -33,11 +33,13 @@ sudo dnf install -yq \
 # in a future version of Amazon Linux
 sudo dnf install -yq \
   bind-utils \
-  lsof
+  lsof \
+  rsyslog
 
 sudo dnf -yq groupinstall "Development Tools"
 
 sudo systemctl enable --now amazon-ssm-agent
+sudo systemctl enable --now rsyslog
 
 GIT_LFS_VERSION=3.4.0
 echo "Installing git lfs ${GIT_LFS_VERSION}..."


### PR DESCRIPTION
Rsys is no longer installed on Amazon Linux 2023, see: [changelog](https://docs.aws.amazon.com/linux/al2023/ug/compare-with-al2.html#journald)

This re-adds the rsyslog daemon and starts it.