### PR TITLE
Bump Docker buildx to v0.19.2 and Docker Compose to v2.31.0

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DOCKER_COMPOSE_V2_VERSION=2.30.3
-DOCKER_BUILDX_VERSION=0.18.0
+DOCKER_BUILDX_VERSION=0.19.2
 MACHINE=$(uname -m)
 
 echo Installing docker...

--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCKER_COMPOSE_V2_VERSION=2.30.3
+DOCKER_COMPOSE_V2_VERSION=2.31.0
 DOCKER_BUILDX_VERSION=0.19.2
 MACHINE=$(uname -m)
 


### PR DESCRIPTION
### Change

- Upgrade buildx from 0.18.0 to 0.19.2
- Upgrade Docker Compose from 2.30.3 to 2.31.0

### Considerations

See the [buildx](https://github.com/docker/buildx/releases) and [compose](https://github.com/docker/compose/releases) release notes for details of the changes:
