### PR TITLE
➖ Docker can be a range of GIDs

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -101,10 +101,6 @@ group:
 
   docker:
     exists: true
-    gid:
-      and:
-        gt: 989
-        lt: 996
 
   sshd:
     exists: true
@@ -217,3 +213,7 @@ command:
     timeout: 30000
     stdout:
     - x86_64
+
+  ## This allows us to support a range of group ids for the docker group, 990-995
+  'getent group docker | cut -d: -f3 | grep -E "^99[0-5]$"':
+    exit-status: 0

--- a/goss.yaml
+++ b/goss.yaml
@@ -42,12 +42,12 @@ port:
   tcp:22:
     listening: true
     ip:
-      - 0.0.0.0
+    - 0.0.0.0
 
   tcp6:22:
     listening: true
     ip:
-      - "::"
+    - "::"
 
 service:
   amazon-cloudwatch-agent:
@@ -80,8 +80,8 @@ user:
     uid: 2000
     gid: 2000
     groups:
-      - buildkite-agent
-      - docker
+    - buildkite-agent
+    - docker
     home: /var/lib/buildkite-agent
     shell: /bin/bash
 
@@ -90,7 +90,7 @@ user:
     uid: 74
     gid: 74
     groups:
-      - sshd
+    - sshd
     home: /usr/share/empty.sshd
     shell: /sbin/nologin
 
@@ -146,7 +146,7 @@ command:
   systemctl is-enabled refresh_authorized_keys.timer:
     exit-status: 1
     stdout:
-      - /disabled/
+    - /disabled/
 
   systemctl is-enabled proc-sys-fs-binfmt_misc.mount:
     exit-status: 0
@@ -178,7 +178,7 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-      - /,name=userns,/
+    - /,name=userns,/
 
   # Check docker plugins are installed
   # Note that goss will evaluate the first layer of templating, and docker will evaluate the second
@@ -187,8 +187,8 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-      - /,buildx,/
-      - /,compose,/
+    - /,buildx,/
+    - /,compose,/
 
   # Check that docker containers can run
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker:latest version:
@@ -200,19 +200,19 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-      - buildkite-agent:docker
+    - buildkite-agent:docker
 
   docker run --rm --platform linux/arm64 -t arm64v8/ubuntu uname -m:
     exit-status: 0
     timeout: 30000
     stdout:
-      - aarch64
+    - aarch64
 
   docker run --rm --platform linux/amd64 -t amd64/ubuntu uname -m:
     exit-status: 0
     timeout: 30000
     stdout:
-      - x86_64
+    - x86_64
 
   ## This allows us to support a range of group ids for the docker group, 990-995
   'getent group docker | cut -d: -f3 | grep -E "^99[0-5]$"':

--- a/goss.yaml
+++ b/goss.yaml
@@ -42,12 +42,12 @@ port:
   tcp:22:
     listening: true
     ip:
-    - 0.0.0.0
+      - 0.0.0.0
 
   tcp6:22:
     listening: true
     ip:
-    - '::'
+      - "::"
 
 service:
   amazon-cloudwatch-agent:
@@ -80,8 +80,8 @@ user:
     uid: 2000
     gid: 2000
     groups:
-    - buildkite-agent
-    - docker
+      - buildkite-agent
+      - docker
     home: /var/lib/buildkite-agent
     shell: /bin/bash
 
@@ -90,7 +90,7 @@ user:
     uid: 74
     gid: 74
     groups:
-    - sshd
+      - sshd
     home: /usr/share/empty.sshd
     shell: /sbin/nologin
 
@@ -101,7 +101,6 @@ group:
 
   docker:
     exists: true
-    gid: 993
 
   sshd:
     exists: true
@@ -147,7 +146,7 @@ command:
   systemctl is-enabled refresh_authorized_keys.timer:
     exit-status: 1
     stdout:
-    - /disabled/
+      - /disabled/
 
   systemctl is-enabled proc-sys-fs-binfmt_misc.mount:
     exit-status: 0
@@ -179,7 +178,7 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-    - /,name=userns,/
+      - /,name=userns,/
 
   # Check docker plugins are installed
   # Note that goss will evaluate the first layer of templating, and docker will evaluate the second
@@ -188,8 +187,8 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-    - /,buildx,/
-    - /,compose,/
+      - /,buildx,/
+      - /,compose,/
 
   # Check that docker containers can run
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker:latest version:
@@ -201,16 +200,20 @@ command:
     exit-status: 0
     timeout: 30000
     stdout:
-    - buildkite-agent:docker
+      - buildkite-agent:docker
 
   docker run --rm --platform linux/arm64 -t arm64v8/ubuntu uname -m:
     exit-status: 0
     timeout: 30000
     stdout:
-    - aarch64
+      - aarch64
 
   docker run --rm --platform linux/amd64 -t amd64/ubuntu uname -m:
     exit-status: 0
     timeout: 30000
     stdout:
-    - x86_64
+      - x86_64
+
+  ## This allows us to support a range of group ids for the docker group, 990-995
+  'getent group docker | cut -d: -f3 | grep -E "^99[0-5]$"':
+    exit-status: 0

--- a/goss.yaml
+++ b/goss.yaml
@@ -101,6 +101,10 @@ group:
 
   docker:
     exists: true
+    gid:
+      and:
+        gt: 989
+        lt: 996
 
   sshd:
     exists: true
@@ -213,7 +217,3 @@ command:
     timeout: 30000
     stdout:
     - x86_64
-
-  ## This allows us to support a range of group ids for the docker group, 990-995
-  'getent group docker | cut -d: -f3 | grep -E "^99[0-5]$"':
-    exit-status: 0


### PR DESCRIPTION
## Issue
We've seen builds where the order of installs from the `install-utils` script can impact the `gid` of the `docker` group, but we specify that `docker` must be in `993` in our GOSS test

https://github.com/buildkite/elastic-ci-stack-for-aws/blob/9965c106699eb60d938f81c813e81b9456b6a181/goss.yaml#L104

The install order in our instance [build](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/9965c106699eb60d938f81c813e81b9456b6a181/packer/linux/buildkite-ami.pkr.hcl#L84) can determine the GIDs that packages get; `install-utils` runs first, so `993` may be taken by the time we install Docker.

## Change
We allow the `docker` group to have a GID between `990` and `995`, inclusive. We could expand this, but it _feels_ like a fine range to start with given we aren't aiming to add lots of packages.
