### PR TITLE
Bump Docker buildx to v0.18.0 and Docker Compose to v2.30.3

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_COMPOSE_V2_VERSION=2.27.0
+DOCKER_COMPOSE_V2_VERSION=2.30.3
 DOCKER_BUILDX_VERSION=0.18.0
 MACHINE=$(uname -m)
 

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DOCKER_COMPOSE_V2_VERSION=2.27.0
-DOCKER_BUILDX_VERSION=0.15.0
+DOCKER_BUILDX_VERSION=0.18.0
 MACHINE=$(uname -m)
 
 echo Installing docker...


### PR DESCRIPTION
### Change

- Upgrade buildx from 0.15.0 to 0.18.0
- Upgrade Docker Compose from 2.27.0 to 2.30.3

### Considerations

See the [buildx](https://github.com/docker/buildx/releases) and [compose](https://github.com/docker/compose/releases) release notes for details of the changes:
