### PR TITLE
Expand the AMI cleaning pipeline to all regions

### DIFF
--- a/.buildkite/pipeline.cleanamis.yaml
+++ b/.buildkite/pipeline.cleanamis.yaml
@@ -6,10 +6,28 @@ steps:
     env:
       DRY_RUN: true
       AWS_REGION: "{{matrix}}"
+    # list of regions should match .buildkite/steps/copy.sh
     matrix:
       - "us-east-1"
+      - "us-east-2"
+      - "us-west-1"
       - "us-west-2"
+      - "af-south-1"
+      - "ap-east-1"
+      - "ap-south-1"
+      - "ap-northeast-2"
+      - "ap-northeast-1"
       - "ap-southeast-2"
+      - "ap-southeast-1"
+      - "ca-central-1"
+      - "eu-central-1"
+      - "eu-west-1"
+      - "eu-west-2"
+      - "eu-south-1"
+      - "eu-west-3"
+      - "eu-north-1"
+      - "me-south-1"
+      - "sa-east-1"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-elastic-stack-for-aws-ami-cleaner

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -77,6 +77,8 @@ if [[ -z "${BUILDKITE_AWS_STACK_BUCKET}" ]]; then
   exit 1
 fi
 
+# to ensure old images are garbage collected, the list of regions should
+# match .buildkite/pipeline.cleanamis.yaml
 ALL_REGIONS=(
   us-east-1
   us-east-2


### PR DESCRIPTION
All regions we publish the elastic stack to, anyway. There's 20 - any region launched in the last few years and not requested by a customer currently has no AMIs published to it.

The pipeline is still in dry run mode, so this will have no actual impact on AMIs. The IAM role also lacks permission to actually delete anything yet.

This will give logs of every region that I can examine and spot check for correctness though.