### PR TITLE
Fix windows agent not restarting

### DIFF
--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -5,9 +5,6 @@ $Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-m
 $InstanceId = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
 $Region = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/placement/region).content
 
-Write-Output "terminate-instance: disconnecting agent..."
-nssm stop buildkite-agent
-
 Write-Output "terminate-instance: requesting instance termination..."
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity" 2> $null
 

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -1,3 +1,5 @@
+Start-Transcript -path C:\buildkite-agent\terminate-instance.log -append
+
 $Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '60'} http://169.254.169.254/latest/api/token).content
 
 $InstanceId = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
@@ -28,3 +30,5 @@ if ($lastexitcode -eq 0) {
     nssm start buildkite-agent
   }
 }
+
+Stop-Transcript

--- a/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
+++ b/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1
@@ -5,7 +5,7 @@ $Token = (Invoke-WebRequest -UseBasicParsing -Method Put -Headers @{'X-aws-ec2-m
 $InstanceId = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/instance-id).content
 $Region = (Invoke-WebRequest -UseBasicParsing -Headers @{'X-aws-ec2-metadata-token' = $Token} http://169.254.169.254/latest/meta-data/placement/region).content
 
-Write-Output "terminate-instance: requesting instance termination..."
+Write-Output "$(Get-Date) terminate-instance: requesting instance termination..."
 aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --instance-id "$InstanceId" "--should-decrement-desired-capacity" 2> $null
 
 # If autoscaling request was successful, we will terminate the instance, otherwise, if
@@ -13,17 +13,17 @@ aws autoscaling terminate-instance-in-auto-scaling-group --region "$Region" --in
 # so that the ASG will terminate it despite scale-in protection. Otherwise, we should not
 # terminate the instance, so we need to retart the agent.
 if ($lastexitcode -eq 0) {
-  Write-Output "terminate-instance: terminating instance..."
+  Write-Output "$(Get-Date) terminate-instance: terminating instance..."
 } else {
-  Write-Output "terminate-instance: ASG could not decrement (we're already at minSize)"
+  Write-Output "$(Get-Date) terminate-instance: ASG could not decrement (we're already at minSize)"
   if ($Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB -eq "true") {
-    Write-Output "terminate-instance: marking instance as unhealthy"
+    Write-Output "$(Get-Date) terminate-instance: marking instance as unhealthy"
     aws autoscaling set-instance-health `
       --instance-id "$InstanceId" `
       --region "$Region" `
       --health-status Unhealthy
   } else {
-    Write-Output "terminate-instance: restarting agent..."
+    Write-Output "$(Get-Date) terminate-instance: restarting agent..."
     nssm start buildkite-agent
   }
 }


### PR DESCRIPTION
## Description

Steps to reproduce:
- Create a windows stack
  - Set`ScaleInIdlePeriod` to some number greater than 0 (I used 6 to speed up the feedback)
  - Set `TerminateInstanceAfterJob` to false
  - Set the MinSize to 1 (this step is necessary to ensure a call to `terminate-instance-in-auto-scaling-group` fails)
  - Set the MaxSize to 1 (again prevent terminate instance succeeding)
  - Ensure no jobs get assigned to the agent

Observed behaviour: After the ScaleInIdlePeriod the EC2 instance is running but the buildkite-agent is in the `SERVICE_STOPPED` state.

Expected behaviour: the EC2 instance is running and the buildkite-agent is in `SERVICE_STARTED` state.

## Analysis

This bug was likely introduced in https://github.com/buildkite/elastic-ci-stack-for-aws/commit/c3ebaa5c45995471e3035838e1ecfb68be493b1a

First it's important to understand how the service is configured in windows. We configure the default behaviour on exit to [Restart](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/packer/windows/conf/bin/bk-install-elastic-stack.ps1#L242) with a 10s delay.
We also configure the [terminate-instance script](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/packer/windows/conf/buildkite-agent/scripts/terminate-instance.ps1) to run once the service stops.

Here's the sequence of events I've pieced together based on log outputs, the [nssm source code](https://github.com/kirillkovalenko/nssm/blob/9b377191952f38a47b27d8d2a132e1e773967401/service.cpp) and [Windows documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-controlservice)

- The agent exits code 0 once the idle timeout is reached
- The terminate-instance script is started asynchronously
- The service enters the SERVICE_PENDING
- The terminate-instance script sends a STOP signal to the service but it's blocked by the throttled restart 
- After 10 seconds the throttled restart expires
- The service enters the SERVICE_START_PENDING state
- The STOP signal returns `buildkite-agent: Unexpected status SERVICE_START_PENDING in response to STOP control.` but queues the stop command.
- The `terminate-instance-in-auto-scaling-group` API call fails because the ASG is already at it's MinSize
- The terminate-instance script sends a START signal, but this fails with `START: An instance of the service is already running.`
- The service processes the stop command and the agent stops

## Changes

Don't attempt to stop the agent before terminating the instance, since it is asynchronous it doesn't complete before the start command is issued.
Because of the restart delay it's unlikely to start and pick up a job before the ASG can scale it down, so the stop is not necessary.

