### PR TITLE
Update packer and the AMI with some fixes for binfmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 VERSION = $(shell git describe --tags --candidates=1)
 SHELL = /bin/bash -o pipefail
 
-PACKER_VERSION ?= 1.9.4
+PACKER_VERSION ?= 1.11.2
 PACKER_LINUX_FILES = $(exec find packer/linux)
 PACKER_WINDOWS_FILES = $(exec find packer/windows)
 

--- a/goss.yaml
+++ b/goss.yaml
@@ -149,6 +149,12 @@ command:
     stdout:
     - /disabled/
 
+  systemctl is-enabled proc-sys-fs-binfmt_misc.mount:
+    exit-status: 0
+
+  systemctl is-enabled docker-binfmt.service:
+    exit-status: 0
+
   systemctl is-enabled docker-gc.timer:
     exit-status: 0
 

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -40,7 +40,7 @@ variable "is_released" {
 data "amazon-ami" "al2023" {
   filters = {
     architecture        = var.arch
-    name                = "al2023-ami-minimal-2023.5.20240903.0-*"
+    name                = "al2023-ami-minimal-2023.6.20241121*"
     virtualization-type = "hvm"
   }
   most_recent = true
@@ -58,6 +58,13 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   ssh_username                              = "ec2-user"
   ssh_clear_authorized_keys = true
   temporary_security_group_source_public_ip = true
+
+  launch_block_device_mappings {
+    volume_type           = "gp3"    
+    device_name = "/dev/xvda"
+    volume_size = 10
+    delete_on_termination = true
+  }
 
   run_tags = {
     Name = "Packer Builder" // marks resources for deletion in cleanup.sh
@@ -114,5 +121,9 @@ build {
 
   provisioner "shell" {
     script = "scripts/install-buildkite-utils.sh"
+  }
+
+  provisioner "shell" {
+    script = "scripts/cleanup.sh"
   }
 }

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -40,7 +40,7 @@ variable "is_released" {
 data "amazon-ami" "al2023" {
   filters = {
     architecture        = var.arch
-    name                = "al2023-ami-minimal-2023.6.20241121*"
+    name                = "al2023-ami-minimal-*"
     virtualization-type = "hvm"
   }
   most_recent = true

--- a/packer/linux/conf/bin/bk-configure-docker.sh
+++ b/packer/linux/conf/bin/bk-configure-docker.sh
@@ -27,28 +27,6 @@ exec > >(tee -a /var/log/elastic-stack.log | logger -t user-data -s 2>/dev/conso
 
 echo "Starting ${BASH_SOURCE[0]}..."
 
-echo Sourcing /usr/local/lib/bk-configure-docker.sh...
-echo This file is written by the scripts in packer/scripts.
-echo Note that the path is /usr/local/lib, not /usr/local/bin.
-echo Contents of /usr/local/lib/bk-configure-docker.sh:
-cat /usr/local/lib/bk-configure-docker.sh
-# shellcheck disable=SC1091
-source /usr/local/lib/bk-configure-docker.sh
-
-echo Installing qemu binfmt for multiarch...
-if ! docker run \
-  --privileged \
-  --userns=host \
-  --pull=never \
-  --rm \
-  "tonistiigi/binfmt@${QEMU_BINFMT_DIGEST}" \
-  --install all; then
-  echo Failed to install binfmt.
-  echo Avaliable docker images:
-  docker image ls
-  exit 1
-fi
-
 if [[ "${DOCKER_USERNS_REMAP:-false}" == "true" ]]; then
   echo Configuring user namespace remapping...
 

--- a/packer/linux/conf/docker/systemd/docker-binfmt.service
+++ b/packer/linux/conf/docker/systemd/docker-binfmt.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Setup Multi-Architecture Build Support with Binfmt
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=-/usr/bin/docker pull \
+    tonistiigi/binfmt:7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
+ExecStart=/usr/bin/docker run --privileged --userns=host \
+    tonistiigi/binfmt:7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55 \
+    --install all
+
+[Install]
+WantedBy=multi-user.target

--- a/packer/linux/scripts/cleanup.sh
+++ b/packer/linux/scripts/cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo dnf clean all

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -45,22 +45,13 @@ sudo cp /tmp/conf/bin/docker-compose /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 docker-compose version
 
-# Writing QEMU container version info to /usr/local/lib/bk-configure-docker.sh.
-# We only pull this image when we build the AMI. It will be run in
-# /usr/local/bin/bk-configure-docker.sh, but it needs to know the image digest
-# to make sure it does not pull in another image instead.
-# NOTE: the executable file is in /usr/local/bin and it sources as file of the
-# same name in /usr/local/lib. These are not the same file.
-# See https://docs.docker.com/build/building/multi-platform/
-
-echo Contents of /usr/local/lib/bk-configure-docker.sh:
-cat <<'EOF' | sudo tee -a /usr/local/lib/bk-configure-docker.sh
-QEMU_BINFMT_VERSION=7.0.0-28
-QEMU_BINFMT_DIGEST=sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
-QEMU_BINFMT_TAG="qemu-v${QEMU_BINFMT_VERSION}@${QEMU_BINFMT_DIGEST}"
-EOF
-# shellcheck disable=SC1091
-source /usr/local/lib/bk-configure-docker.sh
 sudo mkdir -p /usr/local/lib
-echo Pulling qemu binfmt for multiarch...
-sudo docker pull "tonistiigi/binfmt:${QEMU_BINFMT_TAG}"
+
+echo Enabling docker-binfmt...
+sudo systemctl enable docker-binfmt.service
+
+echo Start docker-binfmt...
+sudo systemctl start docker-binfmt.service
+
+echo "show docker-binfmt status..."
+systemctl status docker-binfmt.service

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -47,6 +47,9 @@ docker-compose version
 
 sudo mkdir -p /usr/local/lib
 
+echo "enable binfmt_misc..."
+sudo systemctl enable proc-sys-fs-binfmt_misc.mount
+
 echo Enabling docker-binfmt...
 sudo systemctl enable docker-binfmt.service
 


### PR DESCRIPTION
The AMI version we had pinned due to issues with multiarchecture docker builds failing was removed from list of public AMIs.
```bash
$ aws ec2 describe-images --filters 'Name=name,Values=al2023-ami-minimal-2023.5.20240903.0-*'
{
    "Images": []
}
```

This paired with a few changes which broke our packer build I have made a few changes:

1. Because we run update during the packer build, and a couple of the updates were 400Mb+ and filled up our 2Gb default ebs volume.
2. Added a command to cleanup downloads and cache files from dnf to keep the image lean after these upgrades...
3. Changes in systemd now remove cleanup binfmt_misc on restart https://github.com/systemd/systemd/issues/13129 so we need to add a `docker-binfmt.service` which runs at startup to support multiarchecture docker builds.
4. On top of this the proc-sys-fs-binfmt_misc.mount was being automounted on demand, again removing all the files we create via `docker-binfmt.service`. So I have enabled this mount to always activate on boot.
5. I have removed the pinned version in favour of the latest.

I also upgraded packer as it hadn't been touched in a while.