### PR TITLE
Ensure tag builds have the tag

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -188,8 +188,6 @@ steps:
     command: .buildkite/steps/publish.sh
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
-    env:
-      BUILDKITE_GIT_FETCH_FLAGS: -v --prune --tags
     concurrency_group: "aws-stack-publish"
     concurrency: 1
     concurrency_method: eager

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -22,6 +22,7 @@ echo "--- :git: Checking and fetching git tags"
 if [[ -n "${BUILDKITE_TAG:-}" ]]; then
   git fetch -v --tags
   if ! git tag --list | grep -q "^${BUILDKITE_TAG}$"; then
+    echo "^^^ +++"
     echo "Tag ${BUILDKITE_TAG} does not exist"
     exit 1
   fi

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -17,8 +17,17 @@ echo "--- Downloading mappings.yml artifact"
 mkdir -p build/
 buildkite-agent artifact download build/mappings.yml build/
 
-echo "--- Fetching latest git tags"
-git fetch --tags
+echo "--- :git: Checking and fetching git tags"
+# if BUILDKITE_TAG is set, fetch the tags, and check that it's a valid tag
+if [[ -n "${BUILDKITE_TAG:-}" ]]; then
+  git fetch -v --tags
+  if ! git tag --list | grep -q "^${BUILDKITE_TAG}$"; then
+    echo "Tag ${BUILDKITE_TAG} does not exist"
+    exit 1
+  fi
+else
+  echo "Not a tag build, skipping tag check"
+fi
 
 echo "--- Building :cloudformation: CloudFormation templates"
 make build/aws-stack.yml

--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -8,15 +8,6 @@ s3_upload_templates() {
   aws s3 cp --content-type 'text/yaml' --acl public-read build/aws-stack.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.yml"
 }
 
-if [[ -z "${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}" ]]; then
-  echo "Must set an s3 bucket in BUILDKITE_AWS_STACK_TEMPLATE_BUCKET for publishing templates to"
-  exit 1
-fi
-
-echo "--- Downloading mappings.yml artifact"
-mkdir -p build/
-buildkite-agent artifact download build/mappings.yml build/
-
 echo "--- :git: Checking and fetching git tags"
 # if BUILDKITE_TAG is set, fetch the tags, and check that it's a valid tag
 if [[ -n "${BUILDKITE_TAG:-}" ]]; then
@@ -29,6 +20,17 @@ if [[ -n "${BUILDKITE_TAG:-}" ]]; then
 else
   echo "Not a tag build, skipping tag check"
 fi
+
+echo "--- :aws: Checking template bucket is set"
+if [[ -z "${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}" ]]; then
+  echo "^^^ +++"
+  echo "Must set an s3 bucket in BUILDKITE_AWS_STACK_TEMPLATE_BUCKET for publishing templates to"
+  exit 1
+fi
+
+echo "--- Downloading mappings.yml artifact"
+mkdir -p build/
+buildkite-agent artifact download build/mappings.yml build/
 
 echo "--- Building :cloudformation: CloudFormation templates"
 make build/aws-stack.yml


### PR DESCRIPTION
[This](https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/4208#018b5fc8-d1a6-47ea-9c32-c6157f3aaba8) build was supposed to publish a "latest" template, but it did not because the tag did not exist in the local git repo.
I don't know exactly why it did not work (git mirrors is looking like a likely culprit), but we should error the tag build if the tag is not present.