### PR TITLE
Bump Docker buildx to v0.13.0 and Docker Compose to v2.24.6

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_COMPOSE_V2_VERSION=2.24.4
+DOCKER_COMPOSE_V2_VERSION=2.24.6
 DOCKER_BUILDX_VERSION=0.13.0
 MACHINE=$(uname -m)
 

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DOCKER_COMPOSE_V2_VERSION=2.24.4
-DOCKER_BUILDX_VERSION=0.12.1
+DOCKER_BUILDX_VERSION=0.13.0
 MACHINE=$(uname -m)
 
 echo Installing docker...


### PR DESCRIPTION
### Context

[Docker buildx](https://github.com/docker/buildx) v0.13 has been released!

### Change

Upgrade buildx from 0.12.1 to 0.13.0

### Considerations

See the [buildx release notes](https://github.com/docker/buildx/releases) for details of the changes:
- [v0.13.0 release notes](https://github.com/docker/buildx/releases/tag/v0.13.0)