### PR TITLE
Tag Images with Agent and Elastic CI Stack Version

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -212,8 +212,8 @@ steps:
     artifact_paths: "build/*.yml"
     depends_on: "copy-ami"
 
-  - id: "cleanup"
-    name: "Cleanup"
+  - id: cleanup
+    name: ":broom: Cleanup"
     command: .buildkite/steps/cleanup.sh
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -11,11 +11,12 @@ copy_ami_to_region() {
   local destination_image_name="$4"
 
   aws ec2 copy-image \
+    --copy-image-tags \
     --source-image-id "$source_image_id" \
     --source-region "$source_region" \
     --name "$destination_image_name" \
     --region "$destination_image_region" \
-    --query "ImageId" \
+    --query ImageId \
     --output text
 }
 

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -138,7 +138,8 @@ if [[ $BUILDKITE_BRANCH == main || $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TA
 fi
 
 echo --- Tagging elastic ci stack release version
-echo Note: the same AMI may be used in multiple versions of the elastic stack, so we can\'t use the same tag key
+echo "Note: the same AMI may be used in multiple versions of the elastic stack,"
+echo "so we can't use the same tag key for each version."
 if [[ $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_VERSION:-false} == true ]]; then
   tag-ami "$linux_amd64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
   tag-ami "$linux_arm64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -57,7 +57,7 @@ make_ami_public() {
   aws ec2 modify-image-attribute \
     --region "$region" \
     --image-id "$image_id" \
-    --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
+    --launch-permission '{"Add": [{"Group": "all"}]}'
 }
 
 tag-ami() {

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -107,7 +107,7 @@ if [ $# -eq 0 ]; then
 fi
 
 # If we're not on the main branch or a tag build skip the copy
-if [[ $BUILDKITE_BRANCH != main ]] && [[ $BUILDKITE_TAG != "$BUILDKITE_BRANCH" ]] && [[ ${COPY_TO_ALL_REGIONS:-"false"} != "true" ]]; then
+if [[ $BUILDKITE_BRANCH != main && $BUILDKITE_TAG != "$BUILDKITE_BRANCH" && ${COPY_TO_ALL_REGIONS:-false} != true ]]; then
   echo "--- Skipping AMI copy on non-main/tag branch " >&2
   mkdir -p "$(dirname "$mapping_file")"
   cat <<EOF >"$mapping_file"

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -119,9 +119,11 @@ EOF
 fi
 
 echo --- Tagging source images as released
-aws ec2 tag-images --region "$source_region" --image-ids "$linux_amd64_source_image_id" --tags Key=IsReleased,Value=true
-aws ec2 tag-images --region "$source_region" --image-ids "$linux_arm64_source_image_id" --tags Key=IsReleased,Value=true
-aws ec2 tag-images --region "$source_region" --image-ids "$windows_amd64_source_image_id" --tags Key=IsReleased,Value=true
+if [[ $BUILDKITE_BRANCH == main || $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_IS_RELEASED:-false} == true ]]; then
+  aws ec2 tag-images --region "$source_region" --image-ids "$linux_amd64_source_image_id" --tags Key=IsReleased,Value=true
+  aws ec2 tag-images --region "$source_region" --image-ids "$linux_arm64_source_image_id" --tags Key=IsReleased,Value=true
+  aws ec2 tag-images --region "$source_region" --image-ids "$windows_amd64_source_image_id" --tags Key=IsReleased,Value=true
+fi
 
 echo --- Checking if there is a previously copy in the cache bucket
 s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -130,14 +130,14 @@ EOF
   exit 0
 fi
 
-echo --- Tagging AMIs as released
+echo "--- Tagging AMIs as released"
 if [[ $BUILDKITE_BRANCH == main || $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_IS_RELEASED:-false} == true ]]; then
   tag-ami "$linux_amd64_source_image_id" "$source_region" IsReleased true
   tag-ami "$linux_arm64_source_image_id" "$source_region" IsReleased true
   tag-ami "$windows_amd64_source_image_id" "$source_region" IsReleased true
 fi
 
-echo --- Tagging elastic ci stack release version
+echo "--- Tagging elastic ci stack release version"
 echo "Note: the same AMI may be used in multiple versions of the elastic stack,"
 echo "so we can't use the same tag key for each version."
 if [[ $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_VERSION:-false} == true ]]; then
@@ -146,7 +146,7 @@ if [[ $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_VERSION:-false} == true ]];
   tag-ami "$windows_amd64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
 fi
 
-echo --- Checking if there is a previously copy in the cache bucket
+echo "--- Checking if there is a previously copy in the cache bucket"
 s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
   "${BUILDKITE_AWS_STACK_BUCKET}" \
   "${linux_amd64_source_image_id}" \
