### PR TITLE
Create dependabot.yml, update some Go things

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   fixperms-tests:
-    image: golang:1.21
+    image: golang:1.22
     working_dir: /code
     environment:
       CGO_ENABLED: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PACKER_VERSION ?= 1.9.4
 PACKER_LINUX_FILES = $(exec find packer/linux)
 PACKER_WINDOWS_FILES = $(exec find packer/windows)
 
-GO_VERSION ?= 1.21
+GO_VERSION ?= 1.22
 
 FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/buildkite/elastic-ci-stack-for-aws/v6
 go 1.22
 
 require (
-	github.com/google/go-cmp v0.5.9
-	golang.org/x/sys v0.12.0
+	github.com/google/go-cmp v0.6.0
+	golang.org/x/sys v0.21.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/elastic-ci-stack-for-aws/v6
 
-go 1.20
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
+golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
The go.mod file is for the internal fix-perms tool, which has a very narrow focus and very few dependencies, but strictly speaking it does have dependencies that might need updating from time to time.