### PR TITLE
Restore SSM Session Manager Plugin

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -105,6 +105,10 @@ build {
   }
 
   provisioner "shell" {
+    script = "scripts/install-session-manager-plugin.sh"
+  }
+
+  provisioner "shell" {
     script = "scripts/install-buildkite-agent.sh"
   }
 

--- a/packer/linux/scripts/install-session-manager-plugin.sh
+++ b/packer/linux/scripts/install-session-manager-plugin.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu -o pipefail
+
+SESSION_MANAGER_PLUGIN_VERSION=1.2.677.0
+
+MACHINE="$(uname -m)"
+
+case "${MACHINE}" in
+x86_64) ARCH=64bit ;;
+aarch64) ARCH=arm64 ;;
+*) ARCH=unknown ;;
+esac
+
+echo "Installing session-manager-plugin ${SESSION_MANAGER_PLUGIN_VERSION}..."
+
+sudo dnf install -y "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/linux_${ARCH}/session-manager-plugin.rpm"


### PR DESCRIPTION
This was removed in the migration to Amazon Linux 3 with the [belief that there was no use case for the Session Manager Plugin being present on the agent](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1122#discussion_r1220593363). It has since been realised that it is quite useful. For example, the agent may be used to start ECS Tasks which perform work in other environments/network configurations (such as Database migrations during deployments).

The install script was first restored (`git checkout 2d32dfcc211b268e903a742de87bb27070c53cb7^ -- packer/linux/scripts/install-session-manager-plugin.sh`), then modified slightly per [AWS documentation for Amazon Linux 3](https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-linux.html).