### PR TITLE
Bump Docker buildx to v0.15.0

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DOCKER_COMPOSE_V2_VERSION=2.27.0
-DOCKER_BUILDX_VERSION=0.14.0
+DOCKER_BUILDX_VERSION=0.15.0
 MACHINE=$(uname -m)
 
 echo Installing docker...


### PR DESCRIPTION
This release includes a fix for this buildkit caching issue: https://github.com/moby/buildkit/issues/2274