### PR TITLE
Mark last instance unhealthy if `BuildkiteTerminateInstanceAfterJob` is enabled

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -131,6 +131,10 @@ echo Writing Phase 2/2 for /var/lib/buildkite-agent/cfn-env helper function...
 cat <<EOF >>/var/lib/buildkite-agent/cfn-env
 
 set_always         "BUILDKITE_AGENTS_PER_INSTANCE" "$BUILDKITE_AGENTS_PER_INSTANCE"
+
+# also set via /etc/systemd/system/buildkite-agent.service.d/environment.conf
+set_always         "BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB" "$BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB"
+
 set_always         "BUILDKITE_ECR_POLICY" "${BUILDKITE_ECR_POLICY:-none}"
 set_always         "BUILDKITE_SECRETS_BUCKET" "$BUILDKITE_SECRETS_BUCKET"
 set_always         "BUILDKITE_SECRETS_BUCKET_REGION" "$BUILDKITE_SECRETS_BUCKET_REGION"
@@ -357,6 +361,7 @@ done
 echo "Waited $next_wait_time times for docker to start. We will exit if it still has not started."
 check_docker
 
+# also set in /var/lib/buildkite-agent/cfn-env so that its shown in the job logs
 systemctl set-environment "BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}"
 echo Starting buildkite-agent...
 systemctl enable --now buildkite-agent

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -361,8 +361,17 @@ done
 echo "Waited $next_wait_time times for docker to start. We will exit if it still has not started."
 check_docker
 
-# also set in /var/lib/buildkite-agent/cfn-env so that its shown in the job logs
-systemctl set-environment "BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}"
+echo Writing buildkite-agent systemd environment override...
+# also set in /var/lib/buildkite-agent/cfn-env so that it's shown in the job logs
+mkdir -p /etc/systemd/system/buildkite-agent.service.d
+cat <<EOF | tee /etc/systemd/system/buildkite-agent.service.d/environment.conf
+[Service]
+Environment="BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}"
+EOF
+
+echo Reloading systemctl services...
+systemctl daemon-reload
+
 echo Starting buildkite-agent...
 systemctl enable --now buildkite-agent
 

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -357,6 +357,7 @@ done
 echo "Waited $next_wait_time times for docker to start. We will exit if it still has not started."
 check_docker
 
+systemctl set-environment "BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}"
 echo Starting buildkite-agent...
 systemctl enable --now buildkite-agent
 

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -3,28 +3,50 @@
 set -euo pipefail
 
 terminate() {
-  aws autoscaling terminate-instance-in-auto-scaling-group --region "$1" --instance-id "$2" "--should-decrement-desired-capacity"
+  aws autoscaling terminate-instance-in-auto-scaling-group \
+    --region "$1" \
+    --instance-id "$2" \
+    --should-decrement-desired-capacity
+}
+
+mark_as_unhealthy() {
+  aws autoscaling set-instance-health \
+    --region "$1" \
+    --instance-id "$2" \
+    --health-status Unhealthy
 }
 
 echo "sleeping for 10 seconds before terminating instance to allow agent logs to drain to cloudwatch..."
-
 sleep 10
 
-token=$(curl -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 60" --fail --silent --show-error --location "http://169.254.169.254/latest/api/token")
-instance_id=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/instance-id")
-region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error --location "http://169.254.169.254/latest/meta-data/placement/region")
+token=$(
+  curl \
+    --fail --silent --show-error \
+    -X PUT \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
+    --location "http://169.254.169.254/latest/api/token"
+)
+instance_id=$(
+  curl \
+    --fail --silent --show-error \
+    -H "X-aws-ec2-metadata-token: $token" \
+    --location "http://169.254.169.254/latest/meta-data/instance-id"
+)
+region=$(
+  curl \
+    --fail --silent --show-error \
+    -H "X-aws-ec2-metadata-token: $token" \
+    --location "http://169.254.169.254/latest/meta-data/placement/region"
+)
 
 echo "requesting instance termination..."
-
 if [[ $BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB == "true" ]]; then
