### PR TITLE
Pin amazon linux ami

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -40,7 +40,7 @@ variable "is_released" {
 data "amazon-ami" "al2023" {
   filters = {
     architecture        = var.arch
-    name                = "al2023-ami-minimal-*"
+    name                = "al2023-ami-minimal-2023.5.20240903.0-*"
     virtualization-type = "hvm"
   }
   most_recent = true


### PR DESCRIPTION
The new Amazon Linux AMI seems to have broken multi-platform docker image support.

```
[ec2-user@ip-172-31-57-192 ~]$ docker run --rm --platform linux/arm64/v8 -t arm64v8/ubuntu uname -m
exec /usr/bin/uname: exec format error
```

This pins the version for now