### PR TITLE
Add MountTmpfsAtTmp parameter

### DIFF
--- a/packer/linux/conf/bin/bk-mount-instance-storage.sh
+++ b/packer/linux/conf/bin/bk-mount-instance-storage.sh
@@ -24,6 +24,15 @@ exec > >(tee -a /var/log/elastic-stack.log | logger -t user-data -s 2>/dev/conso
 
 echo "Starting ${BASH_SOURCE[0]}..."
 
+if [[ "${BUILDKITE_MOUNT_TMPFS_AT_TMP:-true}" != "true" ]]; then
+  echo "Disabling automatic mount of tmpfs at /tmp"
+
+  # "It is possible to disable the automatic mounting [...]
+  # You may disable them simply by masking them:"
+  # -- https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/
+  systemctl mask --now tmp.mount
+fi
+
 # Mount instance storage if we can
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html
 
@@ -98,6 +107,6 @@ if [[ ! -f /etc/fstab.backup ]]; then
   echo Appened to /etc/fstab:
   cat /etc/fstab
 else
-  echo /etc/fstab.backup already exists. Not mofidying /etc/fstab:
+  echo /etc/fstab.backup already exists. Not modifying /etc/fstab:
   cat /etc/fstab
 fi

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -67,6 +67,7 @@ Metadata:
         - InstanceOperatingSystem
         - InstanceTypes
         - EnableInstanceStorage
+        - MountTmpfsAtTmp
         - AgentsPerInstance
         - KeyName
         - SecretsBucket
@@ -500,6 +501,14 @@ Parameters:
       - "true"
       - "false"
     Default: "false"
+
+  MountTmpfsAtTmp:
+    Type: String
+    Description: Controls the filesystem mounted at /tmp. By default, /tmp is a tmpfs (memory-backed filesystem). Disabling this causes /tmp to be stored in the root filesystem.
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "true"
 
   EnableCostAllocationTags:
     Type: String
@@ -1228,6 +1237,7 @@ Resources:
                   Content-Type: text/x-shellscript; charset="us-ascii"
                   #!/bin/bash -v
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                  BUILDKITE_MOUNT_TMPFS_AT_TMP="${MountTmpfsAtTmp}" \
                     /usr/local/bin/bk-mount-instance-storage.sh
                   --==BOUNDARY==
                   Content-Type: text/x-shellscript; charset="us-ascii"


### PR DESCRIPTION
Older versions of the stack did not mount /tmp in a tmpfs (Amazon Linux 2 behaviour). 
Newer versions do, by default (Amazon Linux 2023 behaviour). 
Some people would like the older behaviour.