### PR TITLE
Add m8g instances to UsingArmInstances

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -799,6 +799,7 @@ Conditions:
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m6gd" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m7g" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m7gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m8g" ]
         - !Or
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6g" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6gd" ]


### PR DESCRIPTION
This PR adds the [new EC2 `m8g`](https://aws.amazon.com/ec2/instance-types/m8g/) instances to the `UsingArmInstances` block. 