### PR TITLE
Allow ARN to be provided for pipeline signing KMS key

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -38,6 +38,7 @@ Metadata:
           default: Signed Pipelines Configuration
         Parameters:
         - PipelineSigningKMSKeyId
+        - PipelineSigningKMSKeyARN
         - PipelineSigningKMSKeySpec
         - PipelineSigningKMSAccess
         - PipelineSigningVerificationFailureBehavior
@@ -578,7 +579,12 @@ Parameters:
 
   PipelineSigningKMSKeyId:
     Type: String
-    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (Created if left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
+    Default: ""
+
+  PipelineSigningKMSKeyARN:
+    Type: String
+    Description: Optional - ARN of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
     Default: ""
 
   PipelineSigningKMSKeySpec:
@@ -627,9 +633,12 @@ Rules:
               - !Ref PipelineSigningKMSKeyId
               - ""
             - !Equals
+              - !Ref PipelineSigningKMSKeyARN
+              - ""
+            - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId or select a PipelineSigningKMSKeySpec but not both"
+        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId, PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec but not both"
 
 Outputs:
   VpcId:
@@ -759,11 +768,15 @@ Conditions:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
     UsePipelineSigningKMSKey:
-      !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
+      !Or
+        - !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
+        - !Not [ !Equals [ !Ref PipelineSigningKMSKeyARN, "" ] ]
 
     CreatePipelineSigningKMSKey:
       !And
-      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+      - !Or
+        - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+        - !Equals [ !Ref PipelineSigningKMSKeyARN, "" ]
       - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
 
     HasPipelineSigningKMSKey:
@@ -1019,10 +1032,16 @@ Resources:
                         - kms:GetPublicKey
                       - - kms:Verify
                         - kms:GetPublicKey
-                  Resource: !If
-                              - CreatePipelineSigningKMSKey
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+                  Resource:
+                    !If
+                      - CreatePipelineSigningKMSKey
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                      - !If
+                        - !Equals
+                          - !Ref PipelineSigningKMSKeyId
+                          - ""
+                        - !Ref PipelineSigningKMSKeyARN
+                        - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
           - !Ref 'AWS::NoValue'
         - !If
           - UseCustomerManagedKeyForParameterStore
@@ -1367,12 +1386,27 @@ Resources:
                   $Env:AWS_REGION="${AWS::Region}"
                   powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
                   </powershell>
-                - {
-                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
-                    AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
-                  }
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !If
+                      - !Equals
+                        - !Ref PipelineSigningKMSKeyId
+                        - ""
+                      - !Ref PipelineSigningKMSKeyARN
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
               - !Sub
                 - |
                   Content-Type: multipart/mixed; boundary="==BOUNDARY=="
@@ -1432,12 +1466,27 @@ Resources:
                   AWS_REGION="${AWS::Region}" \
                     /usr/local/bin/bk-install-elastic-stack.sh
                   --==BOUNDARY==--
-                - {
-                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
-                    AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
-                  }
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !If
+                      - !Equals
+                        - !Ref PipelineSigningKMSKeyId
+                        - ""
+                      - !Ref PipelineSigningKMSKeyARN
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -772,11 +772,13 @@ Conditions:
         - !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
         - !Not [ !Equals [ !Ref PipelineSigningKMSKeyARN, "" ] ]
 
+    HasPipelineSigningKMSKeyARN:
+      !Not [!Equals [!Ref PipelineSigningKMSKeyARN, ""]]
+
     CreatePipelineSigningKMSKey:
       !And
-      - !Or
-        - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
-        - !Equals [ !Ref PipelineSigningKMSKeyARN, "" ]
+      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+      - !Equals [ !Ref PipelineSigningKMSKeyARN, "" ]
       - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
 
     HasPipelineSigningKMSKey:
@@ -1037,9 +1039,7 @@ Resources:
                       - CreatePipelineSigningKMSKey
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                       - !If
-                        - !Equals
-                          - !Ref PipelineSigningKMSKeyId
-                          - ""
+                        - HasPipelineSigningKMSKeyARN
                         - !Ref PipelineSigningKMSKeyARN
                         - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
           - !Ref 'AWS::NoValue'
@@ -1402,9 +1402,7 @@ Resources:
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                     - !If
-                      - !Equals
-                        - !Ref PipelineSigningKMSKeyId
-                        - ""
+                      - HasPipelineSigningKMSKeyARN
                       - !Ref PipelineSigningKMSKeyARN
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
               - !Sub
@@ -1482,9 +1480,7 @@ Resources:
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                     - !If
-                      - !Equals
-                        - !Ref PipelineSigningKMSKeyId
-                        - ""
+                      - HasPipelineSigningKMSKeyARN
                       - !Ref PipelineSigningKMSKeyARN
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -638,7 +638,7 @@ Rules:
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId, PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec but not both"
+        AssertDescription: "You must provide either a PipelineSigningKMSKeyId or PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:
   VpcId:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -628,16 +628,48 @@ Rules:
   HasPipelineSigningKMSKey:
     Assertions:
       - Assert:
-          !Or
+        - !Or
+          - !Not
             - !Equals
               - !Ref PipelineSigningKMSKeyId
               - ""
+          - !Not
             - !Equals
               - !Ref PipelineSigningKMSKeyARN
               - ""
+          - !Not
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
+        AssertDescription: "You must provide one of: PipelineSigningKMSKeyId, PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec"
+      - Assert:
+        - !Not
+          - !And
+            - !Not
+              - !Equals
+                - !Ref PipelineSigningKMSKeyId
+                - ""
+            - !Not
+              - !Equals
+                - !Ref PipelineSigningKMSKeyARN
+                - ""
+        AssertDescription: "You must not provide both a PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN"
+      - Assert:
+        - !Not
+          - !And
+            - !Or
+              - !Not
+                - !Equals
+                  - !Ref PipelineSigningKMSKeyId
+                  - ""
+              - !Not
+                - !Equals
+                  - !Ref PipelineSigningKMSKeyARN
+                  - ""
+            - !Not
+              - !Equals
+                - !Ref PipelineSigningKMSKeySpec
+                - "none"
         AssertDescription: "You must provide either a PipelineSigningKMSKeyId or PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -579,12 +579,12 @@ Parameters:
 
   PipelineSigningKMSKeyId:
     Type: String
-    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - Identifier of the KMS key to use for pipeline signatures & verification (if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank, and PipelineSigningKMSKeySpec is selected, a fresh signing key will automatically be created)
     Default: ""
 
   PipelineSigningKMSKeyARN:
     Type: String
-    Description: Optional - ARN of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - ARN of the KMS key to use for pipeline signatures & verification (if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyArn are left blank, and PipelineSigningKMSKeySpec is selected, a fresh signing key will automatically be created)
     Default: ""
 
   PipelineSigningKMSKeySpec:


### PR DESCRIPTION
Alterative approach to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1422 to ensure backwards-compatibility with existing stacks.

## Description

Our setup is not compatible with the current stack configuration. We have a KMS key in one AWS account which is shared across multiple accounts to sign and verify pipelines. This approach allows the user to specify an ARN of the KMS key so they may use a key cross-account or even cross-region. Existing behaviour is maintained as the Key ID may be provided using `PipelineSigningKMSKeyId` and the ARN is constructed using the current account and region. Key creation in the stack is also maintained.

### CHANGELOG

* Added `PipelineSigningKMSKeyArn` parameter to allow KMS key ARN to be provided.
* Updated "HasPipelineSigningKMSKey" rule to enforce only _one_ of key ID, ARN, or automatically generated key in stack.
* Updated references to `PipelineSigningKMSKeyId` to instead use `PipelineSigningKMSKeyArn` if provided, and construct ARN only if one is not provided and `PipelineSigningKMSKeyId` is
* Updated JSON object to YAML for readability

---

Co-authored-by: paul <paul.david@redbubble.com>