### PR TITLE
Avoid chowning files with expected ownership

### DIFF
--- a/internal/fixperms/fdfs/fdfs.go
+++ b/internal/fixperms/fdfs/fdfs.go
@@ -114,8 +114,8 @@ func (s *FS) RecursiveChown(uid, gid int) error {
 		if !d.IsDir() {
 			// Skip lchown if the uid and gid already match. This avoids updating
 			// the ctime of files unnecessarily.
-			var stat *unix.Stat_t
-			if stat, err = s.Stat(d.Name()); err != nil {
+			stat, err := s.Stat(d.Name())
+			if err != nil {
 				return err
 			}
 			if int(stat.Uid) == uid && int(stat.Gid) == gid {

--- a/internal/fixperms/fdfs/fdfs.go
+++ b/internal/fixperms/fdfs/fdfs.go
@@ -57,6 +57,16 @@ func (s *FS) Lchown(path string, uid, gid int) error {
 	return nil
 }
 
+// Stat wraps fstatat(2) (with AT_SYMLINK_NOFOLLOW).
+func (s *FS) Stat(path string) (*unix.Stat_t, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstatat(int(s.file.Fd()), path, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return nil, fmt.Errorf("fstatat(%d, %q): %w", s.file.Fd(), path, err)
+	}
+
+	return &stat, nil
+}
+
 // Sub wraps openat2(2) (with O_RDONLY+O_DIRECTORY+O_NOFOLLOW+O_CLOEXEC), and
 // returns an FS.
 func (s *FS) Sub(dir string) (*FS, error) {
@@ -102,6 +112,16 @@ func (s *FS) RecursiveChown(uid, gid int) error {
 	}
 	for _, d := range ds {
 		if !d.IsDir() {
+			// Skip lchown if the uid and gid already match. This avoids updating
+			// the ctime of files unnecessarily.
+			var stat *unix.Stat_t
+			if stat, err = s.Stat(d.Name()); err != nil {
+				return err
+			}
+			if int(stat.Uid) == uid && int(stat.Gid) == gid {
+				continue
+			}
+
 			if err := s.Lchown(d.Name(), uid, gid); err != nil {
 				return err
 			}


### PR DESCRIPTION
Calling fchownat on a file updates the file's ctime (metadata update time), even if uid and gid don't change.

Git uses ctime (along with other metadata) to determine if checked out files have been modified. If the ctime has changed, it rewrites the contents of the file during checkout.

This makes git checkouts in already cloned repos slower than they need to be:
```
# Checking out a commit
[buildkite-agent@ip-10-0-1-159 linux]$ time git checkout -f 626737a5791b
HEAD is now at 626737a5791b Merge tag 'pinctrl-v6.10-2' of git://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-pinctrl

real    0m0.255s
user    0m0.130s
sys     0m0.235s

# Run fix permissions
[buildkite-agent@ip-10-0-1-159 linux]$ /usr/bin/fix-buildkite-agent-builds-permissions buildkite-rian-i-0868df7f3b3f2c10d-1 rians-test-org linux

# Checkout the same commit
[buildkite-agent@ip-10-0-1-159 linux]$ time git checkout -f 626737a5791b
Updating files: 100% (84961/84961), done.
HEAD is now at 626737a5791b Merge tag 'pinctrl-v6.10-2' of git://git.kernel.org/pub/scm/linux/kernel/git/linusw/linux-pinctrl

real    0m14.180s
user    0m6.461s
sys     0m4.178s
```

This PR teaches fixperms to check the current uid/gid and skip calling chown if nothing will change.