### PR TITLE
Add EBS volume tag for BK queue, keep optional cost allocation tags

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1324,13 +1324,17 @@ Resources:
                   - Key: !Ref CostAllocationTagName
                     Value: !Ref CostAllocationTagValue
                   - !Ref "AWS::NoValue"
-            - !If
-              - UseCostAllocationTags
-              - ResourceType: volume
-                Tags:
+            - ResourceType: volume
+              Tags:
+                - Key: Name
+                  Value: !If [ UseStackNameForInstanceName, !Ref "AWS::StackName", !Ref InstanceName ]
+                - Key: BuildkiteQueue
+                  Value: !Ref BuildkiteQueue
+                - !If
+                  - UseCostAllocationTags
                   - Key: !Ref CostAllocationTagName
                     Value: !Ref CostAllocationTagValue
-              - !Ref "AWS::NoValue"
+                  - !Ref "AWS::NoValue"
 
           UserData:
             Fn::Base64: !If


### PR DESCRIPTION
Adds EBS volume tags for `Name` and `BuildkiteQueue` that match the attached instance name, while also keeping optional cost allocation tags.