### PR TITLE
Increase AMI garbage collection to 100 images per run

### DIFF
--- a/.buildkite/steps/clean-old-amis
+++ b/.buildkite/steps/clean-old-amis
@@ -18,7 +18,7 @@ def die(msg)
   exit 1
 end
 
-MAX_DELETIONS = 10
+MAX_DELETIONS = 100
 
 region = ARGV[0] || ENV["AWS_REGION"]
 dry_run = ENV["DRY_RUN"]


### PR DESCRIPTION
I started with 10 while I was building the pipeline, mainly to limit the blast radius if I accidentally deregistered the wrong images.

The pipeline is now up and running and I've manually run it a few times. It's working just as planned, and only un-versioned images created more than a year ago are being deregistered.

I'm confident we can increase this to a higher number now. Looking at the logs for some regions, I can see most have 900-1200 images in them. Once this chance merges, I'll do a couple of manually runs to cut those numbers down by a few hundred, then we can rely on the weekly scheduled build to keep the number down over time.