### PR TITLE
fix: allow hyphens in all `InstanceTypes` values

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -292,7 +292,7 @@ Parameters:
     Type: String
     Default: t3.large
     MinLength: 1
-    AllowedPattern: "^[\\w-\\.]+(,[\\w\\.]*){0,3}$"
+    AllowedPattern: "^[\\w-\\.]+(,[\\w-\\.]*){0,3}$"
     ConstraintDescription: "must contain 1-4 instance types separated by commas. No space before/after the comma."
 
   MaxSize:


### PR DESCRIPTION
The current `InstanceTypes` AllowedPattern allows hyphens for the first instance type listed, but not for the following ones. This is a tiny tweak to allow hyphens for all instance types listed.

Example failing case: `m7i.xlarge,m7i-flex.xlarge` will fail because the hyphen isn't the first type listed. The error message will be: `ValidationError: Parameter InstanceTypes failed to satisfy constraint: must contain 1-4 instance types separated by commas. No space before/after the comma.`