### PR TITLE
Mention docker 20.10.25 to 24.0.5 upgrade in v6.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bump docker-compose to v2.22.0 [#1234](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1234) (@jkburges)
 - Improve logging for startup scripts on linux [#1230](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1230) (@triarius)
 - Wrap quotes around AWS::StackName [#1238](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1238) (@n-tucker)
+- Docker upgraded from from 20.10.25 to 24.0.5 [Amazon Linux 2023 changelog](https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.2.20230920.html)
 
 ### Fixed
 - Fix rsyslog was missing from base AMI [#1240](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1240) (@peter-svensson)


### PR DESCRIPTION
This week I was debugging a docker performance regression in one of our pipelines, and for a while I wondered if the docker version was a problem.

It turned out not to be, but while investigating I discovered the recent 6.8.0 elastic stack release included a reasonably large docker upgrade from 20.10.25 to 24.0.5.

The 20.10 series started in late 2020, and the 24.0 series was released in May 2023. I expect most folks docker based pipelines will continue to work unmodified, but there might be edge cases from a 3+ year jump. Maybe this will save folks a bit of debugging time.

The v3.7.0 release also included a couple of less notable version bumps, but I'm not sure if they're worth including.

* containerd 1.6.19 to 1.7.2
* runc 1.1.5 to 1.1.7