### PR TITLE
Restore "Packer Builder" tag for Packer instances

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -57,6 +57,10 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   source_ami      = data.amazon-ami.al2023.id
   ssh_username    = "ec2-user"
 
+  run_tags = {
+    Name = "Packer Builder" // marks resources for deletion in cleanup.sh
+  }
+
   tags = {
     Name          = "elastic-ci-stack-linux-${var.arch}"
     OSVersion     = "Amazon Linux 2023"


### PR DESCRIPTION
The Amazon packer builder plugin [removed](https://github.com/hashicorp/packer-plugin-amazon/pull/191) this default tag in v1.0.9. We don't pin or lock a specific version of the plugin so I'm not sure when we began using it, but on [at least one occasion](https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/4323#018d8289-2be8-4e2c-b489-9cbbaa25cc32/135-228), a CI build was killed before Packer finished running and terminated the instance.

Because it was not tagged, it was also not terminated up by `cleanup.sh` which would normally occur after the next successful build.

This PR restores the default tag so it can be cleaned up.