### PR TITLE
Add new values for ECRAccessPolicy that include `ecr:BatchImportUpstreamImage` 

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -429,7 +429,7 @@ Parameters:
 
   ECRAccessPolicy:
     Type: String
-    Description: ECR access policy to give instances. The +pullthrough variants add `ecr:BatchImportUpstreamImage` which allows ECR pull through cache to work transparently.
+    Description: ECR access policy to give instances. The `+pullthrough` variants add `ecr:CreateRepository` and `ecr:BatchImportUpstreamImage` which allows ECR pull through cache to work transparently.
     AllowedValues:
       - none
       - readonly
@@ -876,6 +876,7 @@ Resources:
               Statement:
                 - Effect: Allow
                   Action:
+                    - ecr:CreateRepository
                     - ecr:BatchImportUpstreamImage
           - !Ref 'AWS::NoValue'
         - !If

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -718,10 +718,12 @@ Conditions:
 
 Mappings:
   ECRManagedPolicy:
-    none      : { Policy: '' }
-    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
-    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
-    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
+    none                  : { Policy: '' }
+    readonly              : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    readonly+pullthrough  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    poweruser             : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    poweruser+pullthrough : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    full                  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
 
   # Generated from Makefile via build/mappings.yml
   AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId }

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -369,7 +369,7 @@ Parameters:
     Default: ""
 
   RootVolumeType:
-    Description: Type of root volume to use
+    Description: Type of root volume to use. If you are specifying `io1` or `io2`, you will most likely want to specify `RootVolumeIOPS` as well.
     Type: String
     Default: "gp3"
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -429,13 +429,13 @@ Parameters:
 
   ECRAccessPolicy:
     Type: String
-    Description: ECR access policy to give instances. The `+pullthrough` variants add `ecr:CreateRepository` and `ecr:BatchImportUpstreamImage` which allows ECR pull through cache to work transparently.
+    Description: ECR access policy to give instances. The `-pullthrough` variants add `ecr:CreateRepository` and `ecr:BatchImportUpstreamImage` which allows ECR pull through cache to work transparently.
     AllowedValues:
       - none
       - readonly
-      - readonly+pullthrough
+      - readonly-pullthrough
       - poweruser
-      - poweruser+pullthrough
+      - poweruser-pullthrough
       - full
     Default: "none"
 
@@ -644,8 +644,8 @@ Conditions:
 
     AddECRPullThrough:
       !Or
-        - !Equals [ !Ref ECRAccessPolicy, "readonly+pullthrough" ]
-        - !Equals [ !Ref ECRAccessPolicy, "poweruser+pullthrough" ]
+        - !Equals [ !Ref ECRAccessPolicy, "readonly-pullthrough" ]
+        - !Equals [ !Ref ECRAccessPolicy, "poweruser-pullthrough" ]
 
     UseCustomerManagedParameterPath:
       !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
@@ -720,9 +720,9 @@ Mappings:
   ECRManagedPolicy:
     none                  : { Policy: '' }
     readonly              : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
-    readonly+pullthrough  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    readonly-pullthrough  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
     poweruser             : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
-    poweruser+pullthrough : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    poweruser-pullthrough : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
     full                  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
 
   # Generated from Makefile via build/mappings.yml

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -429,11 +429,13 @@ Parameters:
 
   ECRAccessPolicy:
     Type: String
-    Description: ECR access policy to give container instances
+    Description: ECR access policy to give instances. The +pullthrough variants add `ecr:BatchImportUpstreamImage` which allows ECR pull through cache to work transparently.
     AllowedValues:
       - none
       - readonly
+      - readonly+pullthrough
       - poweruser
+      - poweruser+pullthrough
       - full
     Default: "none"
 
@@ -639,6 +641,11 @@ Conditions:
 
     UseECR:
       !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
+
+    AddECRPullThrough:
+      !Or
+        - !Equals [ !Ref ECRAccessPolicy, "readonly+pullthrough" ]
+        - !Equals [ !Ref ECRAccessPolicy, "poweruser+pullthrough" ]
 
     UseCustomerManagedParameterPath:
       !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
@@ -861,6 +868,16 @@ Resources:
                  - !Ref 'AWS::NoValue'
           - !Ref 'AWS::NoValue'
       Policies:
+        - !If
+          - AddECRPullThrough
+          - PolicyName: ECRPullThrough
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - ecr:BatchImportUpstreamImage
+          - !Ref 'AWS::NoValue'
         - !If
           - UseCustomerManagedKeyForParameterStore
           - PolicyName: DecryptAgentToken


### PR DESCRIPTION
This IAM permission is necessary to use an ECR pull through cache. Technically, it is not `readonly`, as images will be written to the pull though cache on cache misses. Surprisingly, it is not in `poweruser` either. But we think customers will want to give Stacks the ability to use pull through caches without giving full permissions.

See https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html for more details.