### PR TITLE
First pass at adding test-splitter to the elastic-ci linux stack.

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -139,6 +139,9 @@ command:
   make --version:
     exit-status: 0
 
+  test-splitter --version:
+    exit-status: 0
+
   wget --version:
     exit-status: 0
 

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -109,6 +109,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/install-buildkite-test-splitter.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/install-buildkite-utils.sh"
   }
 }

--- a/packer/linux/scripts/install-buildkite-test-splitter.sh
+++ b/packer/linux/scripts/install-buildkite-test-splitter.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case $(uname -m) in
+x86_64) ARCH=amd64 ;;
+aarch64) ARCH=arm64 ;;
+*) ARCH=unknown ;;
+esac
+
+TEST_SPLITTER_VERSION=0.7.2
+echo "Downloading test-splitter v${TEST_SPLITTER_VERSION}..."
+sudo curl -Lsf -o /usr/bin/test-splitter \
+  "https://github.com/buildkite/test-splitter/releases/download/v0.7.2/test-splitter-linux-${ARCH}"
+sudo chmod +x /usr/bin/test-splitter
+test-splitter --version


### PR DESCRIPTION
We're trying to make it as easy to get started with using the test splitter client as possible.

This PR adds the current release (v0.7.2) to the packer build for linux (we're not currently building a windows version).