### PR TITLE
Fix path for cfn-env on windows elastic stack

### DIFF
--- a/packer/windows/conf/buildkite-agent/hooks/environment
+++ b/packer/windows/conf/buildkite-agent/hooks/environment
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 echo "~~~ :earth_asia: Setting up environment variables"
 # shellcheck source=/dev/null
-source ~/cfn-env
+source /c/buildkite-agent/cfn-env
 
 # a clean docker config for each job, for improved isolation
 BUILDKITE_DOCKER_CONFIG_TEMP_DIRECTORY=$(mktemp -d)


### PR DESCRIPTION
`~` can resolve to `/c/Windows/system32/config/systemprofile` when we start the agent. We make sure it's in `/c/buildkite-agent/cfn-env` when we build the AMI, so let's reference it as being there.

I ran into this issue when doing some manual iteration on a Windows elastic stack. It should not be an issue outside of this, as there are integration tests that run jobs on Windows Elastic stacks.