### PR TITLE
docs: update RootVolumeIops to include gp3

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -386,7 +386,7 @@ Parameters:
     Default: 125
 
   RootVolumeIops:
-    Description: If the `RootVolumeType` is io1 or io2, the number of IOPS to provision for the root volume
+    Description: If the `RootVolumeType` is gp3, io1, or io2, the number of IOPS to provision for the root volume
     Type: Number
     Default: 1000
 


### PR DESCRIPTION
RootVolumeIops became configurable for gp3 in 6.14.0 - https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1283 this updates the cfn stack description to match

I also noticed that `RootVolumeIops` and `RootVolumeThroughput` are not mentioned at all on the website: https://buildkite.com/docs/agent/v3/elastic-ci-aws/parameters - but I don't think that page is directly controlled from this repo