### PR TITLE
Fix PATH used by jobs

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -9,7 +9,7 @@ After=docker.service
 Type=simple
 User=buildkite-agent
 Environment="HOME=/var/lib/buildkite-agent"
-Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+Environment="PATH=/usr/local/bin:/usr/bin"
 Environment="USER=buildkite-agent"
 # The =- (rather than just = ) in the line below means that systemd won't complain if it can't find the file
 EnvironmentFile=-/var/lib/buildkite-agent/env


### PR DESCRIPTION
The PATH configured in `buildkite-agent.service` is inherited by all jobs executed by Buildkite.

Normally, a binary installed to `/usr/local/bin` would take precedence over similarly named files in `/usr/bin` or `/bin`. This commit restores that expectation allowing an administrator to replace a binary by installing a replacement into `/usr/local/bin`.

There is no entry for `/bin` because al2023 symlinks `/usr/bin` to `/bin`. A specific entry for `/bin` is unnecessary.

Finally, `/usr/local/sbin` and `/usr/sbin` have been removed because as the buildkite-agent is a regular user, it should not have the required permissions to use those binaries.