@@ -159,7 +159,7 @@ if aws s3 cp "${s3_mappings_cache}" "$mapping_file"; then
   exit 0
 fi
 
-echo --- Copying images to other regions
+echo "--- Copying images to other regions"
 
 # Get the image names to copy to other regions
 linux_amd64_source_image_name=$(get_image_name "$linux_amd64_source_image_id" "$source_region")

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -125,6 +125,14 @@ if [[ $BUILDKITE_BRANCH == main || $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TA
   aws ec2 tag-images --region "$source_region" --image-ids "$windows_amd64_source_image_id" --tags Key=IsReleased,Value=true
 fi
 
+echo --- Tagging elastic ci stack release version
+echo Note: the same AMI may be used in multiple versions of the elastic stack, so we can\'t use the same tag key
+if [[ $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_VERSION:-false} == true ]]; then
+  aws ec2 tag-images --region "$source_region" --image-ids "$linux_amd64_source_image_id" --tags "Key=Version:${BUILDKITE_TAG},Value=true"
+  aws ec2 tag-images --region "$source_region" --image-ids "$linux_arm64_source_image_id" --tags "Key=Version:${BUILDKITE_TAG},Value=true"
+  aws ec2 tag-images --region "$source_region" --image-ids "$windows_amd64_source_image_id" --tags "Key=Version:${BUILDKITE_TAG},Value=true"
+fi
+
 echo --- Checking if there is a previously copy in the cache bucket
 s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
   "${BUILDKITE_AWS_STACK_BUCKET}" \

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -118,10 +118,12 @@ EOF
   exit 0
 fi
 
+echo --- Tagging source images as released
 aws ec2 tag-images --region "$source_region" --image-ids "$linux_amd64_source_image_id" --tags Key=IsReleased,Value=true
 aws ec2 tag-images --region "$source_region" --image-ids "$linux_arm64_source_image_id" --tags Key=IsReleased,Value=true
 aws ec2 tag-images --region "$source_region" --image-ids "$windows_amd64_source_image_id" --tags Key=IsReleased,Value=true
 
+echo --- Checking if there is a previously copy in the cache bucket
 s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
   "${BUILDKITE_AWS_STACK_BUCKET}" \
   "${linux_amd64_source_image_id}" \
@@ -129,11 +131,12 @@ s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
   "${windows_amd64_source_image_id}" \
   "${BUILDKITE_BRANCH}")
 
-# Check if there is a previously copy in the cache bucket
 if aws s3 cp "${s3_mappings_cache}" "$mapping_file"; then
   echo "--- Skipping AMI copy, was previously copied"
   exit 0
 fi
+
+echo --- Copying images to other regions
 
 # Get the image names to copy to other regions
 linux_amd64_source_image_name=$(get_image_name "$linux_amd64_source_image_id" "$source_region")

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -118,6 +118,10 @@ EOF
   exit 0
 fi
 