-  # If we're the final before the ASG's min size, the call to terminate-instance-in-autoscaling-group will fail, as AWS
-  # won't allow the ASG to go below its min size. In this case, we need to call shutdown instead and force the issue -
-  # the ASG will then spin up a new instance to replace the one we're shutting down, leaving all well in the world.
-  #
-  # We need to do this because if the call to terminate fails, the systemd unit will start up a new buildkite-agent process
-  # on this machine, with state left over from the last agent, which is the opposite of what we want when $BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB is true.
-  terminate "$region" "$instance_id" || shutdown now
+  # If the ASG is at the min capacity, the call to terminate-instance-in-autoscaling-group
+  # In this case, we mark the instance as unhealthy, then the ASG will spin up a new instance
+  # to replace it.
+  terminate "$region" "$instance_id" || mark_as_unhealthy "$region" "$instance_id"
 else
-  # If we're not in terminate-after-job mode, then it's fine for this to fail, as it'll be as if the instance never got shut down.
+  # If we're not in terminate-after-job mode, then it's fine for this to fail. Systemd will restart
+  # the agent and it'll be as if the instance never got shut down.
   terminate "$region" "$instance_id"
 fi

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -23,7 +23,7 @@ if [[ $BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB == "true" ]]; then
   #
   # We need to do this because if the call to terminate fails, the systemd unit will start up a new buildkite-agent process
   # on this machine, with state left over from the last agent, which is the opposite of what we want when $BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB is true.
-  terminate "$region" "$instance_id" || shutdown
+  terminate "$region" "$instance_id" || shutdown now
 else
   # If we're not in terminate-after-job mode, then it's fine for this to fail, as it'll be as if the instance never got shut down.
   terminate "$region" "$instance_id"

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+terminate() {
+  aws autoscaling terminate-instance-in-auto-scaling-group --region "$1" --instance-id "$2" "--should-decrement-desired-capacity"
+}
+
 echo "sleeping for 10 seconds before terminating instance to allow agent logs to drain to cloudwatch..."
 
 sleep 10
