### PR TITLE
Bump Test Splitter version to v0.8.0

### DIFF
--- a/packer/linux/scripts/install-buildkite-test-splitter.sh
+++ b/packer/linux/scripts/install-buildkite-test-splitter.sh
@@ -7,9 +7,9 @@ aarch64) ARCH=arm64 ;;
 *) ARCH=unknown ;;
 esac
 
-TEST_SPLITTER_VERSION=0.7.3
+TEST_SPLITTER_VERSION=0.8.0
 echo "Downloading test-splitter v${TEST_SPLITTER_VERSION}..."
 sudo curl -Lsf -o /usr/bin/test-splitter \
-  "https://github.com/buildkite/test-splitter/releases/download/v${TEST_SPLITTER_VERSION}/test-splitter-linux-${ARCH}"
+  "https://github.com/buildkite/test-splitter/releases/download/v${TEST_SPLITTER_VERSION}/test-splitter_${TEST_SPLITTER_VERSION}_linux_${ARCH}"
 sudo chmod +x /usr/bin/test-splitter
 test-splitter --version


### PR DESCRIPTION
Bump Test Splitter to v0.8.0

https://github.com/buildkite/test-splitter/releases/download/v0.8.0/test-splitter_0.8.0_linux_amd64
https://github.com/buildkite/test-splitter/releases/download/v0.8.0/test-splitter_0.8.0_linux_arm64