### PR TITLE
remove DRY_RUN flag from AMI cleaning script

### DIFF
--- a/.buildkite/pipeline.cleanamis.yaml
+++ b/.buildkite/pipeline.cleanamis.yaml
@@ -4,7 +4,7 @@ steps:
     agents:
       queue: "oss-deploy"
     env:
-      DRY_RUN: true
+      # DRY_RUN: true
       AWS_REGION: "{{matrix}}"
     # list of regions should match .buildkite/steps/copy.sh
     matrix:


### PR DESCRIPTION
I've run some test builds in dry mode, and spot checked the job logs for multiple regions. Everything I checked looked as expected:

* all regions show elastic stack AMIs tagged with a version are left untouched
* all regions show only elastic stack AMIs in the list
* all regions cap the deletions at only 10 images (for now)

This will require expanding the IAM role to permit deregistering images and deleting snapshots.

I propose leaving the 10-image cap for now. In the unlikely event of a mistake, this will limit the blast radius of deregistered images. We can increase the number once we build confidence.