### PR TITLE
stop setting ACLs when publishing templates to S3

### DIFF
--- a/.buildkite/steps/publish.sh
+++ b/.buildkite/steps/publish.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 s3_upload_templates() {
   local bucket_prefix="${1:-}"
 
-  aws s3 cp --content-type 'text/yaml' --acl public-read build/mappings.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}mappings.yml"
-  aws s3 cp --content-type 'text/yaml' --acl public-read build/aws-stack.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.yml"
+  aws s3 cp --content-type 'text/yaml' build/mappings.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}mappings.yml"
+  aws s3 cp --content-type 'text/yaml' build/aws-stack.yml "s3://${BUILDKITE_AWS_STACK_TEMPLATE_BUCKET}/${bucket_prefix}aws-stack.yml"
 }
 
 echo "--- :git: Checking and fetching git tags"


### PR DESCRIPTION
We recently changed the S3 bucket that holds public CloudFormation templates for the elastic stack from old fashioned ACLs to new fashioned Bucket Owner with Bucket Resource Policy that grants public read access.

Now, this script is failing with an error:

    upload failed: build/mappings.yml to s3://buildkite-aws-stack/secrets-2-2-0/mappings.yml An error occurred (AccessControlListNotSupported) when calling the PutObject operation: The bucket does not allow ACLs

I think removing the --acl flag from our publish command should fix that.