### PR TITLE
fix: Add `r8g` to the `UsingArmInstances` logic

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -804,6 +804,7 @@ Conditions:
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6gd" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r7g" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r7gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r8g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "t4g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "x2gd" ]
 


### PR DESCRIPTION
As it says in the title, this PR adds the `r8g` EC2 instance class to the logic that's used to determine if the current instance is ARM based.