### PR TITLE
Add the option to recursively copy ssm parameters to an env file

### DIFF
--- a/packer/linux/conf/bin/bk-fetch.sh
+++ b/packer/linux/conf/bin/bk-fetch.sh
@@ -1,12 +1,65 @@
 #!/bin/bash
 set -euo pipefail
 
+# fetch_ssm_parameters fetches all SSM parameters under the given path and writes them to the given output file
+fetch_ssm_parameters() {
+  local ssm_path="$1"
+  local output_file="$2"
+
+  # check if the ssm_path is set
+  if [ -z "$ssm_path" ]; then
+    echo "ssm_path is not set"
+    return 1
+  fi
+
+  # check if the output_file is set
+  if [ -z "$output_file" ]; then
+    echo "output_file is not set"
+    return 1
+  fi
+
+  # trim off ssm: prefix
+  ssm_path=${ssm_path//ssm:/}
+
+  # Get all SSM parameter names under the given path
+  #
+  # NOTE: The maximum number of parameters that can be retrieved is 25 to avoid throttling
+  # in the case of misconfigured SSM path with a large number of child parameters
+  local ssm_parameter_names
+  ssm_parameter_names=$(aws ssm get-parameters-by-path \
+    --path "$ssm_path" \
+    --recursive \
+    --max-items 25 \
+    --with-decryption \
+    --query 'Parameters[].Name' \
+    --output text)
+
+  # Loop through each parameter and export it as an environment variable
+  for name in $ssm_parameter_names; do
+    local value
+    value=$(aws ssm get-parameter \
+      --name "$name" \
+      --with-decryption \
+      --query 'Parameter.Value' \
+      --output text)
+    if [ -n "$name" ] && [ -n "$value" ]; then
+      local var_name
+      var_name=$(echo "$name" | awk -F/ '{print toupper($NF)}')
+      echo "Exported variable: $var_name"
+      echo "$var_name=$value" >>"$output_file"
+    fi
+  done
+}
+
 FROM="$1"
 TO="$2"
 
 case "$FROM" in
 s3://*)
   exec aws s3 cp "$FROM" "$TO"
+  ;;
+ssm:*)
+  fetch_ssm_parameters "$FROM" "$TO"
   ;;
 *)
   exec curl -Lfs -o "$TO" "$FROM"

--- a/packer/linux/conf/bin/bk-fetch.sh
+++ b/packer/linux/conf/bin/bk-fetch.sh
@@ -7,48 +7,31 @@ fetch_ssm_parameters() {
   local output_file="$2"
 
   # check if the ssm_path is set
-  if [ -z "$ssm_path" ]; then
+  if [[ -z "${ssm_path}" ]]; then
     echo "ssm_path is not set"
     return 1
   fi
 
   # check if the output_file is set
-  if [ -z "$output_file" ]; then
+  if [[ -z "${output_file}" ]]; then
     echo "output_file is not set"
     return 1
   fi
 
   # trim off ssm: prefix
-  ssm_path=${ssm_path//ssm:/}
+  ssm_path="${ssm_path//ssm:/}"
 
-  # Get all SSM parameter names under the given path
   #
   # NOTE: The maximum number of parameters that can be retrieved is 25 to avoid throttling
   # in the case of misconfigured SSM path with a large number of child parameters
-  local ssm_parameter_names
-  ssm_parameter_names=$(aws ssm get-parameters-by-path \
-    --path "$ssm_path" \
+  aws ssm get-parameters-by-path \
+    --path "${ssm_path}" \
     --recursive \
     --max-items 25 \
     --with-decryption \
-    --query 'Parameters[].Name' \
-    --output text)
-
-  # Loop through each parameter and export it as an environment variable
-  for name in $ssm_parameter_names; do
-    local value
-    value=$(aws ssm get-parameter \
-      --name "$name" \
-      --with-decryption \
-      --query 'Parameter.Value' \
-      --output text)
-    if [ -n "$name" ] && [ -n "$value" ]; then
-      local var_name
-      var_name=$(echo "$name" | awk -F/ '{print toupper($NF)}')
-      echo "Exported variable: $var_name"
-      echo "$var_name=$value" >>"$output_file"
-    fi
-  done
+    --query 'Parameters[*].{Name: Name, Value: Value}' --output json \
+    | jq -r '.[] | [(.Name | split("/")[-1] | ascii_upcase), (["\"", .Value, "\""] | join(""))] | join("=")' \
+      >"${output_file}"
 }
 
 FROM="$1"
@@ -59,7 +42,7 @@ s3://*)
   exec aws s3 cp "$FROM" "$TO"
   ;;
 ssm:*)
-  fetch_ssm_parameters "$FROM" "$TO"
+  fetch_ssm_parameters "${FROM}" "${TO}"
   ;;
 *)
   exec curl -Lfs -o "$TO" "$FROM"


### PR DESCRIPTION
To enable migration of configuration from s3 to AWS SSM parameter store, this change introduces the option to provide a path which is exported to an env file via https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/packer/linux/conf/bin/bk-install-elastic-stack.sh#L301

The path is prefixed with `ssm:` to align with the current structure, note isn't a proper URL as using one would be confusing when the convention for SSM parameter store is to start the path with a `/`.

This is used in the agents systemd service https://github.com/buildkite/elastic-ci-stack-for-aws/blob/main/packer/linux/conf/buildkite-agent/systemd/buildkite-agent.service#L15.

As an example we have the configuration for open telemetry in parameter store `ssm:/config/elastic-stack-otel/buildkite_tracing_backend` will be mapped as follows with their respective values in an `env` file.

| Path | environment variable |
|--------------------|--------|
| /config/elastic-stack-otel/buildkite_tracing_backend | BUILDKITE_TRACING_BACKEND |
| /config/elastic-stack-otel/otel_service_name | OTEL_SERVICE_NAME |
| /config/elastic-stack-otel/otel_exporter_otlp_protocol | OTEL_EXPORTER_OTLP_PROTOCOL |
| /config/elastic-stack-otel/otel_exporter_otlp_endpoint | OTEL_EXPORTER_OTLP_ENDPOINT |
| /config/elastic-stack-otel/otel_exporter_otlp_headers | OTEL_EXPORTER_OTLP_HEADERS |

> [!NOTE]
> I have set the maximum items returned to 25 to avoid throttling in the cases were the path configured has a large number of child values. 