### PR TITLE
fix: make sure buildkite-agent.service is not terminated by OOM

### DIFF
--- a/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -21,6 +21,10 @@ RestartForceExitStatus=SIGPIPE
 TimeoutStartSec=10
 TimeoutStopSec=0
 KillMode=process
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#OOMScoreAdjust=
+# Set to -1000 to disable OOM killing of processes of buildkite-agent service
+# managing EC2 instance lifecycle
+OOMScoreAdjust=-1000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/882

Set OOMScoreAdjust to -1000 preventing buildkite-agent processes from being terminated by OOM killer. 
https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#OOMScoreAdjust=