### PR TITLE
Let user provide full KMS Key ARN and update descriptions

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1389,10 +1389,7 @@ Resources:
                   PipelineSigningKMSKey: !If
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                    - !If
-                      - PipelineSigningKeyIsARN
-                      - !Ref PipelineSigningKMSKeyId
-                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+                    - !Ref PipelineSigningKMSKeyId
               - !Sub
                 - |
                   Content-Type: multipart/mixed; boundary="==BOUNDARY=="
@@ -1467,10 +1464,7 @@ Resources:
                   PipelineSigningKMSKey: !If
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                    - !If
-                      - PipelineSigningKeyIsARN
-                      - !Ref PipelineSigningKMSKeyId
-                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+                    - !Ref PipelineSigningKMSKeyId
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -627,12 +627,9 @@ Rules:
               - !Ref PipelineSigningKMSKeyId
               - ""
             - !Equals
-              - !Ref PipelineSigningKMSKeyARN
-              - ""
-            - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either a PipelineSigningKMSKeyId or PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec, but not both"
+        AssertDescription: "You must provide either a PipelineSigningKMSKeyId, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:
   VpcId:
@@ -762,15 +759,11 @@ Conditions:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
     UsePipelineSigningKMSKey:
-      !Or
-        - !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
-        - !Not [ !Equals [ !Ref PipelineSigningKMSKeyARN, "" ] ]
+      !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
 
     CreatePipelineSigningKMSKey:
       !And
-      - !Or
-        - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
-        - !Equals [ !Ref PipelineSigningKMSKeyARN, "" ]
+      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
       - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
 
     HasPipelineSigningKMSKey:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -772,6 +772,9 @@ Conditions:
     HasSigningKMSAccessSignAndVerify:
       !Equals [ !Ref PipelineSigningKMSAccess, "sign-and-verify" ]
 
+    PipelineSigningKeyIsARN:
+      !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
+
     HasKeyName:
       !Not [ !Equals [ !Ref KeyName, "" ] ]
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1027,10 +1027,8 @@ Resources:
                       - CreatePipelineSigningKMSKey
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                       - !If
-                        - !Equals
-                          - !Ref PipelineSigningKMSKeyId
-                          - ""
-                        - !Ref PipelineSigningKMSKeyARN
+                        - PipelineSigningKeyIsARN
+                        - !Ref PipelineSigningKMSKeyId
                         - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
           - !Ref 'AWS::NoValue'
         - !If
@@ -1392,10 +1390,8 @@ Resources:
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                     - !If
-                      - !Equals
-                        - !Ref PipelineSigningKMSKeyId
-                        - ""
-                      - !Ref PipelineSigningKMSKeyARN
+                      - PipelineSigningKeyIsARN
+                      - !Ref PipelineSigningKMSKeyId
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
               - !Sub
                 - |
@@ -1472,10 +1468,8 @@ Resources:
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                     - !If
-                      - !Equals
-                        - !Ref PipelineSigningKMSKeyId
-                        - ""
-                      - !Ref PipelineSigningKMSKeyARN
+                      - PipelineSigningKeyIsARN
+                      - !Ref PipelineSigningKMSKeyId
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
 
   AgentAutoScaleGroup:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -38,6 +38,7 @@ Metadata:
           default: Signed Pipelines Configuration
         Parameters:
         - PipelineSigningKMSKeyId
+        - PipelineSigningKMSKeyARN
         - PipelineSigningKMSKeySpec
         - PipelineSigningKMSAccess
         - PipelineSigningVerificationFailureBehavior
@@ -578,7 +579,12 @@ Parameters:
 
   PipelineSigningKMSKeyId:
     Type: String
