### PR TITLE
Bump Docker buildx to v0.14.0 and Docker Compose to v2.27.0

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DOCKER_COMPOSE_V2_VERSION=2.24.6
-DOCKER_BUILDX_VERSION=0.13.0
+DOCKER_BUILDX_VERSION=0.14.0
 MACHINE=$(uname -m)
 
 echo Installing docker...

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_COMPOSE_V2_VERSION=2.24.6
+DOCKER_COMPOSE_V2_VERSION=2.27.0
 DOCKER_BUILDX_VERSION=0.14.0
 MACHINE=$(uname -m)
 


### PR DESCRIPTION
### Context

[Docker buildx](https://github.com/docker/buildx) v0.14.0 has been released!

### Change

Upgrade buildx from 0.13.0 to 0.14.0

### Considerations

See the [buildx release notes](https://github.com/docker/buildx/releases) for details of the changes:
- [v0.14.0 release notes](https://github.com/docker/buildx/releases/tag/v0.14.0)
- [v0.13.1 release notes](https://github.com/docker/buildx/releases/tag/v0.13.1)