### PR TITLE
Upgrade the agent scaler which introduces a new agent endpoint param

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -200,7 +200,7 @@ Parameters:
   BuildkiteAgentScalerVersion:
     Description: Version of the buildkite-agent-scaler to use
     Type: String
-    AllowedPattern: '^(?:([2-9]|[1-9][0-9]+)\.(?:\d+)\.(?:\d+)|1\.(?:([1-9][0-9]+|9[0-9]+)\.(?:\d+)|9\.(?:[1-9]|[1-9][0-9]+)))$'
+    AllowedPattern: '^(?:(?:[2-9]|[1-9]\d+)\.\d+\.\d+|1\.(?:[1-9]\d+\.\d+|9\.[1-9]\d*))$'
     ConstraintDescription: "The agent scaler release must be greater than 1.9.0 as a new parameter was introduced in 1.9.1"
     Default: "1.9.1"
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -200,7 +200,9 @@ Parameters:
   BuildkiteAgentScalerVersion:
     Description: Version of the buildkite-agent-scaler to use
     Type: String
-    Default: "1.8.0"
+    AllowedPattern: '^(?:([2-9]|[1-9][0-9]+)\.(?:\d+)\.(?:\d+)|1\.(?:([1-9][0-9]+|9[0-9]+)\.(?:\d+)|9\.(?:[1-9]|[1-9][0-9]+)))$'
+    ConstraintDescription: "The agent scaler release must be greater than 1.9.0 as a new parameter was introduced in 1.9.1"
+    Default: "1.9.1"
 
   LogRetentionDays:
     Type: Number
@@ -1616,6 +1618,7 @@ Resources:
         BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
         BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]
         RolePermissionsBoundaryARN: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, "" ]
+        AgentEndpoint: !Ref AgentEndpoint
         BuildkiteQueue: !Ref BuildkiteQueue
         AgentsPerInstance: !Ref AgentsPerInstance
         MinSize: !Ref MinSize


### PR DESCRIPTION
> [!WARNING]  
> This release will force an upgrade of the agent scaler by checking the version is 1.9.1 or higher. This is required so we can introduce a new parameter to the agent scaler to pass through agent endpoint.

This is an go based test which shows the regex works as intended, maybe helpful in the future.

```go
package semver

import (
	"regexp"
	"testing"
)

func isGreaterThan190(version string) bool {
	pattern := `^(?:(?:[2-9]|[1-9]\d+)\.\d+\.\d+|1\.(?:[1-9]\d+\.\d+|9\.[1-9]\d*))$`
	matched, _ := regexp.MatchString(pattern, version)
	return matched
}

func TestVersionValidation(t *testing.T) {
	tests := []struct {
		name        string
		version     string
		want        bool
		description string
	}{
		{
			name:        "equal_to_boundary",
			version:     "1.9.0",
			want:        false,
			description: "Equal to boundary version",
		},
		{
			name:        "just_above_boundary",
			version:     "1.9.1",
			want:        true,
			description: "Just above boundary version",
		},
		{
			name:        "above_boundary",
			version:     "1.9.2",
			want:        true,
			description: "Above boundary version",
		},
		{
			name:        "minor_version_increment",
			version:     "1.10.0",
			want:        true,
			description: "Minor version increment",
		},
		{
			name:        "major_version_increment",
			version:     "2.0.0",
			want:        true,
			description: "Major version increment",
		},
		{
			name:        "below_boundary",
			version:     "1.8.9",
			want:        false,
			description: "Below boundary version",
		},
		{
			name:        "lower_major_version",
			version:     "0.9.9",
			want:        false,
			description: "Lower major version",
		},
		{
			name:        "higher_major_version",
			version:     "2.9.1",
			want:        true,
			description: "Higher major version",
		},
		{
			name:        "double_digit_patch",
			version:     "1.9.10",
			want:        true,
			description: "Double digit patch version",
		},
		{
			name:        "double_digit_major",
			version:     "10.0.0",
			want:        true,
			description: "Double digit major version",
		},
	}

	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {
			got := isGreaterThan190(tt.version)
			if got != tt.want {
				t.Errorf("\nVersion: %v\nWant: %v\nGot: %v\nDescription: %v",
					tt.version, tt.want, got, tt.description)
			}
		})
	}
}
```

Results:

```
%  go test -v ./semver_test.go
=== RUN   TestVersionValidation
=== RUN   TestVersionValidation/equal_to_boundary
=== RUN   TestVersionValidation/just_above_boundary
=== RUN   TestVersionValidation/above_boundary
=== RUN   TestVersionValidation/minor_version_increment
=== RUN   TestVersionValidation/major_version_increment
=== RUN   TestVersionValidation/below_boundary
=== RUN   TestVersionValidation/lower_major_version
=== RUN   TestVersionValidation/higher_major_version
=== RUN   TestVersionValidation/double_digit_patch
=== RUN   TestVersionValidation/double_digit_major
--- PASS: TestVersionValidation (0.00s)
    --- PASS: TestVersionValidation/equal_to_boundary (0.00s)
    --- PASS: TestVersionValidation/just_above_boundary (0.00s)
    --- PASS: TestVersionValidation/above_boundary (0.00s)
    --- PASS: TestVersionValidation/minor_version_increment (0.00s)
    --- PASS: TestVersionValidation/major_version_increment (0.00s)
    --- PASS: TestVersionValidation/below_boundary (0.00s)
    --- PASS: TestVersionValidation/lower_major_version (0.00s)
    --- PASS: TestVersionValidation/higher_major_version (0.00s)
    --- PASS: TestVersionValidation/double_digit_patch (0.00s)
    --- PASS: TestVersionValidation/double_digit_major (0.00s)
PASS
ok      command-line-arguments  0.248s
```