### PR TITLE
Tidy up hcl whitespace and upgrade windows to use gp3 for more iops

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -60,9 +60,9 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   temporary_security_group_source_public_ip = true
 
   launch_block_device_mappings {
-    volume_type           = "gp3"    
-    device_name = "/dev/xvda"
-    volume_size = 10
+    volume_type           = "gp3"
+    device_name           = "/dev/xvda"
+    volume_size           = 10
     delete_on_termination = true
   }
 

--- a/packer/windows/buildkite-ami.pkr.hcl
+++ b/packer/windows/buildkite-ami.pkr.hcl
@@ -60,6 +60,13 @@ source "amazon-ebs" "elastic-ci-stack" {
   winrm_use_ssl   = true
   winrm_username  = "Administrator"
 
+  launch_block_device_mappings {
+    volume_type           = "gp3"
+    device_name           = "/dev/sda1"
+    volume_size           = 30
+    delete_on_termination = true
+  }
+
   tags = {
     Name          = "elastic-ci-stack-windows"
     OSVersion     = "Windows Server 2019"


### PR DESCRIPTION
Overriding the defaults set by packer with the goal of providing better performance for instances launched using this AMI by ensuring we use GP3 volumes by default.

> **launch_block_device_mappings** - Add one or more block devices before the Packer build starts. If you add instance store volumes or EBS volumes in addition to the root device volume, the created AMI will contain block device mapping information for those volumes.

https://developer.hashicorp.com/packer/integrations/hashicorp/amazon/latest/components/builder/ebs



https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-storage-compare-volume-types.html
