### PR TITLE
🐛 Fix the teamID interpolation

### DIFF
--- a/.github/workflows/linear_issue_open.yml
+++ b/.github/workflows/linear_issue_open.yml
@@ -46,8 +46,7 @@ jobs:
               input: {
                 title: title,
                 description: `${body}\n\nOriginal ${isIssue ? 'Issue' : 'PR'}: ${url}`,
-                teamId: process.env.LINEAR_TEAM_ID,
-                labelIds: process.env.LINEAR_LABEL_IDS?.split(',')
+                teamId: `${process.env.LINEAR_TEAM_ID}`
               }
             };
 


### PR DESCRIPTION
## Changes
Wraps the teamId interpolation in backticks because Node likes that for strings
