### PR TITLE
Bump Agent and Scaler

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -15,7 +15,7 @@ sudo mkdir -p /var/lib/buildkite-agent/.aws
 sudo cp /tmp/conf/aws/config /var/lib/buildkite-agent/.aws/config
 sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
 
-AGENT_VERSION=3.75.0
+AGENT_VERSION=3.75.1
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
   "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.75.0"
+$AGENT_VERSION = "3.75.1"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -186,7 +186,7 @@ Parameters:
   BuildkiteAgentScalerVersion:
     Description: Version of the buildkite-agent-scaler to use
     Type: String
-    Default: "1.7.0"
+    Default: "1.8.0"
 
   LogRetentionDays:
     Type: Number


### PR DESCRIPTION
- Bump agent version to [v3.75.1](https://github.com/buildkite/agent/releases/tag/v3.75.1)
- Bump scaler default version to [v1.8.0](https://github.com/buildkite/buildkite-agent-scaler/releases/tag/v1.8.0)