### PR TITLE
♻️ Ensures docker GID is 993 for tests

### DIFF
--- a/.github/workflows/linear_issue_open.yml
+++ b/.github/workflows/linear_issue_open.yml
@@ -47,7 +47,6 @@ jobs:
                 title: title,
                 description: `${body}\n\nOriginal ${isIssue ? 'Issue' : 'PR'}: ${url}`,
                 teamId: `${process.env.LINEAR_TEAM_ID}`,
-                labelIds: `${process.env.LINEAR_LABEL_IDS?.split(',')}`
               }
             };
 

--- a/.github/workflows/linear_issue_open.yml
+++ b/.github/workflows/linear_issue_open.yml
@@ -46,8 +46,8 @@ jobs:
               input: {
                 title: title,
                 description: `${body}\n\nOriginal ${isIssue ? 'Issue' : 'PR'}: ${url}`,
-                teamId: process.env.LINEAR_TEAM_ID,
-                labelIds: process.env.LINEAR_LABEL_IDS?.split(',')
+                teamId: `${process.env.LINEAR_TEAM_ID}`,
+                labelIds: `${process.env.LINEAR_LABEL_IDS?.split(',')}`
               }
             };
 

--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+## Ensure the `docker` group gets GID 993
+## Our GOSS testing seems to be reliant on this being the group used
+## so we should ensure that if we aren't willing to be more leniant
+sudo groupadd -g 993 docker || true
+
 case $(uname -m) in
 x86_64) ARCH=amd64 ;;
 aarch64) ARCH=arm64 ;;


### PR DESCRIPTION
## Changes
Our GOSS tests rely on `docker` being in GID 993; https://github.com/buildkite/elastic-ci-stack-for-aws/blob/9965c106699eb60d938f81c813e81b9456b6a181/goss.yaml#L104

However, if anything is installed in the `install-utils` script it can/will overwrite this by taking that group and causing test failures.

Now, in `install-utils` we first add a group, `docker` and give it GID 993, tests should now pass and we ensure additional tools cannot take that group.
