### PR TITLE
Bump Go to 1.23

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   fixperms-tests:
-    image: golang:1.22
+    image: golang:1.23-alpine
     working_dir: /code
     environment:
       CGO_ENABLED: 0

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   fixperms-tests:
-    image: golang:1.23-alpine
+    image: golang:1.23
     working_dir: /code
     environment:
       CGO_ENABLED: 0

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PACKER_VERSION ?= 1.11.2
 PACKER_LINUX_FILES = $(exec find packer/linux)
 PACKER_WINDOWS_FILES = $(exec find packer/windows)
 
-GO_VERSION ?= 1.22
+GO_VERSION ?= 1.23
 
 FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/elastic-ci-stack-for-aws/v6
 
-go 1.22
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Changes

- Bumps the base `go` version in `go.mod` to `1.23`
- Increments the same in the Makefile
- Uses `golang:1.23` in the fixperms tests image in the `compose` file
    - TIL that `-alpine` versions don't have `/usr/bin/cp` installed
