### PR TITLE
Add support for InstanceBuffer

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -103,6 +103,7 @@ Metadata:
         Parameters:
         - MinSize
         - MaxSize
+        - InstanceBuffer
         - OnDemandPercentage
         - SpotAllocationStrategy
         - ScaleOutFactor
@@ -327,6 +328,11 @@ Parameters:
     Type: Number
     Default: 0
     MinValue: 0
+
+  InstanceBuffer:
+    Description: How many free instances to maintain
+    Type: Number
+    Default: "0"
 
   ScalerEventSchedulePeriod:
     Description: How often the Event Schedule for buildkite-agent-scaler is triggered. Should be an expression with units, e.g. "30 seconds", "1 minute", "5 minutes".
@@ -1620,6 +1626,7 @@ Resources:
         AgentsPerInstance: !Ref AgentsPerInstance
         MinSize: !Ref MinSize
         MaxSize: !Ref MaxSize
+        InstanceBuffer: !Ref InstanceBuffer
         AgentAutoScaleGroup: !Ref AgentAutoScaleGroup
         ScaleOutFactor: !Ref ScaleOutFactor
         ScaleOutForWaitingJobs: !Ref ScaleOutForWaitingJobs


### PR DESCRIPTION
Add a way to control the number of idle instances: https://github.com/buildkite/buildkite-agent-scaler/blob/61bab8e9318432ca0f89aa1c0dcbd80b8ec1d543/template.yaml#L57C1-L60C17

I guess documentation needs to be adjusted, unless autogenerated.