### PR TITLE
Enforces IMDSv2 support on the running instance being provisioned by Packer

### DIFF
--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -59,6 +59,13 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   ssh_clear_authorized_keys = true
   temporary_security_group_source_public_ip = true
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "required"
+    http_put_response_hop_limit = 1
+  }
+  imds_support  = "v2.0"
+
   launch_block_device_mappings {
     volume_type           = "gp3"
     device_name           = "/dev/xvda"


### PR DESCRIPTION
This PR changes the provisioned instance (by the Packer) to be IMDSv2 required, instead of IMDSv2 optional.

Related links:

- https://github.com/hashicorp/packer-plugin-amazon/issues/310
- https://github.com/hashicorp/packer-plugin-amazon/pull/346
