### PR TITLE
Update bk/elastic-ci-stack-s3-secrets-hooks to v2.2.0

### DIFF
--- a/packer/linux/scripts/install-buildkite-utils.sh
+++ b/packer/linux/scripts/install-buildkite-utils.sh
@@ -15,7 +15,7 @@ echo "Installing fix-buildkite-agent-builds-permissions..."
 sudo chmod +x "/tmp/build/fix-perms-linux-${ARCH}"
 sudo mv "/tmp/build/fix-perms-linux-${ARCH}" /usr/bin/fix-buildkite-agent-builds-permissions
 
-S3_SECRETS_HELPER_VERSION=2.1.6
+S3_SECRETS_HELPER_VERSION=2.2.0
 echo "Downloading s3-secrets-helper ${S3_SECRETS_HELPER_VERSION}..."
 sudo curl -Lsf -o /usr/local/bin/s3secrets-helper \
   "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-linux-${ARCH}"

--- a/packer/windows/scripts/install-s3secrets-helper.ps1
+++ b/packer/windows/scripts/install-s3secrets-helper.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$S3_SECRETS_HELPER_VERSION = "2.1.6"
+$S3_SECRETS_HELPER_VERSION = "2.2.0"
 
 Write-Output "Downloading s3-secrets-helper v${S3_SECRETS_HELPER_VERSION}..."
 Invoke-WebRequest -OutFile C:\buildkite-agent\bin\s3secrets-helper.exe -Uri "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-windows-amd64"


### PR DESCRIPTION
Updates https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks to the latest release. There are no functional changes in this release, it's all maintenance:

* update golang from 1.16 to 1.23
* update various gomods, like the AWS SDK

I followed the docs in https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/docs/updating-secrets.md to make this PR