### PR TITLE
Bump agent version to v3.62.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,8 @@ AGENT_VERSION ?= $(shell curl -Lfs "https://buildkite.com/agent/releases/latest?
 
 SED ?= sed
 ifeq ($(shell uname), Darwin)
+	# Use GNU sed, not MacOS sed
+	# Install with: brew install gsed
 	SED = gsed
 endif
 

--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -15,7 +15,7 @@ sudo mkdir -p /var/lib/buildkite-agent/.aws
 sudo cp /tmp/conf/aws/config /var/lib/buildkite-agent/.aws/config
 sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
 
-AGENT_VERSION=3.61.0
+AGENT_VERSION=3.62.0
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
   "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.61.0"
+$AGENT_VERSION = "3.62.0"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
I also added a comment to the Makefile about how to get `gsed` on mac because I had to look it up.

Agent release: https://github.com/buildkite/agent/releases/tag/v3.62.0