-    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (Created if left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
+    Default: ""
+
+  PipelineSigningKMSKeyARN:
+    Type: String
+    Description: Optional - ARN of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
     Default: ""
 
   PipelineSigningKMSKeySpec:
@@ -627,9 +633,12 @@ Rules:
               - !Ref PipelineSigningKMSKeyId
               - ""
             - !Equals
+              - !Ref PipelineSigningKMSKeyARN
+              - ""
+            - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId or select a PipelineSigningKMSKeySpec but not both"
+        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId, PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec but not both"
 
 Outputs:
   VpcId:
@@ -759,11 +768,15 @@ Conditions:
       !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
     UsePipelineSigningKMSKey:
-      !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
+      !Or
+        - !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
+        - !Not [ !Equals [ !Ref PipelineSigningKMSKeyARN, "" ] ]
 
     CreatePipelineSigningKMSKey:
       !And
-      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+      - !Or
+        - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+        - !Equals [ !Ref PipelineSigningKMSKeyARN, "" ]
       - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
 
     HasPipelineSigningKMSKey:
@@ -1019,10 +1032,16 @@ Resources:
                         - kms:GetPublicKey
                       - - kms:Verify
                         - kms:GetPublicKey
-                  Resource: !If
-                              - CreatePipelineSigningKMSKey
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                              - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+                  Resource:
+                    !If
+                      - CreatePipelineSigningKMSKey
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                      - !If
+                        - !Equals
+                          - !Ref PipelineSigningKMSKeyId
+                          - ""
+                        - !Ref PipelineSigningKMSKeyARN
+                        - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
           - !Ref 'AWS::NoValue'
         - !If
           - UseCustomerManagedKeyForParameterStore
@@ -1367,12 +1386,27 @@ Resources:
                   $Env:AWS_REGION="${AWS::Region}"
                   powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
                   </powershell>
-                - {
-                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
-                    AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
-                  }
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !If
+                      - !Equals
+                        - !Ref PipelineSigningKMSKeyId
+                        - ""
+                      - !Ref PipelineSigningKMSKeyARN
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
               - !Sub
                 - |
                   Content-Type: multipart/mixed; boundary="==BOUNDARY=="
@@ -1432,12 +1466,27 @@ Resources:
                   AWS_REGION="${AWS::Region}" \
                     /usr/local/bin/bk-install-elastic-stack.sh
                   --==BOUNDARY==--
-                - {
-                    LocalSecretsBucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ],
-                    LocalSecretsBucketRegion: !If [ CreateSecretsBucket, !Ref "AWS::Region", !Ref SecretsBucketRegion ],
-                    AgentTokenPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ],
-                    PipelineSigningKMSKey: !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, !Ref PipelineSigningKMSKeyId ],
-                  }
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !If
+                      - !Equals
+                        - !Ref PipelineSigningKMSKeyId
+                        - ""
+                      - !Ref PipelineSigningKMSKeyARN
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -772,7 +772,7 @@ Conditions:
     HasSigningKMSAccessSignAndVerify:
       !Equals [ !Ref PipelineSigningKMSAccess, "sign-and-verify" ]
 
-    PipelineSigningKeyIsARN:
+    PipelineSigningKMSKeyIsARN:
       !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
 
     HasKeyName:
@@ -1027,7 +1027,7 @@ Resources:
                       - CreatePipelineSigningKMSKey
                       - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                       - !If
-                        - PipelineSigningKeyIsARN
+                        - PipelineSigningKMSKeyIsARN
                         - !Ref PipelineSigningKMSKeyId
                         - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
           - !Ref 'AWS::NoValue'

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -638,7 +638,7 @@ Rules:
             - !Equals
               - !Ref PipelineSigningKMSKeySpec
               - "none"
-        AssertDescription: "You must provide either provide a PipelineSigningKMSKeyId, PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec but not both"
+        AssertDescription: "You must provide either a PipelineSigningKMSKeyId or PipelineSigningKMSKeyARN, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:
   VpcId:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -38,7 +38,6 @@ Metadata:
           default: Signed Pipelines Configuration
         Parameters:
         - PipelineSigningKMSKeyId
-        - PipelineSigningKMSKeyARN
         - PipelineSigningKMSKeySpec
         - PipelineSigningKMSAccess
         - PipelineSigningVerificationFailureBehavior
@@ -579,12 +578,7 @@ Parameters:
 
   PipelineSigningKMSKeyId:
     Type: String
-    Description: Optional - Identifier of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
-    Default: ""
-
-  PipelineSigningKMSKeyARN:
-    Type: String
-    Description: Optional - ARN of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
+    Description: Optional - Identifier or ARN of the KMS key used to sign and verify pipelines (created if both PipelineSigningKMSKeyId and PipelineSigningKMSKeyARN are left blank and PipelineSigningKMSKeySpec is selected)
     Default: ""
 
   PipelineSigningKMSKeySpec:


### PR DESCRIPTION
# Description

_(this is yet another approach to #1422 and #1424 - pick the one you prefer 😅)_

We have a use case where we want to have a single KMS key that Buildkite agents in multiple accounts can use to sign and verify pipeline steps. By letting the user specify the whole key ARN rather than just the key ID, the user is free to use a key wherever they want.

This third attempt has a different set of tradeoffs to the previous two:

* non-breaking change - this template will accept the same parameter as before, but the user can provide either the Key ID part or the full ARN, better than #1422's breaking change
* slightly less complex conditional and one less parameter - having to check that either-or Key ID or ARN are provided made #1424 a bit unwieldy

