### PR TITLE
Allow user to specify full KMS key ARN for pipeline signing.

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -37,7 +37,7 @@ Metadata:
       - Label:
           default: Signed Pipelines Configuration
         Parameters:
-        - PipelineSigningKMSKeyId
+        - PipelineSigningKMSKeyArn
         - PipelineSigningKMSKeySpec
         - PipelineSigningKMSAccess
         - PipelineSigningVerificationFailureBehavior
@@ -576,9 +576,9 @@ Parameters:
     Description: Optional - Customise the EC2 instance Name tag
     Default: ""
 
-  PipelineSigningKMSKeyId:
+  PipelineSigningKMSKeyArn:
     Type: String
-    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (Created if left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - ARN of the KMS key used to sign and verify pipelines (created if left blank and PipelineSigningKMSKeySpec is selected)
     Default: ""
 
   PipelineSigningKMSKeySpec:
@@ -624,12 +624,12 @@ Rules:
       - Assert:
           !Or
             - !Equals
-              - !Ref PipelineSigningKMSKeyId
+              - !Ref PipelineSigningKMSKeyArn
               - ""
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId or select a PipelineSigningKMSKeySpec but not both"
+        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyArn or select a PipelineSigningKMSKeySpec but not both"
 
 Outputs:
   VpcId:
@@ -759,11 +759,11 @@ Conditions:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
     UsePipelineSigningKMSKey:
-      !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
+      !Not [ !Equals [ !Ref PipelineSigningKMSKeyArn, "" ] ]
 
     CreatePipelineSigningKMSKey:
       !And
-      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+      - !Equals [ !Ref PipelineSigningKMSKeyArn, "" ]
       - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
 
     HasPipelineSigningKMSKey:
@@ -1022,7 +1022,7 @@ Resources:
                   Resource: !If
                               - CreatePipelineSigningKMSKey
                               - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+                              - !Ref PipelineSigningKMSKeyArn
           - !Ref 'AWS::NoValue'
         - !If
           - UseCustomerManagedKeyForParameterStore
@@ -1371,7 +1371,7 @@ Resources:
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
                     LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
                     AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
+                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyArn ],
                   }
               - !Sub
                 - |
@@ -1436,7 +1436,7 @@ Resources:
                     LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
                     LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
                     AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
+                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyArn ],
                   }
 
   AgentAutoScaleGroup:


### PR DESCRIPTION
# Description

We have a use case where we want to have a single KMS key that Buildkite agents in multiple accounts can use to sign and verify pipeline steps. By letting the user specify the whole key ARN rather than just the key ID, the user is free to use a key wherever they want.

We are aware that this is a breaking change, which is not ideal (i.e., if a user has already specified the `PipelineSigningKMSKeyId` parameter, they'll need to replace it with `PipelineSigningKMSKeyArn`).  Please let us know if it'd be better to accept either/or key ID or ARN -- the reason we didn't implement the change like that off the bat is that as far as we could tell, that'd add a bunch of ugly if-statements everywhere to check which had been provided and do slightly different things accordingly.

### CHANGELOG

* templates/aws-stack.yml: Rename `PipelineSigningKMSKeyId` to `PipelineSigningKMSKeyArn` and avoid assuming the key is in the same account/region as the agent stack.