### PR TITLE
Enable optionally changing EC2 Instance Types used for AMI Creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ PACKER_WINDOWS_FILES = $(exec find packer/windows)
 
 AWS_REGION ?= us-east-1
 
-ARM64_INSTANCE_TYPE = m7g.xlarge
-AMD64_INSTANCE_TYPE = m7a.xlarge
-WIN64_INSTANCE_TYPE = m7i.xlarge
+ARM64_INSTANCE_TYPE ?= m7g.xlarge
+AMD64_INSTANCE_TYPE ?= m7a.xlarge
+WIN64_INSTANCE_TYPE ?= m7i.xlarge
 
 BUILDKITE_BUILD_NUMBER ?= none
 BUILDKITE_PIPELINE_DEFAULT_BRANCH ?= main


### PR DESCRIPTION
Not all EC2 Instance Types are available in each AWS Region, for example, in `eu-west-2` the `m7` EC2 Instance Types are not available - yet - so running the Makefile commands using the defaults will result in failing to launching the EC2 Instances for AMI Creation with the following error message:
```
Error launching source instance: Unsupported: The requested configuration is currently not supported. Please check the documentation for supported configurations.
```

Potential future usuablity improvement could be add some kind of check(s)?