### PR TITLE
Linux env hook was too eager, breaking ECR retries

### DIFF
--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -95,8 +95,13 @@ if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" 
     export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
   fi
 
+  # Do not propagate the error trap into the ECR plugin's environment hook, because its 'retry' function breaks when we do that.
+  set +E
+
   # shellcheck source=/dev/null
   source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/environment
+
+  set -E
 fi
 
 if [[ "${DOCKER_USERNS_REMAP:-false}" == "false" ]]; then


### PR DESCRIPTION
When we introduced the `environment` hook error trap in #1179, we set it to propagate into all `source`-d plugin environment hooks. Unfortunately, this breaks the `retry` function in the ECR plugin's environment hook (which runs a command and then checks the exit code to determine whether to retry) by interrupting execution before the exit code can be checked.

Repro: https://github.com/buildkite-plugins/ecr-buildkite-plugin/pull/101

Fix by temporarily unsetting `-E`, stopping propagation of the trap command into the plugin environment hook.

- [ ] Before merging, add thank-you note to @-zzak and @-matthewd, who helped to diagnose and suggested the fix.