### PR TITLE
Update the default queue name to match what's provisioned in a new org

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -240,7 +240,7 @@ Parameters:
   BuildkiteQueue:
     Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"
     Type: String
-    Default: default
+    Default: default-queue
     MinLength: 1
 
   AgentsPerInstance:
@@ -625,7 +625,7 @@ Rules:
           !Or
             - !Equals
               - !Ref PipelineSigningKMSKeyId
-              - ""            
+              - ""
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
@@ -739,7 +739,7 @@ Conditions:
 
     UseCostAllocationTags:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
-    
+
     UsePipelineSigningKMSKey:
       !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
 
@@ -940,7 +940,7 @@ Resources:
       Name: !Sub "/${AWS::StackName}/buildkite/agent-token"
       Type: String
       Value: !Ref BuildkiteAgentToken
-  
+
   PipelineSigningKMSKey:
     Type: AWS::KMS::Key
     Condition: CreatePipelineSigningKMSKey


### PR DESCRIPTION
By default, a new Buildkite org will have one cluster called Default, with a queue named `default-queue`. This PR updates the elastic ci stack default to match so that we get agents registered with the default queue out of the box.

This might be a breaking change for any orgs that have a queue named `default` that deploy the elastic stack without supplying a value for `BuildkiteQueue`.