### PR TITLE
Test/verify OS PR to Elastic Stack - clearing SSH keys

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -102,7 +102,7 @@ steps:
     name: ":cloudformation: :linux: AMD64 Test"
     command:
       - git --version
-      - goss validate --format documentation
+      - sudo goss validate --format documentation
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-linux-amd64-${BUILDKITE_BUILD_NUMBER}"
@@ -145,7 +145,7 @@ steps:
     name: ":cloudformation: :linux: ARM64 Test"
     command:
       - git --version
-      - goss validate --format documentation
+      - sudo goss validate --format documentation
     timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-linux-arm64-${BUILDKITE_BUILD_NUMBER}"

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -100,6 +100,10 @@ cat <<EOF >config.json
   {
     "ParameterKey": "EnableInstanceStorage",
     "ParameterValue": "${enable_instance_storage:-false}"
+  },
+  {
+    "ParameterKey": "BuildkiteAdditionalSudoPermissions",
+    "ParameterValue": "/usr/local/bin/goss"
   }
 ]
 EOF

--- a/goss.yaml
+++ b/goss.yaml
@@ -14,6 +14,14 @@ file:
   /etc/systemd/system/refresh_authorized_keys.timer:
     exists: true
 
+  /home/ec2-user/.ssh/authorized_keys:
+    exists: true
+    contains: ["!packer"]
+
+  /root/.ssh/authorized_keys:
+    exists: true
+    contains: ["!packer"]
+
   /var/lib/buildkite-agent/builds:
     filetype: directory
     exists: true

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -111,8 +111,4 @@ build {
   provisioner "shell" {
     script = "scripts/install-buildkite-utils.sh"
   }
-
-  provisioner "shell" {
-    inline = ["rm /home/ec2-user/.ssh/authorized_keys"]
-  }
 }

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -56,6 +56,7 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   region                                    = var.region
   source_ami                                = data.amazon-ami.al2023.id
   ssh_username                              = "ec2-user"
+  ssh_clear_authorized_keys = true
   temporary_security_group_source_public_ip = true
 
   run_tags = {


### PR DESCRIPTION
This PR is verifying the changes / fix for:
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1312 -> https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1311 raised by [Gezi-lzq](https://github.com/Gezi-lzq)

@patrobinson and I have:

- [x] Reproduced the issue / bug (via manual test)
- [x] Implemented the fix as suggested by the customer
- [x] Extend tests 

A big thank you to [Gezi-lzq](https://github.com/Gezi-lzq) for raising and your contribution! We really appreciate it :) was easier to open up this branch to get it merged. 

> ## Describe the bug
> The SSH key generated by Packer for provisioning is not being completely removed from the authorized_keys file. This issue was believed to have been addressed in Issue #544 but persists due to the key's presence in the root account's authorized_keys, not just the ec2-user. This incomplete removal contravenes the security policies intended for AMIs.
> 
> ## Steps To Reproduce
> To observe the behavior indicative of this issue, one can follow these steps:
> 
> ## Use Packer to provision an AMI.
> Access the provisioned instance.
> Navigate to the ~/.ssh/authorized_keys file for both ec2-user and root.
> Notice the Packer-generated SSH key remains in the root's authorized_keys.
> 
> ## Expected behavior
> The expected behavior was that all Packer-generated SSH keys would be removed from all authorized_keys files (including both ec2-user and root accounts) upon the completion of the provisioning process, leaving no residual keys behind.
> 
> ## Actual behaviour
> The actual behavior observed was that while the Packer-generated SSH key was removed from the ec2-user's authorized_keys file, it remained in the root's authorized_keys file, posing a potential security risk.
> 
> ## Solution Approach
> To effectively address this issue, it is recommended to leverage the ssh_clear_authorized_keys feature, enabling Packer to automatically remove its temporary SSH key.
> 
> Reference: https://developer.hashicorp.com/packer/docs/communicators/ssh
> > [ssh_clear_authorized_keys](https://developer.hashicorp.com/packer/docs/communicators/ssh#ssh_clear_authorized_keys) (bool) - If true, Packer will attempt to remove its temporary key from ~/.ssh/authorized_keys and /root/.ssh/authorized_keys. This is a mostly cosmetic option, since Packer will delete the temporary private key from the host system regardless of whether this is set to true (unless the user has set the -debug flag). Defaults to "false"; currently only works on guests with sed installed.
> 
> （As a newcomer to open source, I found the previous issue while searching for a Packer solution, realizing the fix might be incorrect. This prompted me to submit this issue for reassessment.）