### PR TITLE
Revert "Merge pull request #1432 from blackliner/ec2-instance-connect"

### DIFF
--- a/.github/workflows/linear_issue_open.yml
+++ b/.github/workflows/linear_issue_open.yml
@@ -46,8 +46,8 @@ jobs:
               input: {
                 title: title,
                 description: `${body}\n\nOriginal ${isIssue ? 'Issue' : 'PR'}: ${url}`,
-                teamId: process.env.LINEAR_TEAM_ID,
-                labelIds: process.env.LINEAR_LABEL_IDS?.split(',')
+                teamId: `${process.env.LINEAR_TEAM_ID}`,
+                labelIds: `${process.env.LINEAR_LABEL_IDS?.split(',')}`
               }
             };
 

--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -16,7 +16,6 @@ sudo dnf install -yq \
   amazon-ssm-agent \
   aws-cfn-bootstrap \
   awscli-2 \
-  ec2-instance-connect \
   git \
   jq \
   mdadm \


### PR DESCRIPTION
## Changes
The addition of `ec2-instance-connect` seems to have changes the `gid` for Docker along the way, we should revert that change and test it locally instead to determine if we need to adjust a) test expected values, b) the `gid` given to one of those tools
