### PR TITLE
Add docker builder prune to environment hook

### DIFF
--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -43,6 +43,7 @@ echo "Checking disk space"
 if ! /usr/local/bin/bk-check-disk-space.sh; then
   echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL:-4h}"
   docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL:-4h}"
+  docker builder prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL:-4h}"
 
   echo "Checking disk space again"
   if ! /usr/local/bin/bk-check-disk-space.sh; then


### PR DESCRIPTION
When the environment hook detects that there is not enough disk space on the agent it invokes `docker image prune`.

On our agents with 64 GiB disks we are finding that our agents are filling up too quickly and even when we set `DOCKER_PRUNE_UNTIL=30m` not enough us cleaned up.

The `packer/linux/conf/docker/scripts/docker-low-disk-gc` script also has similar logic, except in addition to `docker image prune` it runs `docker builder prune`.

On one of our agents that had started failing builds due to full disk and where the environment hook's disk clean up was not freeing up enough disk space, I manually ran the `docker builder prune` command with appropriate command line arguments and it freed up 20 GB of disk for us. So it seems that it would be beneficial to run this in the environment hook as well.