### PR TITLE
Fix `ScalerEventSchedulePeriod` was missing from interface

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -97,7 +97,7 @@ Metadata:
         - ScaleInIdlePeriod
         - ScaleOutForWaitingJobs
         - InstanceCreationTimeout
-        - ScalerEventScheduleRate
+        - ScalerEventSchedulePeriod
         - ScalerMinPollInterval
 
       - Label:


### PR DESCRIPTION
This was added in v6.7.0, but we missed adding it to the interface.