+aws ec2 tag-images --region "$source_region" --image-ids "$linux_amd64_source_image_id" --tags Key=IsReleased,Value=true
+aws ec2 tag-images --region "$source_region" --image-ids "$linux_arm64_source_image_id" --tags Key=IsReleased,Value=true
+aws ec2 tag-images --region "$source_region" --image-ids "$windows_amd64_source_image_id" --tags Key=IsReleased,Value=true
+
 s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
   "${BUILDKITE_AWS_STACK_BUCKET}" \
   "${linux_amd64_source_image_id}" \

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -141,8 +141,7 @@ linux_arm64_source_image_name=$(get_image_name "$linux_arm64_source_image_id" "$
 windows_amd64_source_image_name=$(get_image_name "$windows_amd64_source_image_id" "$source_region")
 
 # Copy to all other regions
-# shellcheck disable=SC2048
-for region in ${ALL_REGIONS[*]}; do
+for region in "${ALL_REGIONS[@]}"; do
   if [[ $region != "$source_region" ]]; then
     echo "--- :linux: Copying Linux AMD64 $linux_amd64_source_image_id to $region" >&2
     IMAGES+=("$(copy_ami_to_region "$linux_amd64_source_image_id" "$source_region" "$region" "${linux_amd64_source_image_name}-${region}")")
@@ -165,8 +164,7 @@ Mappings:
 EOF
 
 echo "--- Waiting for AMIs to become available" >&2
-# shellcheck disable=SC2048
-for region in ${ALL_REGIONS[*]}; do
+for region in "${ALL_REGIONS[@]}"; do
   linux_amd64_image_id="${IMAGES[0]}"
   linux_arm64_image_id="${IMAGES[1]}"
   windows_amd64_image_id="${IMAGES[2]}"

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ print-agent-versions:
 
 # Build linuxarm64 packer image
 packer-linux-arm64.output: $(PACKER_LINUX_FILES)
+	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -147,6 +148,7 @@ build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
 
 # Build windows packer image
 packer-windows-amd64.output: $(PACKER_WINDOWS_FILES)
+	@echo Agent Version: $(CURRENT_AGENT_VERSION_WINDOWS)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \

--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
 	mkdir -p build
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
+CURRENT_AGENT_VERSION_LINUX ?= $(shell sed -En 's/^AGENT_VERSION="?(.+?)"?$/\1/p' packer/linux/scripts/install-buildkite-agent.sh)
+CURRENT_AGENT_VERSION_WINDOWS ?= $(shell sed -En 's/^\$AGENT_VERSION = "(.+?)"$/\1/p' packer/windows/scripts/install-buildkite-agent.ps1)
+
 # Build linuxarm64 packer image
 packer-linux-arm64.output: $(PACKER_LINUX_FILES)
 	docker run \
@@ -130,6 +133,7 @@ packer-linux-arm64.output: $(PACKER_LINUX_FILES)
 			-var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
+			-var 'agent_version=$(CURRENT_AGENT_VERSION_LINUX)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
@@ -155,6 +159,7 @@ packer-windows-amd64.output: $(PACKER_WINDOWS_FILES)
 			-var 'instance_type=$(WIN64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
+			-var 'agent_version=$(CURRENT_AGENT_VERSION_WINDOWS)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 # -----------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -199,10 +199,9 @@ update-stack: build/aws-stack.yml env-STACK_NAME
 AGENT_VERSION ?= $(shell curl -Lfs "https://buildkite.com/agent/releases/latest?platform=linux&arch=amd64" | grep version | cut -d= -f2)
 
 bump-agent-version:
-	sed -i.bak -E "s/\[Buildkite Agent v.*\]/[Buildkite Agent v$(AGENT_VERSION)]/g" README.md
-	sed -i.bak -E "s/AGENT_VERSION=.+/AGENT_VERSION=$(AGENT_VERSION)/g" packer/linux/scripts/install-buildkite-agent.sh
-	sed -i.bak -E "s/\\\$$AGENT_VERSION = \".+\"/\$$AGENT_VERSION = \"$(AGENT_VERSION)\"/g" packer/windows/scripts/install-buildkite-agent.ps1
-	rm README.md.bak packer/linux/scripts/install-buildkite-agent.sh.bak packer/windows/scripts/install-buildkite-agent.ps1.bak
+	sed -iE "s/\[Buildkite Agent v.*\]/[Buildkite Agent v$(AGENT_VERSION)]/g" README.md
+	sed -iE "s/AGENT_VERSION=.+/AGENT_VERSION=$(AGENT_VERSION)/g" packer/linux/scripts/install-buildkite-agent.sh
+	sed -iE "s/\\\$$AGENT_VERSION = \".+\"/\$$AGENT_VERSION = \"$(AGENT_VERSION)\"/g" packer/windows/scripts/install-buildkite-agent.ps1
 
 validate: build/aws-stack.yml
 	aws --no-cli-pager cloudformation validate-template \

--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,9 @@ build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
 	mkdir -p build
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
-CURRENT_AGENT_VERSION_LINUX ?= $(shell sed -En 's/^AGENT_VERSION="?(.+?)"?$/\1/p' packer/linux/scripts/install-buildkite-agent.sh)
-CURRENT_AGENT_VERSION_WINDOWS ?= $(shell sed -En 's/^\$AGENT_VERSION = "(.+?)"$/\1/p' packer/windows/scripts/install-buildkite-agent.ps1)
+# NOTE: make removes the $ escapes, everything else is passed to the shell
+CURRENT_AGENT_VERSION_LINUX ?= $(shell sed -En 's/^AGENT_VERSION="?(.+?)"?$$/\1/p' packer/linux/scripts/install-buildkite-agent.sh)
+CURRENT_AGENT_VERSION_WINDOWS ?= $(shell sed -En 's/^\$$AGENT_VERSION = "(.+?)"$$/\1/p' packer/windows/scripts/install-buildkite-agent.ps1)
 
 # Build linuxarm64 packer image
 packer-linux-arm64.output: $(PACKER_LINUX_FILES)

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
 CURRENT_AGENT_VERSION_LINUX ?= $(shell sed -En 's/^AGENT_VERSION="?(.+?)"?$$/\1/p' packer/linux/scripts/install-buildkite-agent.sh)
 CURRENT_AGENT_VERSION_WINDOWS ?= $(shell sed -En 's/^\$$AGENT_VERSION = "(.+?)"$$/\1/p' packer/windows/scripts/install-buildkite-agent.ps1)
 
+print-agent-versions:
+	@echo Linux: $(CURRENT_AGENT_VERSION_LINUX)
+	@echo Windows: $(CURRENT_AGENT_VERSION_WINDOWS)
+
 # Build linuxarm64 packer image
 packer-linux-arm64.output: $(PACKER_LINUX_FILES)
 	docker run \

--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,9 @@ update-stack: build/aws-stack.yml env-STACK_NAME
 AGENT_VERSION ?= $(shell curl -Lfs "https://buildkite.com/agent/releases/latest?platform=linux&arch=amd64" | grep version | cut -d= -f2)
 
 bump-agent-version:
-	sed -iE "s/\[Buildkite Agent v.*\]/[Buildkite Agent v$(AGENT_VERSION)]/g" README.md
-	sed -iE "s/AGENT_VERSION=.+/AGENT_VERSION=$(AGENT_VERSION)/g" packer/linux/scripts/install-buildkite-agent.sh
-	sed -iE "s/\\\$$AGENT_VERSION = \".+\"/\$$AGENT_VERSION = \"$(AGENT_VERSION)\"/g" packer/windows/scripts/install-buildkite-agent.ps1
+	sed -Ei "s/\[Buildkite Agent v.*\]/[Buildkite Agent v$(AGENT_VERSION)]/g" README.md
+	sed -Ei "s/AGENT_VERSION=.+/AGENT_VERSION=$(AGENT_VERSION)/g" packer/linux/scripts/install-buildkite-agent.sh
+	sed -Ei "s/\\\$$AGENT_VERSION = \".+\"/\$$AGENT_VERSION = \"$(AGENT_VERSION)\"/g" packer/windows/scripts/install-buildkite-agent.ps1
 
 validate: build/aws-stack.yml
 	aws --no-cli-pager cloudformation validate-template \

--- a/Makefile
+++ b/Makefile
@@ -197,8 +197,6 @@ bump-agent-version:
 	sed -i.bak -E "s/AGENT_VERSION=.+/AGENT_VERSION=$(AGENT_VERSION)/g" packer/linux/scripts/install-buildkite-agent.sh
 	sed -i.bak -E "s/\\\$$AGENT_VERSION = \".+\"/\$$AGENT_VERSION = \"$(AGENT_VERSION)\"/g" packer/windows/scripts/install-buildkite-agent.ps1
 	rm README.md.bak packer/linux/scripts/install-buildkite-agent.sh.bak packer/windows/scripts/install-buildkite-agent.ps1.bak
-	git add README.md packer/linux/scripts/install-buildkite-agent.sh packer/windows/scripts/install-buildkite-agent.ps1
-	git commit -m "Bump buildkite-agent to v$(AGENT_VERSION)"
 
 validate: build/aws-stack.yml
 	aws --no-cli-pager cloudformation validate-template \

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -27,6 +27,11 @@ variable "build_number" {
   default = "none"
 }
 
+variable "agent_version" {
+  type    = string
+  default = "devel"
+}
+
 variable "is_released" {
   type    = bool
   default = false
@@ -56,6 +61,7 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
     Name          = "elastic-ci-stack-linux-${var.arch}"
     OSVersion     = "Amazon Linux 2023"
     BuildNumber   = var.build_number
+    AgentVersion  = var.agent_version
     IsReleased    = var.is_released
     SourceAMIID   = data.amazon-ami.al2023.id
     SourceAMIName = data.amazon-ami.al2023.name

--- a/packer/windows/buildkite-ami.pkr.hcl
+++ b/packer/windows/buildkite-ami.pkr.hcl
@@ -27,6 +27,11 @@ variable "build_number" {
   default = "none"
 }
 
+variable "agent_version" {
+  type    = string
+  default = "devel"
+}
+
 variable "is_released" {
   type    = bool
   default = false
@@ -59,6 +64,7 @@ source "amazon-ebs" "elastic-ci-stack" {
     Name          = "elastic-ci-stack-windows"
     OSVersion     = "Windows Server 2019"
     BuildNumber   = var.build_number
+    AgentVersion  = var.agent_version
     IsReleased    = var.is_released
     SourceAMIID   = data.amazon-ami.windows-server-2019.id
     SourceAMIName = data.amazon-ami.windows-server-2019.name


### PR DESCRIPTION
The format of the tags will be:
```
Key=AgentVersion,Value=x.y.x
Key=Version:x.y.z,Value=true
```
Since the same AMI can be used for multiple Elastic CI Stack Versions, we can't just have one `Version` tag key and need to have a separate tag key for each version of the Elastic CI Stack.

The Agent Version is not like that and is known when the image is built by Packer. Note, however, that if users elect to use the "beta" or "edge" channels for agents, the version of the agent may differ from that of the tag.