### PR TITLE
Add support for c8g instances.

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -789,6 +789,7 @@ Conditions:
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7g" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7gd" ]
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7gn" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c8g" ]
         - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "g5g" ]
         - !Or
           - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "i4g" ]

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -625,7 +625,7 @@ Rules:
           !Or
             - !Equals
               - !Ref PipelineSigningKMSKeyId
-              - ""            
+              - ""
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
@@ -739,7 +739,7 @@ Conditions:
 
     UseCostAllocationTags:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
-    
+
     UsePipelineSigningKMSKey:
       !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
 
@@ -941,7 +941,7 @@ Resources:
       Name: !Sub "/${AWS::StackName}/buildkite/agent-token"
       Type: String
       Value: !Ref BuildkiteAgentToken
-  
+
   PipelineSigningKMSKey:
     Type: AWS::KMS::Key
     Condition: CreatePipelineSigningKMSKey


### PR DESCRIPTION
These new instance types https://aws.amazon.com/ec2/instance-types/c8g/ ought to be recognised as ARM64 workers.