### PR TITLE
Add signing verification behaviour and fix windows config option

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -292,6 +292,7 @@ disconnect-after-job=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
 tracing-backend=${BUILDKITE_AGENT_TRACING_BACKEND}
 cancel-grace-period=${BUILDKITE_AGENT_CANCEL_GRACE_PERIOD}
 signing-aws-kms-key=${BUILDKITE_AGENT_SIGNING_KMS_KEY}
+verification-failure-behavior=${BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR}
 EOF
 
 if [[ "${BUILDKITE_ENV_FILE_URL}" != "" ]]; then

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -147,7 +147,8 @@ shell=powershell
 disconnect-after-idle-timeout=${Env:BUILDKITE_SCALE_IN_IDLE_PERIOD}
 disconnect-after-job=${Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
 tracing-backend=${Env:BUILDKITE_AGENT_TRACING_BACKEND}
-signing-jwks-key-id=${Env:BUILDKITE_AGENT_SIGNING_KMS_KEY}
+signing-aws-kms-key=${Env:BUILDKITE_AGENT_SIGNING_KMS_KEY}
+verification-failure-behavior=${Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR}
 "@
 $OFS=" "
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -40,6 +40,7 @@ Metadata:
         - PipelineSigningKMSKeyId
         - PipelineSigningKMSKeySpec
         - PipelineSigningKMSAccess
+        - PipelineSigningVerificationFailureBehavior
 
       - Label:
           default: Advanced Configuration

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -596,6 +596,14 @@ Parameters:
       - "verify"
     Default: "sign-and-verify"
 
+  PipelineSigningVerificationFailureBehavior:
+    Type: String
+    Description: The behavior when a job is received without a valid verifiable signature (without a signature, with an invalid signature, or with a signature that fails verification)
+    AllowedValues:
+      - "block"
+      - "warn"
+    Default: "block"
+
 Rules:
   HasToken:
     Assertions:
@@ -1323,6 +1331,7 @@ Resources:
                   $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}"
                   $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
                   $Env:BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}"
+                  $Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}"
                   $Env:BUILDKITE_ENV_FILE_URL="${AgentEnvFileUrl}"
                   $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
                   $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
@@ -1382,6 +1391,7 @@ Resources:
                   BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
                   BUILDKITE_AGENT_CANCEL_GRACE_PERIOD="${BuildkiteAgentCancelGracePeriod}" \
                   BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}" \
+                  BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
                   BUILDKITE_QUEUE="${BuildkiteQueue}" \
                   BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
                   BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \


### PR DESCRIPTION
This also fixes a misconfiguration on the windows agent. 

This setting is critical to rolling out signing as it is helpful during migration if you want to enable warn mode while updating pipelines.

> This setting determines the Buildkite agent's response when it receives a job without a proper signature, and also specifies how strictly the agent should enforce signature verification for incoming jobs. The agent will warn about missing or invalid signatures, but will still proceed to execute the job. If not explicitly specified, the default behavior is block, which prevents any job without a valid signature from running, ensuring a secure pipeline environment by default.