### PR TITLE
Build fix-perms in Makefile

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,20 +2,10 @@ version: '3'
 
 services:
   fixperms-tests:
-    image: golang:latest
+    image: golang:1.21
     working_dir: /code
     environment:
       CGO_ENABLED: 0
     volumes:
       - ..:/code:ro
     command: go test -v ./...
-
-  fixperms-build:
-    image: golang:latest
-    working_dir: /code
-    environment:
-      CGO_ENABLED: 0
-    volumes:
-      - ..:/code
-      - /var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors
-    command: .buildkite/steps/build-fixperms.sh

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -22,18 +22,6 @@ steps:
           run: fixperms-tests
           config: .buildkite/docker-compose.yml
 
-  - id: "fixperms-build"
-    name: ":go: fixperms build"
-    agents:
-      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
-    artifact_paths: "build/fix-perms-*"
-    plugins:
-      - docker-compose#v2.1.0:
-          run: fixperms-build
-          config: .buildkite/docker-compose.yml
-      - artifacts#v1.9.0:
-          upload: "builds/fix-perms-*"
-
   - id: "deploy-service-role-stack"
     name: ":aws-iam: :cloudformation:"
     agents:
@@ -43,7 +31,6 @@ steps:
       - "fmt"
       - "lint"
       - "fixperms-tests"
-      - "fixperms-build"
 
   - id: "packer-windows-amd64"
     name: ":packer: :windows:"
@@ -56,7 +43,6 @@ steps:
       - "fmt"
       - "lint"
       - "fixperms-tests"
-      - "fixperms-build"
 
   - id: "launch-windows-amd64"
     name: ":cloudformation: :windows: AMD64 Launch"
@@ -101,7 +87,6 @@ steps:
       - "fmt"
       - "lint"
       - "fixperms-tests"
-      - "fixperms-build"
 
   - id: "launch-linux-amd64"
     name: ":cloudformation: :linux: AMD64 Launch"
@@ -145,7 +130,6 @@ steps:
       - "fmt"
       - "lint"
       - "fixperms-tests"
-      - "fixperms-build"
 
   - id: "launch-linux-arm64"
     name: ":cloudformation: :linux: ARM64 Launch"

--- a/.buildkite/steps/build-fixperms.sh
+++ b/.buildkite/steps/build-fixperms.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-for arch in amd64 arm64; do
-  GOOS=linux GOARCH="${arch}" go build -v -o "build/fix-perms-linux-${arch}" ./internal/fixperms
-done

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -17,11 +17,11 @@ fi
 mkdir -p "build/"
 
 # Build a hash of packer files and the agent versions
-packer_files_sha=$(find Makefile "packer/${os}" plugins/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
-internal_files_sha=$(find go.mod go.sum internal/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
+packer_files_sha=$(find Makefile "packer/${os}" plugins/ -type f -print0 | xargs -0 sha256sum | awk '{print $1}' | sort | sha256sum | awk '{print $1}')
+internal_files_sha=$(find go.mod go.sum internal/ -type f -print0 | xargs -0 sha256sum | awk '{print $1}' | sort | sha256sum | awk '{print $1}')
 stable_agent_sha=$(curl -Lfs "https://download.buildkite.com/agent/stable/latest/${agent_binary}.sha256")
 unstable_agent_sha=$(curl -Lfs "https://download.buildkite.com/agent/unstable/latest/${agent_binary}.sha256")
-packer_hash=$(echo "$packer_files_sha" "$internal_files_sha" "$arch" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
+packer_hash=$(echo "$packer_files_sha" "$internal_files_sha" "$arch" "$stable_agent_sha" "$unstable_agent_sha" | sha256sum | awk '{print $1}')
 
 echo "Packer image hash for ${os}/${arch} is ${packer_hash}"
 packer_file="packer-${packer_hash}-${os}-${arch}.output"

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -16,17 +16,12 @@ fi
 
 mkdir -p "build/"
 
-if [[ "$os" == "linux" ]]; then
-  buildkite-agent artifact download "build/fix-perms-linux-${arch}" ./build
-  mv "build/fix-perms-linux-${arch}" packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
-  chmod 755 packer/linux/conf/buildkite-agent/scripts/fix-buildkite-agent-builds-permissions
-fi
-
 # Build a hash of packer files and the agent versions
 packer_files_sha=$(find Makefile "packer/${os}" plugins/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
+internal_files_sha=$(find go.mod go.sum internal/ -type f -print0 | xargs -0 sha1sum | awk '{print $1}' | sort | sha1sum | awk '{print $1}')
 stable_agent_sha=$(curl -Lfs "https://download.buildkite.com/agent/stable/latest/${agent_binary}.sha256")
 unstable_agent_sha=$(curl -Lfs "https://download.buildkite.com/agent/unstable/latest/${agent_binary}.sha256")
-packer_hash=$(echo "$packer_files_sha" "$arch" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
+packer_hash=$(echo "$packer_files_sha" "$internal_files_sha" "$arch" "$stable_agent_sha" "$unstable_agent_sha" | sha1sum | awk '{print $1}')
 
 echo "Packer image hash for ${os}/${arch} is ${packer_hash}"
 packer_file="packer-${packer_hash}-${os}-${arch}.output"

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -81,6 +81,11 @@ build {
     source      = "../../plugins"
   }
 
+  provisioner "file" {
+    destination = "/tmp/build"
+    source      = "../../build"
+  }
+
   provisioner "shell" {
     script = "scripts/install-utils.sh"
   }

--- a/packer/linux/scripts/install-buildkite-utils.sh
+++ b/packer/linux/scripts/install-buildkite-utils.sh
@@ -11,6 +11,10 @@ echo "Installing bk elastic stack bin files..."
 sudo chmod +x /tmp/conf/bin/bk-*
 sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 
+echo "Installing fix-buildkite-agent-builds-permissions..."
+sudo chmod +x "/tmp/build/fix-perms-linux-${ARCH}"
+sudo mv "/tmp/build/fix-perms-linux-${ARCH}" /usr/bin/fix-buildkite-agent-builds-permissions
+
 S3_SECRETS_HELPER_VERSION=2.1.6
 echo "Downloading s3-secrets-helper ${S3_SECRETS_HELPER_VERSION}..."
 sudo curl -Lsf -o /usr/local/bin/s3secrets-helper \


### PR DESCRIPTION
In #1219 I overlooked the Makefile, which is used by both the pipeline (.buildkite/steps/packer.sh) and to build the stack without using the pipeline.
The result was that anyone just running `make clean && make packer` will be missing the new binary.

For now fix-perms is specific to the stack, so while one option is to split it into its own repo and generalise it and put a ribbon on it, the other is to make the Makefile responsible for building it, and using `docker` to run a container from the Makefile has precedent (hashicorp/packer).