@@ -12,4 +16,15 @@ region=$(curl -H "X-aws-ec2-metadata-token: $token" --fail --silent --show-error
 
 echo "requesting instance termination..."
 
-aws autoscaling terminate-instance-in-auto-scaling-group --region "$region" --instance-id "$instance_id" "--should-decrement-desired-capacity"
+if [[ $BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB == "true" ]]; then
+  # If we're the final before the ASG's min size, the call to terminate-instance-in-autoscaling-group will fail, as AWS
+  # won't allow the ASG to go below its min size. In this case, we need to call shutdown instead and force the issue -
+  # the ASG will then spin up a new instance to replace the one we're shutting down, leaving all well in the world.
+  #
+  # We need to do this because if the call to terminate fails, the systemd unit will start up a new buildkite-agent process
+  # on this machine, with state left over from the last agent, which is the opposite of what we want when $BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB is true.
+  terminate "$region" "$instance_id" || shutdown
+else
+  # If we're not in terminate-after-job mode, then it's fine for this to fail, as it'll be as if the instance never got shut down.
+  terminate "$region" "$instance_id"
+fi

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -212,13 +212,18 @@ Write-Output "Starting the Buildkite Agent"
 
 nssm install buildkite-agent C:\buildkite-agent\bin\buildkite-agent.exe start
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 nssm set buildkite-agent ObjectName .\$UserName $Password
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 nssm set buildkite-agent AppStdout C:\buildkite-agent\buildkite-agent.log
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 nssm set buildkite-agent AppStderr C:\buildkite-agent\buildkite-agent.log
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 nssm set buildkite-agent AppEnvironmentExtra :HOME=C:\buildkite-agent
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 If ((![string]::IsNullOrEmpty($Env:BUILDKITE_ENV_FILE_URL)) -And (Test-Path -Path C:\buildkite-agent\env -PathType leaf)) {
   foreach ($var in Get-Content C:\buildkite-agent\env) {
@@ -227,14 +232,15 @@ If ((![string]::IsNullOrEmpty($Env:BUILDKITE_ENV_FILE_URL)) -And (Test-Path -Pat
   }
 }
 
-nssm set buildkite-agent AppEnvironmentExtra BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB
+nssm set buildkite-agent AppEnvironmentExtra BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=$Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppExit Default Restart
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 nssm set buildkite-agent AppRestartDelay 10000
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 nssm set buildkite-agent AppEvents Exit/Post "powershell C:\buildkite-agent\bin\terminate-instance.ps1"
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -72,6 +72,10 @@ function set_always() {
 Add-Content -Path C:\buildkite-agent\cfn-env -Value @"
 
 set_always         "BUILDKITE_AGENTS_PER_INSTANCE" "$Env:BUILDKITE_AGENTS_PER_INSTANCE"
+
+# also set via nssm
+set_always         "BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB" "$Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB"
+
 set_always         "BUILDKITE_ECR_POLICY" "$Env:BUILDKITE_ECR_POLICY"
 set_always         "BUILDKITE_SECRETS_BUCKET" "$Env:BUILDKITE_SECRETS_BUCKET"
 set_always         "BUILDKITE_SECRETS_BUCKET_REGION" "$Env:BUILDKITE_SECRETS_BUCKET_REGION"
@@ -231,6 +235,7 @@ If ((![string]::IsNullOrEmpty($Env:BUILDKITE_ENV_FILE_URL)) -And (Test-Path -Pat
   }
 }
 
+# also set in cfn so it's show in job logs
 nssm set buildkite-agent AppEnvironmentExtra +BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=$Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -227,6 +227,9 @@ If ((![string]::IsNullOrEmpty($Env:BUILDKITE_ENV_FILE_URL)) -And (Test-Path -Pat
   }
 }
 
+nssm set buildkite-agent AppEnvironmentExtra BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB
+If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppExit Default Restart
 If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -146,7 +146,7 @@ tracing-backend=${Env:BUILDKITE_AGENT_TRACING_BACKEND}
 "@
 $OFS=" "
 
-nssm set lifecycled AppEnvironmentExtra :AWS_REGION=$Env:AWS_REGION
+nssm set lifecycled AppEnvironmentExtra +AWS_REGION=$Env:AWS_REGION
 nssm set lifecycled AppEnvironmentExtra +LIFECYCLED_HANDLER="C:\buildkite-agent\bin\stop-agent-gracefully.ps1"
 Restart-Service lifecycled
 
@@ -222,16 +222,16 @@ If ($lastexitcode -ne 0) { Exit $lastexitcode }
 nssm set buildkite-agent AppStderr C:\buildkite-agent\buildkite-agent.log
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
-nssm set buildkite-agent AppEnvironmentExtra :HOME=C:\buildkite-agent
+nssm set buildkite-agent AppEnvironmentExtra +HOME=C:\buildkite-agent
 
 If ((![string]::IsNullOrEmpty($Env:BUILDKITE_ENV_FILE_URL)) -And (Test-Path -Path C:\buildkite-agent\env -PathType leaf)) {
   foreach ($var in Get-Content C:\buildkite-agent\env) {
-    nssm set buildkite-agent AppEnvironmentExtra $var
+    nssm set buildkite-agent AppEnvironmentExtra "+$var"
     If ($lastexitcode -ne 0) { Exit $lastexitcode }
   }
 }
 
-nssm set buildkite-agent AppEnvironmentExtra BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=$Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB
+nssm set buildkite-agent AppEnvironmentExtra +BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB=$Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 nssm set buildkite-agent AppExit Default Restart

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -223,7 +223,6 @@ nssm set buildkite-agent AppStderr C:\buildkite-agent\buildkite-agent.log
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 nssm set buildkite-agent AppEnvironmentExtra :HOME=C:\buildkite-agent
-If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
 If ((![string]::IsNullOrEmpty($Env:BUILDKITE_ENV_FILE_URL)) -And (Test-Path -Path C:\buildkite-agent\env -PathType leaf)) {
   foreach ($var in Get-Content C:\buildkite-agent\env) {

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -9,8 +9,10 @@ aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --in
 if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will terminate
   Write-Output "terminate-instance: disabling buildkite-agent service"
   nssm stop buildkite-agent
-}
-else {
+} else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
-  Stop-Computer -ComputerName "localhost" -Force
+  if ($Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB -eq "true") {
+    Write-Output "terminate-instance: terminating instance anyway"
+    Stop-Computer -ComputerName "localhost" -Force
+  }
 }

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -12,7 +12,11 @@ if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will term
 } else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
   if ($Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB -eq "true") {
-    Write-Output "terminate-instance: terminating instance anyway"
-    Stop-Computer -ComputerName "localhost" -Force
+    Write-Output "terminate-instance: marking instance as unhealthy"
+    aws autoscaling set-instance-health `
+      --instance-id "$InstanceId" `
+      --region "$Region" `
+      --health-status Unhealthy `
+      --no-should-respect-grace-period
   }
 }

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -12,4 +12,5 @@ if ($lastexitcode -eq 0) { # If autoscaling request was successful, we will term
 }
 else {
   Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
+  Stop-Computer -ComputerName "localhost" -Force
 }

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -22,8 +22,7 @@ if ($lastexitcode -eq 0) {
     aws autoscaling set-instance-health `
       --instance-id "$InstanceId" `
       --region "$Region" `
-      --health-status Unhealthy `
-      --no-should-respect-grace-period
+      --health-status Unhealthy
   } else {
     Write-Output "terminate-instance: restarting agent..."
     nssm start buildkite-agent

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -699,6 +699,9 @@ Conditions:
     UseStackNameForInstanceName:
       !Equals [ !Ref InstanceName, "" ]
 
+    TerminateInstanceAfterJob:
+      !Equals [ !Ref BuildkiteTerminateInstanceAfterJob, "true" ]
+
 Mappings:
   ECRManagedPolicy:
     none      : { Policy: '' }
@@ -1092,7 +1095,10 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "" ] ] ] ]
-          InstanceInitiatedShutdownBehavior: "terminate"
+          InstanceInitiatedShutdownBehavior: !If
+            - TerminateInstanceAfterJob
+            - terminate
+            - stop
           MetadataOptions:
             HttpTokens: !Ref IMDSv2Tokens
             # Allow containers using a Docker network on the host to receive IDMSv2 responses

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1095,10 +1095,6 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "" ] ] ] ]
-          InstanceInitiatedShutdownBehavior: !If
-            - TerminateInstanceAfterJob
-            - terminate
-            - stop
           MetadataOptions:
             HttpTokens: !Ref IMDSv2Tokens
             # Allow containers using a Docker network on the host to receive IDMSv2 responses

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1092,6 +1092,7 @@ Resources:
           IamInstanceProfile:
             Arn: !GetAtt "IAMInstanceProfile.Arn"
           InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "" ] ] ] ]
+          InstanceInitiatedShutdownBehavior: "terminate"
           MetadataOptions:
             HttpTokens: !Ref IMDSv2Tokens
             # Allow containers using a Docker network on the host to receive IDMSv2 responses

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -699,9 +699,6 @@ Conditions:
     UseStackNameForInstanceName:
       !Equals [ !Ref InstanceName, "" ]
 
-    TerminateInstanceAfterJob:
-      !Equals [ !Ref BuildkiteTerminateInstanceAfterJob, "true" ]
-
 Mappings:
   ECRManagedPolicy:
     none      : { Policy: '' }


### PR DESCRIPTION
This is a different implementation of the same goal as #1225, but we found when testing that PR that the instances would NOT terminate on linux because the buildkite-agent user does not have permission to shutdown the instance. Rather than granting it this permisison, in this PR we mark the instance as unhealthy if
1. The idle period has expired and the agent has shutdown.
1. The call to the AWS API to terminate the instance and decrement the desired capacity fails.
1. `BuildkiteTerminateInstanceAfterJob` is enabled.

Closes: #1225