### PR TITLE
Only allow SSH to reach Packer instance from Elastic Stack

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -49,13 +49,14 @@ data "amazon-ami" "al2023" {
 }
 
 source "amazon-ebs" "elastic-ci-stack-ami" {
-  ami_description = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
-  ami_groups      = ["all"]
-  ami_name        = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
-  instance_type   = var.instance_type
-  region          = var.region
-  source_ami      = data.amazon-ami.al2023.id
-  ssh_username    = "ec2-user"
+  ami_description                           = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
+  ami_groups                                = ["all"]
+  ami_name                                  = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
+  instance_type                             = var.instance_type
+  region                                    = var.region
+  source_ami                                = data.amazon-ami.al2023.id
+  ssh_username                              = "ec2-user"
+  temporary_security_group_source_public_ip = true
 
   tags = {
     Name          = "elastic-ci-stack-linux-${var.arch}"


### PR DESCRIPTION
GuardDuty is complaining to us about Packer instances being probed on their SSH port, which by default is open to the world.

Packer can be configured to allow connections only from a particular CIDR, however elastic-stack runs in the `main` VPC on `10.16.0.0/16`, whereas Packer runs in the default VPC on `172.31.0.0/16`, and there is no routing configured between them.

Apparently they communicate over the public internet, so this seems the simplest method to block public SSH.

There's a few other options to consider, I'm happy to go down one of these paths instead:

* Launch the Packer instances in the same VPC as the Elastic Stack by hard coding `vpc_id` (brittle if you update the stack)
* Launch the Packer instances in the same VPC as the Elastic Stack by setting `vpc_filter` (we currently have 2 identically tagged VPCs, leftover from a previous stack version perhaps?)
* Peer the Packer VPC and Elastic Stack VPCs so they can communicate privately