### PR TITLE
Add a param for signal grace period

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -29,113 +29,114 @@ Metadata:
       - Label:
           default: Base Configuration
         Parameters:
-        - BuildkiteAgentToken
-        - BuildkiteAgentTokenParameterStorePath
-        - BuildkiteAgentTokenParameterStoreKMSKey
-        - BuildkiteQueue
-        - AgentEndpoint
+          - BuildkiteAgentToken
+          - BuildkiteAgentTokenParameterStorePath
+          - BuildkiteAgentTokenParameterStoreKMSKey
+          - BuildkiteQueue
+          - AgentEndpoint
 
       - Label:
           default: Signed Pipelines Configuration
         Parameters:
-        - PipelineSigningKMSKeyId
-        - PipelineSigningKMSKeySpec
-        - PipelineSigningKMSAccess
-        - PipelineSigningVerificationFailureBehavior
+          - PipelineSigningKMSKeyId
+          - PipelineSigningKMSKeySpec
+          - PipelineSigningKMSAccess
+          - PipelineSigningVerificationFailureBehavior
 
       - Label:
           default: Advanced Configuration
         Parameters:
-        - BuildkiteAgentRelease
-        - BuildkiteAgentTags
-        - BuildkiteAgentTimestampLines
-        - BuildkiteAgentExperiments
-        - BuildkiteAgentEnableGitMirrors
-        - BuildkiteAgentTracingBackend
-        - BuildkiteAgentCancelGracePeriod
-        - BuildkiteTerminateInstanceAfterJob
-        - BuildkiteAdditionalSudoPermissions
-        - BuildkiteWindowsAdministrator
-        - BuildkiteAgentScalerServerlessARN
-        - BuildkiteAgentScalerVersion
-        - LogRetentionDays
+          - BuildkiteAgentRelease
+          - BuildkiteAgentTags
+          - BuildkiteAgentTimestampLines
+          - BuildkiteAgentExperiments
+          - BuildkiteAgentEnableGitMirrors
+          - BuildkiteAgentTracingBackend
+          - BuildkiteAgentCancelGracePeriod
+          - BuildkiteAgentSignalGracePeriod
+          - BuildkiteTerminateInstanceAfterJob
+          - BuildkiteAdditionalSudoPermissions
+          - BuildkiteWindowsAdministrator
+          - BuildkiteAgentScalerServerlessARN
+          - BuildkiteAgentScalerVersion
+          - LogRetentionDays
 
       - Label:
           default: Network Configuration
         Parameters:
-        - VpcId
-        - Subnets
-        - AvailabilityZones
-        - SecurityGroupIds
-        - AssociatePublicIpAddress
+          - VpcId
+          - Subnets
+          - AvailabilityZones
+          - SecurityGroupIds
+          - AssociatePublicIpAddress
 
       - Label:
           default: Instance Configuration
         Parameters:
-        - ImageId
-        - ImageIdParameter
-        - InstanceOperatingSystem
-        - InstanceTypes
-        - EnableInstanceStorage
-        - MountTmpfsAtTmp
-        - AgentsPerInstance
-        - KeyName
-        - SecretsBucket
-        - SecretsBucketRegion
-        - SecretsBucketEncryption
-        - ArtifactsBucket
-        - AuthorizedUsersUrl
-        - BootstrapScriptUrl
-        - AgentEnvFileUrl
-        - RootVolumeSize
-        - RootVolumeName
-        - RootVolumeType
-        - RootVolumeEncrypted
-        - ManagedPolicyARNs
-        - InstanceRoleName
-        - InstanceRolePermissionsBoundaryARN
-        - IMDSv2Tokens
-        - EnableDetailedMonitoring
-        - InstanceName
+          - ImageId
+          - ImageIdParameter
+          - InstanceOperatingSystem
+          - InstanceTypes
+          - EnableInstanceStorage
+          - MountTmpfsAtTmp
+          - AgentsPerInstance
+          - KeyName
+          - SecretsBucket
+          - SecretsBucketRegion
+          - SecretsBucketEncryption
+          - ArtifactsBucket
+          - AuthorizedUsersUrl
+          - BootstrapScriptUrl
+          - AgentEnvFileUrl
+          - RootVolumeSize
+          - RootVolumeName
+          - RootVolumeType
+          - RootVolumeEncrypted
+          - ManagedPolicyARNs
+          - InstanceRoleName
+          - InstanceRolePermissionsBoundaryARN
+          - IMDSv2Tokens
+          - EnableDetailedMonitoring
+          - InstanceName
 
       - Label:
           default: Auto-scaling Configuration
         Parameters:
-        - MinSize
-        - MaxSize
-        - OnDemandPercentage
-        - SpotAllocationStrategy
-        - ScaleOutFactor
-        - ScaleInIdlePeriod
-        - ScaleOutForWaitingJobs
-        - InstanceCreationTimeout
-        - ScalerEventSchedulePeriod
-        - ScalerMinPollInterval
+          - MinSize
+          - MaxSize
+          - OnDemandPercentage
+          - SpotAllocationStrategy
+          - ScaleOutFactor
+          - ScaleInIdlePeriod
+          - ScaleOutForWaitingJobs
+          - InstanceCreationTimeout
+          - ScalerEventSchedulePeriod
+          - ScalerMinPollInterval
 
       - Label:
           default: Cost Allocation Configuration
         Parameters:
-        - EnableCostAllocationTags
-        - CostAllocationTagName
-        - CostAllocationTagValue
+          - EnableCostAllocationTags
+          - CostAllocationTagName
+          - CostAllocationTagValue
 
       - Label:
           default: Docker Daemon Configuration
         Parameters:
-        - EnableDockerUserNamespaceRemap
-        - EnableDockerExperimental
+          - EnableDockerUserNamespaceRemap
+          - EnableDockerExperimental
 
       - Label:
           default: Docker Registry Configuration
         Parameters:
-        - ECRAccessPolicy
+          - ECRAccessPolicy
 
       - Label:
           default: Plugin Configuration
         Parameters:
-        - EnableSecretsPlugin
-        - EnableECRPlugin
-        - EnableDockerLoginPlugin
+          - EnableSecretsPlugin
+          - EnableECRPlugin
+          - EnableDockerLoginPlugin
 
 Parameters:
   KeyName:
@@ -223,6 +224,12 @@ Parameters:
     Type: Number
     Default: 60
     MinValue: 1
+
+  BuildkiteAgentSignalGracePeriod:
+    Description: The number of seconds given to a subprocess to handle being sent `cancel-signal`. After this period has elapsed, SIGKILL will be sent.
+    Type: Number
+    Default: -1
+    MinValue: -1
 
   BuildkiteTerminateInstanceAfterJob:
     Description: Set to "true" to terminate the instance after a job has completed.
@@ -616,295 +623,1236 @@ Parameters:
 Rules:
   HasToken:
     Assertions:
-      - Assert:
-          !Or
-            - !Not
-              - !Equals
-                - !Ref BuildkiteAgentToken
-                - ""
-            - !Not
-              - !Equals
-                - !Ref BuildkiteAgentTokenParameterStorePath
-                - ""
+      - Assert: !Or
+          - !Not
+            - !Equals
+              - !Ref BuildkiteAgentToken
+              - ""
+          - !Not
+            - !Equals
+              - !Ref BuildkiteAgentTokenParameterStorePath
+              - ""
         AssertDescription: "You must provide BuildkiteAgentToken or BuildkiteAgentTokenParameterStorePath"
   HasPipelineSigningKMSKey:
     Assertions:
-      - Assert:
-          !Or
-            - !Equals
-              - !Ref PipelineSigningKMSKeyId
-              - ""
-            - !Equals
-              - !Ref PipelineSigningKMSKeySpec
-              - "none"
+      - Assert: !Or
+          - !Equals
+            - !Ref PipelineSigningKMSKeyId
+            - ""
+          - !Equals
+            - !Ref PipelineSigningKMSKeySpec
+            - "none"
         AssertDescription: "You must provide either a PipelineSigningKMSKeyId, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:
   VpcId:
-    Value:
-      !If [ CreateVpcResources, !Ref Vpc, !Ref VpcId ]
+    Value: !If [CreateVpcResources, !Ref Vpc, !Ref VpcId]
     Export:
-      Name: !Sub '${AWS::StackName}-VpcId'
+      Name: !Sub "${AWS::StackName}-VpcId"
 
   ManagedSecretsBucket:
-    Value:
-      !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, "Undefined" ]
+    Value: !If [CreateSecretsBucket, !Ref ManagedSecretsBucket, "Undefined"]
     Export:
-      Name: !Sub '${AWS::StackName}-ManagedSecretsBucket'
+      Name: !Sub "${AWS::StackName}-ManagedSecretsBucket"
 
   ManagedSecretsLoggingBucket:
     Value:
-      !If [ CreateSecretsBucket, !Ref ManagedSecretsLoggingBucket, "Undefined" ]
+      !If [CreateSecretsBucket, !Ref ManagedSecretsLoggingBucket, "Undefined"]
     Export:
-      Name: !Sub '${AWS::StackName}-ManagedSecretsLoggingBucket'
+      Name: !Sub "${AWS::StackName}-ManagedSecretsLoggingBucket"
 
   PipelineSigningKMSKey:
-    Value:
-      !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, "none" ]
+    Value: !If [CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, "none"]
     Export:
-      Name: !Sub '${AWS::StackName}-PipelineSigningKMSKey'
+      Name: !Sub "${AWS::StackName}-PipelineSigningKMSKey"
 
   AutoScalingGroupName:
     Value: !Ref AgentAutoScaleGroup
     Export:
-      Name: !Sub '${AWS::StackName}-AutoScalingGroupName'
+      Name: !Sub "${AWS::StackName}-AutoScalingGroupName"
 
   InstanceRoleName:
     Value: !Ref IAMRole
     Export:
-      Name: !Sub '${AWS::StackName}-InstanceRoleName'
+      Name: !Sub "${AWS::StackName}-InstanceRoleName"
 
 Conditions:
-    CreateVpcResources:
-      !Equals [ !Ref VpcId, "" ]
+  CreateVpcResources: !Equals [!Ref VpcId, ""]
 
-    CreateSecurityGroup:
-      !Equals [ !Ref SecurityGroupIds, "" ]
+  CreateSecurityGroup: !Equals [!Ref SecurityGroupIds, ""]
 
-    CreateSecretsBucket:
-      !And
-         - !Equals [ !Ref EnableSecretsPlugin, "true"]
-         - !Equals [ !Ref SecretsBucket, "" ]
+  CreateSecretsBucket: !And
+    - !Equals [!Ref EnableSecretsPlugin, "true"]
+    - !Equals [!Ref SecretsBucket, ""]
 
-    EnforceSecretsBucketEncryption:
-      !And
-         - !Condition CreateSecretsBucket
-         - !Equals [ !Ref SecretsBucketEncryption, "true"]
+  EnforceSecretsBucketEncryption: !And
+    - !Condition CreateSecretsBucket
+    - !Equals [!Ref SecretsBucketEncryption, "true"]
 
-    SetInstanceRoleName:
-      !Not [ !Equals [ !Ref InstanceRoleName, "" ] ]
+  SetInstanceRoleName: !Not [!Equals [!Ref InstanceRoleName, ""]]
 
-    SetInstanceRolePermissionsBoundaryARN:
-      !Not [ !Equals [ !Ref InstanceRolePermissionsBoundaryARN, "" ] ]
+  SetInstanceRolePermissionsBoundaryARN:
+    !Not [!Equals [!Ref InstanceRolePermissionsBoundaryARN, ""]]
 
-    UseSpecifiedSecretsBucket:
-      !Not [ !Equals [ !Ref SecretsBucket, "" ] ]
+  UseSpecifiedSecretsBucket: !Not [!Equals [!Ref SecretsBucket, ""]]
 
-    HasSecretsBucket:
-      !Or [ !Condition CreateSecretsBucket, !Condition UseSpecifiedSecretsBucket ]
+  HasSecretsBucket:
+    !Or [!Condition CreateSecretsBucket, !Condition UseSpecifiedSecretsBucket]
 
-    UseSpecifiedAvailabilityZones:
-      !Not [ !Equals [ !Join [ "", !Ref AvailabilityZones ], "" ]  ]
+  UseSpecifiedAvailabilityZones:
+    !Not [!Equals [!Join ["", !Ref AvailabilityZones], ""]]
 
-    UseArtifactsBucket:
-      !Not [ !Equals [ !Ref ArtifactsBucket, "" ] ]
+  UseArtifactsBucket: !Not [!Equals [!Ref ArtifactsBucket, ""]]
 
-    HasImageId:
-      !Not [ !Equals [ !Ref ImageId, "" ] ]
-    HasImageIdParameter:
-      !Not [ !Equals [ !Ref ImageIdParameter, "" ] ]
+  HasImageId: !Not [!Equals [!Ref ImageId, ""]]
+  HasImageIdParameter: !Not [!Equals [!Ref ImageIdParameter, ""]]
 
-    UseDefaultInstanceCreationTimeout:
-      !Equals [ !Ref InstanceCreationTimeout, "" ]
+  UseDefaultInstanceCreationTimeout: !Equals [!Ref InstanceCreationTimeout, ""]
 
-    UseDefaultRootVolumeName:
-      !Equals [ !Ref RootVolumeName, "" ]
+  UseDefaultRootVolumeName: !Equals [!Ref RootVolumeName, ""]
 
-    UseInstanceType2:
-      !Not [ !Equals [ !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType2:
+    !Not [
+      !Equals [
+        !Select [
+          "1",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType3:
-      !Not [ !Equals [ !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType3:
+    !Not [
+      !Equals [
+        !Select [
+          "2",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType4:
-      !Not [ !Equals [ !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType4:
+    !Not [
+      !Equals [
+        !Select [
+          "3",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType5:
-      !Not [ !Equals [ !Select [ "4", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType5:
+    !Not [
+      !Equals [
+        !Select [
+          "4",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType6:
-      !Not [ !Equals [ !Select [ "5", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType6:
+    !Not [
+      !Equals [
+        !Select [
+          "5",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType7:
-      !Not [ !Equals [ !Select [ "6", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType7:
+    !Not [
+      !Equals [
+        !Select [
+          "6",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType8:
-      !Not [ !Equals [ !Select [ "7", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType8:
+    !Not [
+      !Equals [
+        !Select [
+          "7",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType9:
-      !Not [ !Equals [ !Select [ "8", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType9:
+    !Not [
+      !Equals [
+        !Select [
+          "8",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType10:
-      !Not [ !Equals [ !Select [ "9", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType10:
+    !Not [
+      !Equals [
+        !Select [
+          "9",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType11:
-      !Not [ !Equals [ !Select [ "10", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType11:
+    !Not [
+      !Equals [
+        !Select [
+          "10",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType12:
-      !Not [ !Equals [ !Select [ "11", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
-    
-    UseInstanceType13:
-      !Not [ !Equals [ !Select [ "12", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType12:
+    !Not [
+      !Equals [
+        !Select [
+          "11",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType14:
-      !Not [ !Equals [ !Select [ "13", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
-    
-    UseInstanceType15:
-      !Not [ !Equals [ !Select [ "14", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType13:
+    !Not [
+      !Equals [
+        !Select [
+          "12",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType16:
-      !Not [ !Equals [ !Select [ "15", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType14:
+    !Not [
+      !Equals [
+        !Select [
+          "13",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType17:
-      !Not [ !Equals [ !Select [ "16", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
-    
-    UseInstanceType18:
-      !Not [ !Equals [ !Select [ "17", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
-    
-    UseInstanceType19:
-      !Not [ !Equals [ !Select [ "18", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
-    
-    UseInstanceType20:
-      !Not [ !Equals [ !Select [ "19", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType15:
+    !Not [
+      !Equals [
+        !Select [
+          "14",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType21:
-      !Not [ !Equals [ !Select [ "20", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType16:
+    !Not [
+      !Equals [
+        !Select [
+          "15",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType22:
-      !Not [ !Equals [ !Select [ "21", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType17:
+    !Not [
+      !Equals [
+        !Select [
+          "16",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType23:
-      !Not [ !Equals [ !Select [ "22", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
-    
-    UseInstanceType24:
-      !Not [ !Equals [ !Select [ "23", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType18:
+    !Not [
+      !Equals [
+        !Select [
+          "17",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseInstanceType25:
-      !Not [ !Equals [ !Select [ "24", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+  UseInstanceType19:
+    !Not [
+      !Equals [
+        !Select [
+          "18",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseManagedPolicyARN:
-      !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARNs ], "" ] ]
+  UseInstanceType20:
+    !Not [
+      !Equals [
+        !Select [
+          "19",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseECR:
-      !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
+  UseInstanceType21:
+    !Not [
+      !Equals [
+        !Select [
+          "20",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseCustomerManagedParameterPath:
-      !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
-    UseCustomerManagedKeyForParameterStore:
-      !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ] ]
-    CreateAgentTokenParameter:
-      !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ]
+  UseInstanceType22:
+    !Not [
+      !Equals [
+        !Select [
+          "21",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    HasVariableSize:
-      !Not [ !Equals [ !Ref MaxSize, !Ref MinSize ] ]
+  UseInstanceType23:
+    !Not [
+      !Equals [
+        !Select [
+          "22",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UseCostAllocationTags:
-      !Equals [ !Ref EnableCostAllocationTags, "true" ]
+  UseInstanceType24:
+    !Not [
+      !Equals [
+        !Select [
+          "23",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    UsePipelineSigningKMSKey:
-      !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
+  UseInstanceType25:
+    !Not [
+      !Equals [
+        !Select [
+          "24",
+          !Split [
+            ",",
+            !Join [
+              ",",
+              [
+                !Ref InstanceTypes,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+              ],
+            ],
+          ],
+        ],
+        "",
+      ],
+    ]
 
-    CreatePipelineSigningKMSKey:
-      !And
-      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
-      - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
+  UseManagedPolicyARN: !Not [!Equals [!Join ["", !Ref ManagedPolicyARNs], ""]]
 
-    HasPipelineSigningKMSKey:
-      !Or [ !Condition CreatePipelineSigningKMSKey, !Condition UsePipelineSigningKMSKey ]
+  UseECR: !Not [!Equals [!Ref ECRAccessPolicy, "none"]]
 
-    HasSigningKMSAccessSignAndVerify:
-      !Equals [ !Ref PipelineSigningKMSAccess, "sign-and-verify" ]
+  UseCustomerManagedParameterPath:
+    !Not [!Equals [!Ref BuildkiteAgentTokenParameterStorePath, ""]]
+  UseCustomerManagedKeyForParameterStore:
+    !Not [!Equals [!Ref BuildkiteAgentTokenParameterStoreKMSKey, ""]]
+  CreateAgentTokenParameter:
+    !Equals [!Ref BuildkiteAgentTokenParameterStorePath, ""]
 
-    PipelineSigningKMSKeyIsARN:
-      !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
+  HasVariableSize: !Not [!Equals [!Ref MaxSize, !Ref MinSize]]
 
-    HasKeyName:
-      !Not [ !Equals [ !Ref KeyName, "" ] ]
+  UseCostAllocationTags: !Equals [!Ref EnableCostAllocationTags, "true"]
 
-    EnableSshIngress:
-      !And
-        - { Condition : CreateSecurityGroup }
-        # Enable ingress if a key can be specified another way
-        - !Or
-          - { Condition: HasKeyName }
-          - !Not [ !Equals [ !Ref AuthorizedUsersUrl, "" ] ]
+  UsePipelineSigningKMSKey: !Not [!Equals [!Ref PipelineSigningKMSKeyId, ""]]
 
-    # Whether or not there's any managed polices to attach
-    HasManagedPolicies:
-      !Or [ { Condition: UseManagedPolicyARN }, { Condition: UseECR } ]
+  CreatePipelineSigningKMSKey: !And
+    - !Equals [!Ref PipelineSigningKMSKeyId, ""]
+    - !Not [!Equals [!Ref PipelineSigningKMSKeySpec, "none"]]
 
-    UseWindowsAgents:
-      !Equals [ !Ref InstanceOperatingSystem, "windows" ]
+  HasPipelineSigningKMSKey:
+    !Or [
+      !Condition CreatePipelineSigningKMSKey,
+      !Condition UsePipelineSigningKMSKey,
+    ]
 
-    UseLinuxAgents:
-      !Equals [ !Ref InstanceOperatingSystem, "linux" ]
+  HasSigningKMSAccessSignAndVerify:
+    !Equals [!Ref PipelineSigningKMSAccess, "sign-and-verify"]
 
-    # Unfortunately, Cloudformation's !Or intrinsic function only accepts
-    # between 2 and 10 arguments.  To get around this, we're grouping the
-    # instance families in sub-conditionals.  At least this doesn't force us
-    # into using a Custom Resource.
-    UsingArmInstances:
-      !Or
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "a1" ]
-        - !Or
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c6g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c6gd" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c6gn" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7gd" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7gn" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c8g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "g5g" ]
-        - !Or
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "i4g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "Im4gn" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "Is4gen" ]
-        - !Or
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m6g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m6gd" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m7g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m7gd" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m8g" ]
-        - !Or
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6gd" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r7g" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r7gd" ]
-          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r8g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "t4g" ]
-        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "x2gd" ]
+  PipelineSigningKMSKeyIsARN:
+    !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
 
-    UseStackNameForInstanceName:
-      !Equals [ !Ref InstanceName, "" ]
+  HasKeyName: !Not [!Equals [!Ref KeyName, ""]]
 
-    IsRootVolumeIsGp3:
-      !Equals [ !Ref RootVolumeType, "gp3" ]
+  EnableSshIngress: !And
+    - { Condition: CreateSecurityGroup }
+    # Enable ingress if a key can be specified another way
+    - !Or
+      - { Condition: HasKeyName }
+      - !Not [!Equals [!Ref AuthorizedUsersUrl, ""]]
 
-    IsRootVolumeIsIo1OrIo2OrGp3:
-      !Or
-        - !Equals [ !Ref RootVolumeType, "io1" ]
-        - !Equals [ !Ref RootVolumeType, "io2" ]
-        - !Equals [ !Ref RootVolumeType, "gp3" ]
+  # Whether or not there's any managed polices to attach
+  HasManagedPolicies:
+    !Or [{ Condition: UseManagedPolicyARN }, { Condition: UseECR }]
+
+  UseWindowsAgents: !Equals [!Ref InstanceOperatingSystem, "windows"]
+
+  UseLinuxAgents: !Equals [!Ref InstanceOperatingSystem, "linux"]
+
+  # Unfortunately, Cloudformation's !Or intrinsic function only accepts
+  # between 2 and 10 arguments.  To get around this, we're grouping the
+  # instance families in sub-conditionals.  At least this doesn't force us
+  # into using a Custom Resource.
+  UsingArmInstances: !Or
+    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "a1"]
+    - !Or
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c6g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c6gd"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c6gn"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c7g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c7gd"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c7gn"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c8g"]
+    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "g5g"]
+    - !Or
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "i4g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "Im4gn"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "Is4gen"]
+    - !Or
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m6g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m6gd"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m7g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m7gd"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m8g"]
+    - !Or
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r6g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r6gd"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r7g"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r7gd"]
+      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r8g"]
+    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "t4g"]
+    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "x2gd"]
+
+  UseStackNameForInstanceName: !Equals [!Ref InstanceName, ""]
+
+  IsRootVolumeIsGp3: !Equals [!Ref RootVolumeType, "gp3"]
+
+  IsRootVolumeIsIo1OrIo2OrGp3: !Or
+    - !Equals [!Ref RootVolumeType, "io1"]
+    - !Equals [!Ref RootVolumeType, "io2"]
+    - !Equals [!Ref RootVolumeType, "gp3"]
 
 Mappings:
   ECRManagedPolicy:
-    none      : { Policy: '' }
-    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
-    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
-    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
+    none: { Policy: "" }
+    readonly:
+      { Policy: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly" }
+    poweruser:
+      { Policy: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser" }
+    full:
+      { Policy: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess" }
 
   # Generated from Makefile via build/mappings.yml
-  AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId }
+  AWSRegion2AMI:
+    {
+      linuxamd64: !Ref ImageId,
+      linuxarm64: !Ref ImageId,
+      windows: !Ref ImageId,
+    }
 
 Resources:
   Vpc:
@@ -915,7 +1863,7 @@ Resources:
       InstanceTenancy: default
       Tags:
         - Key: Name
-          Value: !Ref 'AWS::StackName'
+          Value: !Ref "AWS::StackName"
 
   Gateway:
     Type: AWS::EC2::InternetGateway
@@ -923,7 +1871,7 @@ Resources:
     Properties:
       Tags:
         - Key: Name
-          Value: !Ref 'AWS::StackName'
+          Value: !Ref "AWS::StackName"
 
   GatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -938,16 +1886,15 @@ Resources:
     DependsOn:
       - GatewayAttachment
     Properties:
-      AvailabilityZone:
-        !If
-          - "UseSpecifiedAvailabilityZones"
-          - !Select [ 0, !Ref AvailabilityZones ]
-          - !Select [ 0, !GetAZs '' ]
+      AvailabilityZone: !If
+        - "UseSpecifiedAvailabilityZones"
+        - !Select [0, !Ref AvailabilityZones]
+        - !Select [0, !GetAZs ""]
       CidrBlock: 10.0.1.0/24
       VpcId: !Ref Vpc
       Tags:
         - Key: Name
-          Value: !Ref 'AWS::StackName'
+          Value: !Ref "AWS::StackName"
 
   Subnet1:
     Type: AWS::EC2::Subnet
@@ -955,16 +1902,15 @@ Resources:
     DependsOn:
       - GatewayAttachment
     Properties:
-      AvailabilityZone:
-        !If
-          - "UseSpecifiedAvailabilityZones"
-          - !Select [ 1, !Ref AvailabilityZones ]
-          - !Select [ 1, !GetAZs '' ]
+      AvailabilityZone: !If
+        - "UseSpecifiedAvailabilityZones"
+        - !Select [1, !Ref AvailabilityZones]
+        - !Select [1, !GetAZs ""]
       CidrBlock: 10.0.2.0/24
       VpcId: !Ref Vpc
       Tags:
         - Key: Name
-          Value: !Ref 'AWS::StackName'
+          Value: !Ref "AWS::StackName"
 
   Routes:
     Type: AWS::EC2::RouteTable
@@ -973,7 +1919,7 @@ Resources:
       VpcId: !Ref Vpc
       Tags:
         - Key: Name
-          Value: !Ref 'AWS::StackName'
+          Value: !Ref "AWS::StackName"
 
   RouteDefault:
     Type: AWS::EC2::Route
@@ -1006,7 +1952,7 @@ Resources:
     Metadata:
       VpcResources: !If
         - CreateVpcResources
-        - [ !Ref RouteDefault, !Ref Subnet0Routes, !Ref Subnet1Routes ]
+        - [!Ref RouteDefault, !Ref Subnet0Routes, !Ref Subnet1Routes]
         - !Ref "AWS::NoValue"
 
   BuildkiteAgentTokenParameter:
@@ -1027,89 +1973,101 @@ Resources:
       KeyUsage: SIGN_VERIFY
       Tags:
         - Key: Name
-          Value: !Sub '${AWS::StackName}-PipelineSigningKey'
+          Value: !Sub "${AWS::StackName}-PipelineSigningKey"
 
   # Allow ec2 instances to assume a role and be granted the IAMPolicies
   IAMInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
-      Roles: [ !Ref IAMRole ]
+      Roles: [!Ref IAMRole]
 
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !If [ SetInstanceRoleName, !Ref InstanceRoleName, !Sub "${AWS::StackName}-Role" ]
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
+      RoleName:
+        !If [
+          SetInstanceRoleName,
+          !Ref InstanceRoleName,
+          !Sub "${AWS::StackName}-Role",
+        ]
+      PermissionsBoundary:
+        !If [
+          SetInstanceRolePermissionsBoundaryARN,
+          !Ref InstanceRolePermissionsBoundaryARN,
+          !Ref "AWS::NoValue",
+        ]
       ManagedPolicyArns: !If
-          - HasManagedPolicies
-          # Support multiple policies to attach by merging the values together and splitting on ','
-          - !Split
-            - ','
-            # Join will skip over AWS::NoValue values
-            - !Join
-             - ','
-             - - !If
-                 - UseECR
-                 - !FindInMap [ ECRManagedPolicy, !Ref ECRAccessPolicy, 'Policy' ]
-                 - !Ref 'AWS::NoValue'
-               # This may support multiple values of its own (separated by commas)
-               - !If
-                 - UseManagedPolicyARN
-                 - !Join [ ',', !Ref ManagedPolicyARNs ]
-                 - !Ref 'AWS::NoValue'
-          - !Ref 'AWS::NoValue'
+        - HasManagedPolicies
+        # Support multiple policies to attach by merging the values together and splitting on ','
+        - !Split
+          - ","
+          # Join will skip over AWS::NoValue values
+          - !Join
+            - ","
+            - - !If
+                - UseECR
+                - !FindInMap [ECRManagedPolicy, !Ref ECRAccessPolicy, "Policy"]
+                - !Ref "AWS::NoValue"
+              # This may support multiple values of its own (separated by commas)
+              - !If
+                - UseManagedPolicyARN
+                - !Join [",", !Ref ManagedPolicyARNs]
+                - !Ref "AWS::NoValue"
+        - !Ref "AWS::NoValue"
       Policies:
         - !If
           - HasPipelineSigningKMSKey
           - PolicyName: PipelineSigningKMSKeyAccess
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
-                  Action:
-                    !If
-                      - HasSigningKMSAccessSignAndVerify
-                      - - kms:Sign
-                        - kms:Verify
-                        - kms:GetPublicKey
-                      - - kms:Verify
-                        - kms:GetPublicKey
-                  Resource:
-                    !If
-                      - CreatePipelineSigningKMSKey
-                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                      - !If
-                        - PipelineSigningKMSKeyIsARN
-                        - !Ref PipelineSigningKMSKeyId
-                        - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
-          - !Ref 'AWS::NoValue'
+                  Action: !If
+                    - HasSigningKMSAccessSignAndVerify
+                    - - kms:Sign
+                      - kms:Verify
+                      - kms:GetPublicKey
+                    - - kms:Verify
+                      - kms:GetPublicKey
+                  Resource: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !If
+                      - PipelineSigningKMSKeyIsARN
+                      - !Ref PipelineSigningKMSKeyId
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+          - !Ref "AWS::NoValue"
         - !If
           - UseCustomerManagedKeyForParameterStore
           - PolicyName: DecryptAgentToken
             PolicyDocument:
-              Version: '2012-10-17'
+              Version: "2012-10-17"
               Statement:
                 - Effect: Allow
                   Action:
                     - kms:Decrypt
                   Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
-          - !Ref 'AWS::NoValue'
+          - !Ref "AWS::NoValue"
         - PolicyName: ReadAgentToken
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action: ssm:GetParameter
-                Resource:
-                  !Sub
-                    - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ParameterPath}
-                    - ParameterPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
+                Resource: !Sub
+                  - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ParameterPath}
+                  - ParameterPath:
+                      !If [
+                        UseCustomerManagedParameterPath,
+                        !Ref BuildkiteAgentTokenParameterStorePath,
+                        !Ref BuildkiteAgentTokenParameter,
+                      ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [ autoscaling.amazonaws.com, ec2.amazonaws.com ]
+              Service: [autoscaling.amazonaws.com, ec2.amazonaws.com]
             Action: sts:AssumeRole
       Path: /
 
@@ -1129,10 +2087,20 @@ Resources:
               Resource:
                 - !Sub
                   - "arn:aws:s3:::${Bucket}/*"
-                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
+                  - Bucket:
+                      !If [
+                        CreateSecretsBucket,
+                        !Ref ManagedSecretsBucket,
+                        !Ref SecretsBucket,
+                      ]
                 - !Sub
                   - "arn:aws:s3:::${Bucket}"
-                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
+                  - Bucket:
+                      !If [
+                        CreateSecretsBucket,
+                        !Ref ManagedSecretsBucket,
+                        !Ref SecretsBucket,
+                      ]
             - !Ref "AWS::NoValue"
           - !If
             - UseArtifactsBucket
@@ -1204,13 +2172,11 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      BucketEncryption:
-        !If
+      BucketEncryption: !If
         - EnforceSecretsBucketEncryption
-        -
-          ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "AES256"
+        - ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: "AES256"
         - !Ref "AWS::NoValue"
       Tags:
         - !If
@@ -1228,46 +2194,44 @@ Resources:
         Id: ManagedSecretsLoggingBucketPolicy
         Version: "2012-10-17"
         Statement:
-        - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
-          Effect: Allow
-          Principal:
-            Service: 'logging.s3.amazonaws.com'
-          Action:
-          - 's3:PutObject'
-          Resource:
-          - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
-          - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
-          Condition:
-            ArnLike:
-              'aws:SourceArn': !GetAtt 'ManagedSecretsBucket.Arn'
-            StringEquals:
-              'aws:SourceAccount': !Ref 'AWS::AccountId'
-        - !If
-          - EnforceSecretsBucketEncryption
-          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
-            Effect: Deny
-            Principal: '*'
-            Action: 's3:*'
+          - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
+            Effect: Allow
+            Principal:
+              Service: "logging.s3.amazonaws.com"
+            Action:
+              - "s3:PutObject"
             Resource:
-            - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
-            - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
+              - !GetAtt "ManagedSecretsLoggingBucket.Arn"
+              - !Sub "${ManagedSecretsLoggingBucket.Arn}/*"
             Condition:
-              Bool:
-                'aws:SecureTransport': false
-          - !Ref "AWS::NoValue"
+              ArnLike:
+                "aws:SourceArn": !GetAtt "ManagedSecretsBucket.Arn"
+              StringEquals:
+                "aws:SourceAccount": !Ref "AWS::AccountId"
+          - !If
+            - EnforceSecretsBucketEncryption
+            - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+              Effect: Deny
+              Principal: "*"
+              Action: "s3:*"
+              Resource:
+                - !GetAtt "ManagedSecretsLoggingBucket.Arn"
+                - !Sub "${ManagedSecretsLoggingBucket.Arn}/*"
+              Condition:
+                Bool:
+                  "aws:SecureTransport": false
+            - !Ref "AWS::NoValue"
 
   ManagedSecretsBucket:
     Type: AWS::S3::Bucket
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
-      BucketEncryption:
-        !If
+      BucketEncryption: !If
         - EnforceSecretsBucketEncryption
-        -
-          ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "AES256"
+        - ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: "AES256"
         - !Ref "AWS::NoValue"
       LoggingConfiguration:
         DestinationBucketName: !Ref ManagedSecretsLoggingBucket
@@ -1294,16 +2258,16 @@ Resources:
         Id: ManagedSecretsBucketPolicy
         Version: "2012-10-17"
         Statement:
-        - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
-          Effect: Deny
-          Principal: '*'
-          Action: 's3:*'
-          Resource:
-          - !GetAtt 'ManagedSecretsBucket.Arn'
-          - !Sub '${ManagedSecretsBucket.Arn}/*'
-          Condition:
-            Bool:
-              'aws:SecureTransport': false
+          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+            Effect: Deny
+            Principal: "*"
+            Action: "s3:*"
+            Resource:
+              - !GetAtt "ManagedSecretsBucket.Arn"
+              - !Sub "${ManagedSecretsBucket.Arn}/*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": false
 
   ImageIdParameterStack:
     Type: AWS::CloudFormation::Stack
@@ -1317,213 +2281,283 @@ Resources:
     Type: "AWS::EC2::LaunchTemplate"
     Properties:
       LaunchTemplateData:
-          NetworkInterfaces:
-            - DeviceIndex: 0
-              AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
-              Groups: !Split [ ",", !If [ "CreateSecurityGroup", !Ref SecurityGroup, !Ref SecurityGroupIds ] ]
-          KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
-          IamInstanceProfile:
-            Arn: !GetAtt "IAMInstanceProfile.Arn"
-          InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ]
-          MetadataOptions:
-            HttpTokens: !Ref IMDSv2Tokens
-            # Allow containers using a Docker network on the host to receive IDMSv2 responses
-            HttpPutResponseHopLimit: 2
-            InstanceMetadataTags: enabled
-          Monitoring:
-            Enabled: !Ref EnableDetailedMonitoring
-          ImageId: !If
-            - HasImageId
-            - !Ref ImageId
+        NetworkInterfaces:
+          - DeviceIndex: 0
+            AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
+            Groups:
+              !Split [
+                ",",
+                !If [
+                  "CreateSecurityGroup",
+                  !Ref SecurityGroup,
+                  !Ref SecurityGroupIds,
+                ],
+              ]
+        KeyName: !If ["HasKeyName", !Ref KeyName, !Ref "AWS::NoValue"]
+        IamInstanceProfile:
+          Arn: !GetAtt "IAMInstanceProfile.Arn"
+        InstanceType:
+          !Select [
+            "0",
+            !Split [
+              ",",
+              !Join [
+                ",",
+                [
+                  !Ref InstanceTypes,
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                  "",
+                ],
+              ],
+            ],
+          ]
+        MetadataOptions:
+          HttpTokens: !Ref IMDSv2Tokens
+          # Allow containers using a Docker network on the host to receive IDMSv2 responses
+          HttpPutResponseHopLimit: 2
+          InstanceMetadataTags: enabled
+        Monitoring:
+          Enabled: !Ref EnableDetailedMonitoring
+        ImageId: !If
+          - HasImageId
+          - !Ref ImageId
+          - !If
+            - HasImageIdParameter
+            - !GetAtt ImageIdParameterStack.Outputs.ImageId
             - !If
-              - HasImageIdParameter
-              - !GetAtt ImageIdParameterStack.Outputs.ImageId
+              - UseWindowsAgents
+              - !FindInMap
+                - AWSRegion2AMI
+                - !Ref "AWS::Region"
+                - "windows"
               - !If
-                - UseWindowsAgents
+                - UsingArmInstances
                 - !FindInMap
                   - AWSRegion2AMI
-                  - !Ref 'AWS::Region'
-                  - 'windows'
-                - !If
-                  - UsingArmInstances
-                  - !FindInMap
-                    - AWSRegion2AMI
-                    - !Ref 'AWS::Region'
-                    - 'linuxarm64'
-                  - !FindInMap
-                    - AWSRegion2AMI
-                    - !Ref 'AWS::Region'
-                    - 'linuxamd64'
-          BlockDeviceMappings:
-            - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
-              Ebs:
-                VolumeSize: !Ref RootVolumeSize
-                VolumeType: !Ref RootVolumeType
-                Encrypted: !Ref RootVolumeEncrypted
-                Throughput: !If [ IsRootVolumeIsGp3, !Ref RootVolumeThroughput, !Ref "AWS::NoValue" ]
-                Iops: !If [ IsRootVolumeIsIo1OrIo2OrGp3, !Ref RootVolumeIops, !Ref "AWS::NoValue" ]
-          TagSpecifications:
-            - ResourceType: instance
-              Tags:
-                - Key: Role
-                  Value: buildkite-agent
-                - Key: Name
-                  Value: !If [ UseStackNameForInstanceName, !Ref "AWS::StackName", !Ref InstanceName ]
-                - Key: BuildkiteAgentRelease
-                  Value: !Ref BuildkiteAgentRelease
-                - Key: BuildkiteQueue
-                  Value: !Ref BuildkiteQueue
-                - !If
-                  - UseCostAllocationTags
-                  - Key: !Ref CostAllocationTagName
-                    Value: !Ref CostAllocationTagValue
-                  - !Ref "AWS::NoValue"
-            - ResourceType: volume
-              Tags:
-                - Key: Name
-                  Value: !If [ UseStackNameForInstanceName, !Ref "AWS::StackName", !Ref InstanceName ]
-                - Key: BuildkiteQueue
-                  Value: !Ref BuildkiteQueue
-                - !If
-                  - UseCostAllocationTags
-                  - Key: !Ref CostAllocationTagName
-                    Value: !Ref CostAllocationTagValue
-                  - !Ref "AWS::NoValue"
+                  - !Ref "AWS::Region"
+                  - "linuxarm64"
+                - !FindInMap
+                  - AWSRegion2AMI
+                  - !Ref "AWS::Region"
+                  - "linuxamd64"
+        BlockDeviceMappings:
+          - DeviceName:
+              !If [
+                UseDefaultRootVolumeName,
+                !If [UseWindowsAgents, /dev/sda1, /dev/xvda],
+                !Ref RootVolumeName,
+              ]
+            Ebs:
+              VolumeSize: !Ref RootVolumeSize
+              VolumeType: !Ref RootVolumeType
+              Encrypted: !Ref RootVolumeEncrypted
+              Throughput:
+                !If [
+                  IsRootVolumeIsGp3,
+                  !Ref RootVolumeThroughput,
+                  !Ref "AWS::NoValue",
+                ]
+              Iops:
+                !If [
+                  IsRootVolumeIsIo1OrIo2OrGp3,
+                  !Ref RootVolumeIops,
+                  !Ref "AWS::NoValue",
+                ]
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Role
+                Value: buildkite-agent
+              - Key: Name
+                Value:
+                  !If [
+                    UseStackNameForInstanceName,
+                    !Ref "AWS::StackName",
+                    !Ref InstanceName,
+                  ]
+              - Key: BuildkiteAgentRelease
+                Value: !Ref BuildkiteAgentRelease
+              - Key: BuildkiteQueue
+                Value: !Ref BuildkiteQueue
+              - !If
+                - UseCostAllocationTags
+                - Key: !Ref CostAllocationTagName
+                  Value: !Ref CostAllocationTagValue
+                - !Ref "AWS::NoValue"
+          - ResourceType: volume
+            Tags:
+              - Key: Name
+                Value:
+                  !If [
+                    UseStackNameForInstanceName,
+                    !Ref "AWS::StackName",
+                    !Ref InstanceName,
+                  ]
+              - Key: BuildkiteQueue
+                Value: !Ref BuildkiteQueue
+              - !If
+                - UseCostAllocationTags
+                - Key: !Ref CostAllocationTagName
+                  Value: !Ref CostAllocationTagValue
+                - !Ref "AWS::NoValue"
 
-          UserData:
-            Fn::Base64: !If
-              - UseWindowsAgents
-              - !Sub
-                - |
-                  <powershell>
-                  $Env:DOCKER_USERNS_REMAP="${EnableDockerUserNamespaceRemap}"
-                  $Env:DOCKER_EXPERIMENTAL="${EnableDockerExperimental}"
-                  $Env:DOCKER_NETWORKING_PROTOCOL="${DockerNetworkingProtocol}"
-                  powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
+        UserData:
+          Fn::Base64: !If
+            - UseWindowsAgents
+            - !Sub
+              - |
+                <powershell>
+                $Env:DOCKER_USERNS_REMAP="${EnableDockerUserNamespaceRemap}"
+                $Env:DOCKER_EXPERIMENTAL="${EnableDockerExperimental}"
+                $Env:DOCKER_NETWORKING_PROTOCOL="${DockerNetworkingProtocol}"
+                powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
 
-                  $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
-                  $Env:BUILDKITE_STACK_VERSION="%v"
-                  $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
-                  $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
-                  $Env:BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}"
-                  $Env:BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}"
-                  $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
-                  $Env:BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}"
-                  $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
-                  $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
-                  $Env:BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}"
-                  $Env:BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}"
-                  $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
-                  $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
-                  $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}"
-                  $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
-                  $Env:BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}"
-                  $Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}"
-                  $Env:BUILDKITE_ENV_FILE_URL="${AgentEnvFileUrl}"
-                  $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
-                  $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
-                  $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
-                  $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
-                  $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
-                  $Env:AWS_DEFAULT_REGION="${AWS::Region}"
-                  $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
-                  $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
-                  $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
-                  $Env:AWS_REGION="${AWS::Region}"
-                  powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
-                  </powershell>
-                - LocalSecretsBucket: !If
-                    - CreateSecretsBucket
-                    - !Ref ManagedSecretsBucket
-                    - !Ref SecretsBucket
-                  LocalSecretsBucketRegion: !If
-                    - CreateSecretsBucket
-                    - !Ref "AWS::Region"
-                    - !Ref SecretsBucketRegion
-                  AgentTokenPath: !If
-                    - UseCustomerManagedParameterPath
-                    - !Ref BuildkiteAgentTokenParameterStorePath
-                    - !Ref BuildkiteAgentTokenParameter
-                  PipelineSigningKMSKey: !If
-                    - CreatePipelineSigningKMSKey
-                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                    - !Ref PipelineSigningKMSKeyId
-              - !Sub
-                - |
-                  Content-Type: multipart/mixed; boundary="==BOUNDARY=="
-                  MIME-Version: 1.0
-                  --==BOUNDARY==
-                  Content-Type: text/cloud-config; charset="us-ascii"
-                  #cloud-config
-                  cloud_final_modules:
-                    - [scripts-user, always]
-                  --==BOUNDARY==
-                  Content-Type: text/x-shellscript; charset="us-ascii"
-                  #!/bin/bash -v
-                  BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
-                  BUILDKITE_MOUNT_TMPFS_AT_TMP="${MountTmpfsAtTmp}" \
-                    /usr/local/bin/bk-mount-instance-storage.sh
-                  --==BOUNDARY==
-                  Content-Type: text/x-shellscript; charset="us-ascii"
-                  #!/bin/bash -v
-                  DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
-                  DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
-                  DOCKER_NETWORKING_PROTOCOL=${DockerNetworkingProtocol} \
-                  BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
-                    /usr/local/bin/bk-configure-docker.sh
-                  --==BOUNDARY==
-                  Content-Type: text/x-shellscript; charset="us-ascii"
-                  #!/bin/bash -v
-                  BUILDKITE_STACK_NAME="${AWS::StackName}" \
-                  BUILDKITE_STACK_VERSION="%v" \
-                  BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}" \
-                  BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
-                  BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}" \
-                  BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}" \
-                  BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
-                  BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}" \
-                  BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
-                  BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
-                  BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
-                  BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}" \
-                  BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
-                  BUILDKITE_AGENT_CANCEL_GRACE_PERIOD="${BuildkiteAgentCancelGracePeriod}" \
-                  BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}" \
-                  BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
-                  BUILDKITE_QUEUE="${BuildkiteQueue}" \
-                  BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
-                  BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
-                  BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
-                  BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
-                  BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
-                  BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
-                  BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
-                  BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
-                  AWS_DEFAULT_REGION="${AWS::Region}" \
-                  SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}" \
-                  ECR_PLUGIN_ENABLED="${EnableECRPlugin}" \
-                  DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}" \
-                  DOCKER_EXPERIMENTAL="${EnableDockerExperimental}" \
-                  DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
-                  AWS_REGION="${AWS::Region}" \
-                    /usr/local/bin/bk-install-elastic-stack.sh
-                  --==BOUNDARY==--
-                - LocalSecretsBucket: !If
-                    - CreateSecretsBucket
-                    - !Ref ManagedSecretsBucket
-                    - !Ref SecretsBucket
-                  LocalSecretsBucketRegion: !If
-                    - CreateSecretsBucket
-                    - !Ref "AWS::Region"
-                    - !Ref SecretsBucketRegion
-                  AgentTokenPath: !If
-                    - UseCustomerManagedParameterPath
-                    - !Ref BuildkiteAgentTokenParameterStorePath
-                    - !Ref BuildkiteAgentTokenParameter
-                  PipelineSigningKMSKey: !If
-                    - CreatePipelineSigningKMSKey
-                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                    - !Ref PipelineSigningKMSKeyId
+                $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
+                $Env:BUILDKITE_STACK_VERSION="%v"
+                $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
+                $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
+                $Env:BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}"
+                $Env:BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}"
+                $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
+                $Env:BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}"
+                $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
+                $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
+                $Env:BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}"
+                $Env:BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}"
+                $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
+                $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
+                $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}"
+                $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
+                $Env:BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}"
+                $Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}"
+                $Env:BUILDKITE_ENV_FILE_URL="${AgentEnvFileUrl}"
+                $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
+                $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
+                $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
+                $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
+                $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
+                $Env:AWS_DEFAULT_REGION="${AWS::Region}"
+                $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
+                $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
+                $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
+                $Env:AWS_REGION="${AWS::Region}"
+                powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
+                </powershell>
+              - LocalSecretsBucket: !If
+                  - CreateSecretsBucket
+                  - !Ref ManagedSecretsBucket
+                  - !Ref SecretsBucket
+                LocalSecretsBucketRegion: !If
+                  - CreateSecretsBucket
+                  - !Ref "AWS::Region"
+                  - !Ref SecretsBucketRegion
+                AgentTokenPath: !If
+                  - UseCustomerManagedParameterPath
+                  - !Ref BuildkiteAgentTokenParameterStorePath
+                  - !Ref BuildkiteAgentTokenParameter
+                PipelineSigningKMSKey: !If
+                  - CreatePipelineSigningKMSKey
+                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                  - !Ref PipelineSigningKMSKeyId
+            - !Sub
+              - |
+                Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+                MIME-Version: 1.0
+                --==BOUNDARY==
+                Content-Type: text/cloud-config; charset="us-ascii"
+                #cloud-config
+                cloud_final_modules:
+                  - [scripts-user, always]
+                --==BOUNDARY==
+                Content-Type: text/x-shellscript; charset="us-ascii"
+                #!/bin/bash -v
+                BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                BUILDKITE_MOUNT_TMPFS_AT_TMP="${MountTmpfsAtTmp}" \
+                  /usr/local/bin/bk-mount-instance-storage.sh
+                --==BOUNDARY==
+                Content-Type: text/x-shellscript; charset="us-ascii"
+                #!/bin/bash -v
+                DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+                DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
+                DOCKER_NETWORKING_PROTOCOL=${DockerNetworkingProtocol} \
+                BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                  /usr/local/bin/bk-configure-docker.sh
+                --==BOUNDARY==
+                Content-Type: text/x-shellscript; charset="us-ascii"
+                #!/bin/bash -v
+                BUILDKITE_STACK_NAME="${AWS::StackName}" \
+                BUILDKITE_STACK_VERSION="%v" \
+                BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}" \
+                BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
+                BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}" \
+                BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}" \
+                BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
+                BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}" \
+                BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
+                BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
+                BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
+                BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}" \
+                BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
+                BUILDKITE_AGENT_CANCEL_GRACE_PERIOD="${BuildkiteAgentCancelGracePeriod}" \
+                BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS="${BuildkiteAgentSignalGracePeriod}"\
+                BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}" \
+                BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
+                BUILDKITE_QUEUE="${BuildkiteQueue}" \
+                BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
+                BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
+                BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
+                BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
+                BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
+                BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
+                BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
+                AWS_DEFAULT_REGION="${AWS::Region}" \
+                SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}" \
+                ECR_PLUGIN_ENABLED="${EnableECRPlugin}" \
+                DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}" \
+                DOCKER_EXPERIMENTAL="${EnableDockerExperimental}" \
+                DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+                AWS_REGION="${AWS::Region}" \
+                  /usr/local/bin/bk-install-elastic-stack.sh
+                --==BOUNDARY==--
+              - LocalSecretsBucket: !If
+                  - CreateSecretsBucket
+                  - !Ref ManagedSecretsBucket
+                  - !Ref SecretsBucket
+                LocalSecretsBucketRegion: !If
+                  - CreateSecretsBucket
+                  - !Ref "AWS::Region"
+                  - !Ref SecretsBucketRegion
+                AgentTokenPath: !If
+                  - UseCustomerManagedParameterPath
+                  - !Ref BuildkiteAgentTokenParameterStorePath
+                  - !Ref BuildkiteAgentTokenParameter
+                PipelineSigningKMSKey: !If
+                  - CreatePipelineSigningKMSKey
+                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                  - !Ref PipelineSigningKMSKeyId
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -1531,7 +2565,8 @@ Resources:
       - IAMPolicies
       - VpcComplete
     Properties:
-      VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
+      VPCZoneIdentifier:
+        !If ["CreateVpcResources", [!Ref Subnet0, !Ref Subnet1], !Ref Subnets]
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
@@ -1541,103 +2576,1003 @@ Resources:
             LaunchTemplateId: !Ref AgentLaunchTemplate
             Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
           Overrides:
-          - InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-          - !If
-            - UseInstanceType2
-            - InstanceType: !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType3
-            - InstanceType: !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType4
-            - InstanceType: !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType5
-            - InstanceType: !Select [ "4", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType6
-            - InstanceType: !Select [ "5", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType7
-            - InstanceType: !Select [ "6", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType8
-            - InstanceType: !Select [ "7", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType9
-            - InstanceType: !Select [ "8", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType10
-            - InstanceType: !Select [ "9", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType11
-            - InstanceType: !Select [ "10", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType12
-            - InstanceType: !Select [ "11", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType13
-            - InstanceType: !Select [ "12", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType14
-            - InstanceType: !Select [ "13", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType15
-            - InstanceType: !Select [ "14", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType16
-            - InstanceType: !Select [ "15", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType17
-            - InstanceType: !Select [ "16", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType18
-            - InstanceType: !Select [ "17", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType19
-            - InstanceType: !Select [ "18", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType20
-            - InstanceType: !Select [ "19", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType21
-            - InstanceType: !Select [ "20", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType22
-            - InstanceType: !Select [ "21", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType23
-            - InstanceType: !Select [ "22", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType24
-            - InstanceType: !Select [ "23", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
-          - !If
-            - UseInstanceType25
-            - InstanceType: !Select [ "24", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
-            - !Ref "AWS::NoValue"
+            - InstanceType:
+                !Select [
+                  "0",
+                  !Split [
+                    ",",
+                    !Join [
+                      ",",
+                      [
+                        !Ref InstanceTypes,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                      ],
+                    ],
+                  ],
+                ]
+            - !If
+              - UseInstanceType2
+              - InstanceType:
+                  !Select [
+                    "1",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType3
+              - InstanceType:
+                  !Select [
+                    "2",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType4
+              - InstanceType:
+                  !Select [
+                    "3",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType5
+              - InstanceType:
+                  !Select [
+                    "4",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType6
+              - InstanceType:
+                  !Select [
+                    "5",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType7
+              - InstanceType:
+                  !Select [
+                    "6",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType8
+              - InstanceType:
+                  !Select [
+                    "7",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType9
+              - InstanceType:
+                  !Select [
+                    "8",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType10
+              - InstanceType:
+                  !Select [
+                    "9",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType11
+              - InstanceType:
+                  !Select [
+                    "10",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType12
+              - InstanceType:
+                  !Select [
+                    "11",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType13
+              - InstanceType:
+                  !Select [
+                    "12",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType14
+              - InstanceType:
+                  !Select [
+                    "13",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType15
+              - InstanceType:
+                  !Select [
+                    "14",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType16
+              - InstanceType:
+                  !Select [
+                    "15",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType17
+              - InstanceType:
+                  !Select [
+                    "16",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType18
+              - InstanceType:
+                  !Select [
+                    "17",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType19
+              - InstanceType:
+                  !Select [
+                    "18",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType20
+              - InstanceType:
+                  !Select [
+                    "19",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType21
+              - InstanceType:
+                  !Select [
+                    "20",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType22
+              - InstanceType:
+                  !Select [
+                    "21",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType23
+              - InstanceType:
+                  !Select [
+                    "22",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType24
+              - InstanceType:
+                  !Select [
+                    "23",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
+            - !If
+              - UseInstanceType25
+              - InstanceType:
+                  !Select [
+                    "24",
+                    !Split [
+                      ",",
+                      !Join [
+                        ",",
+                        [
+                          !Ref InstanceTypes,
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                          "",
+                        ],
+                      ],
+                    ],
+                  ]
+              - !Ref "AWS::NoValue"
 
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
@@ -1657,7 +3592,12 @@ Resources:
       NewInstancesProtectedFromScaleIn: true
     CreationPolicy:
       ResourceSignal:
-        Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, PT5M ], !Ref InstanceCreationTimeout ]
+        Timeout:
+          !If [
+            UseDefaultInstanceCreationTimeout,
+            !If [UseWindowsAgents, PT10M, PT5M],
+            !Ref InstanceCreationTimeout,
+          ]
         Count: !Ref MinSize
     UpdatePolicy:
       AutoScalingReplacingUpdate:
@@ -1666,7 +3606,12 @@ Resources:
   AsgProcessSuspenderRole:
     Type: AWS::IAM::Role
     Properties:
-      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
+      PermissionsBoundary:
+        !If [
+          SetInstanceRolePermissionsBoundaryARN,
+          !Ref InstanceRolePermissionsBoundaryARN,
+          !Ref "AWS::NoValue",
+        ]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -1685,13 +3630,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'autoscaling:SuspendProcesses'
+                  - "autoscaling:SuspendProcesses"
                 Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-AgentAutoScaleGroup-*
 
   AzRebalancingSuspenderFunction:
     Type: AWS::Lambda::Function
     Properties:
-      Description: 'Disables AZ Rebalancing on the agent ASG'
+      Description: "Disables AZ Rebalancing on the agent ASG"
       Code:
         ZipFile: |
           import cfnresponse
@@ -1710,7 +3655,7 @@ Resources:
               cfnresponse.send(event, context, cfnresponse.FAILED, {}, "CustomResourcePhysicalID")
       Handler: index.handler
       Role: !GetAtt AsgProcessSuspenderRole.Arn
-      Runtime: 'python3.10'
+      Runtime: "python3.10"
 
   AzRebalancingSuspender:
     Type: AWS::CloudFormation::CustomResource
@@ -1724,10 +3669,10 @@ Resources:
     Condition: CreateSecurityGroup
     Properties:
       GroupDescription: Enable access to agents
-      VpcId: !If [ "CreateVpcResources",  !Ref Vpc, !Ref VpcId ]
+      VpcId: !If ["CreateVpcResources", !Ref Vpc, !Ref VpcId]
       Tags:
-      - Key: Name
-        Value: !Ref 'AWS::StackName'
+        - Key: Name
+          Value: !Ref "AWS::StackName"
 
   SecurityGroupSshIngress:
     Condition: EnableSshIngress
@@ -1747,9 +3692,24 @@ Resources:
         ApplicationId: !Ref BuildkiteAgentScalerServerlessARN
         SemanticVersion: !Ref BuildkiteAgentScalerVersion
       Parameters:
-        BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
-        BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]
-        RolePermissionsBoundaryARN: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, "" ]
+        BuildkiteAgentTokenParameter:
+          !If [
+            UseCustomerManagedParameterPath,
+            !Ref BuildkiteAgentTokenParameterStorePath,
+            !Ref BuildkiteAgentTokenParameter,
+          ]
+        BuildkiteAgentTokenParameterStoreKMSKey:
+          !If [
+            UseCustomerManagedKeyForParameterStore,
+            !Ref BuildkiteAgentTokenParameterStoreKMSKey,
+            "",
+          ]
+        RolePermissionsBoundaryARN:
+          !If [
+            SetInstanceRolePermissionsBoundaryARN,
+            !Ref InstanceRolePermissionsBoundaryARN,
+            "",
+          ]
         AgentEndpoint: !Ref AgentEndpoint
         BuildkiteQueue: !Ref BuildkiteQueue
         AgentsPerInstance: !Ref AgentsPerInstance

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -29,114 +29,114 @@ Metadata:
       - Label:
           default: Base Configuration
         Parameters:
-          - BuildkiteAgentToken
-          - BuildkiteAgentTokenParameterStorePath
-          - BuildkiteAgentTokenParameterStoreKMSKey
-          - BuildkiteQueue
-          - AgentEndpoint
+        - BuildkiteAgentToken
+        - BuildkiteAgentTokenParameterStorePath
+        - BuildkiteAgentTokenParameterStoreKMSKey
+        - BuildkiteQueue
+        - AgentEndpoint
 
       - Label:
           default: Signed Pipelines Configuration
         Parameters:
-          - PipelineSigningKMSKeyId
-          - PipelineSigningKMSKeySpec
-          - PipelineSigningKMSAccess
-          - PipelineSigningVerificationFailureBehavior
+        - PipelineSigningKMSKeyId
+        - PipelineSigningKMSKeySpec
+        - PipelineSigningKMSAccess
+        - PipelineSigningVerificationFailureBehavior
 
       - Label:
           default: Advanced Configuration
         Parameters:
-          - BuildkiteAgentRelease
-          - BuildkiteAgentTags
-          - BuildkiteAgentTimestampLines
-          - BuildkiteAgentExperiments
-          - BuildkiteAgentEnableGitMirrors
-          - BuildkiteAgentTracingBackend
-          - BuildkiteAgentCancelGracePeriod
-          - BuildkiteAgentSignalGracePeriod
-          - BuildkiteTerminateInstanceAfterJob
-          - BuildkiteAdditionalSudoPermissions
-          - BuildkiteWindowsAdministrator
-          - BuildkiteAgentScalerServerlessARN
-          - BuildkiteAgentScalerVersion
-          - LogRetentionDays
+        - BuildkiteAgentRelease
+        - BuildkiteAgentTags
+        - BuildkiteAgentTimestampLines
+        - BuildkiteAgentExperiments
+        - BuildkiteAgentEnableGitMirrors
+        - BuildkiteAgentTracingBackend
+        - BuildkiteAgentCancelGracePeriod
+        - BuildkiteAgentSignalGracePeriod
+        - BuildkiteTerminateInstanceAfterJob
+        - BuildkiteAdditionalSudoPermissions
+        - BuildkiteWindowsAdministrator
+        - BuildkiteAgentScalerServerlessARN
+        - BuildkiteAgentScalerVersion
+        - LogRetentionDays
 
       - Label:
           default: Network Configuration
         Parameters:
-          - VpcId
-          - Subnets
-          - AvailabilityZones
-          - SecurityGroupIds
-          - AssociatePublicIpAddress
+        - VpcId
+        - Subnets
+        - AvailabilityZones
+        - SecurityGroupIds
+        - AssociatePublicIpAddress
 
       - Label:
           default: Instance Configuration
         Parameters:
-          - ImageId
-          - ImageIdParameter
-          - InstanceOperatingSystem
-          - InstanceTypes
-          - EnableInstanceStorage
-          - MountTmpfsAtTmp
-          - AgentsPerInstance
-          - KeyName
-          - SecretsBucket
-          - SecretsBucketRegion
-          - SecretsBucketEncryption
-          - ArtifactsBucket
-          - AuthorizedUsersUrl
-          - BootstrapScriptUrl
-          - AgentEnvFileUrl
-          - RootVolumeSize
-          - RootVolumeName
-          - RootVolumeType
-          - RootVolumeEncrypted
-          - ManagedPolicyARNs
-          - InstanceRoleName
-          - InstanceRolePermissionsBoundaryARN
-          - IMDSv2Tokens
-          - EnableDetailedMonitoring
-          - InstanceName
+        - ImageId
+        - ImageIdParameter
+        - InstanceOperatingSystem
+        - InstanceTypes
+        - EnableInstanceStorage
+        - MountTmpfsAtTmp
+        - AgentsPerInstance
+        - KeyName
+        - SecretsBucket
+        - SecretsBucketRegion
+        - SecretsBucketEncryption
+        - ArtifactsBucket
+        - AuthorizedUsersUrl
+        - BootstrapScriptUrl
+        - AgentEnvFileUrl
+        - RootVolumeSize
+        - RootVolumeName
+        - RootVolumeType
+        - RootVolumeEncrypted
+        - ManagedPolicyARNs
+        - InstanceRoleName
+        - InstanceRolePermissionsBoundaryARN
+        - IMDSv2Tokens
+        - EnableDetailedMonitoring
+        - InstanceName
 
       - Label:
           default: Auto-scaling Configuration
         Parameters:
-          - MinSize
-          - MaxSize
-          - OnDemandPercentage
-          - SpotAllocationStrategy
-          - ScaleOutFactor
-          - ScaleInIdlePeriod
-          - ScaleOutForWaitingJobs
-          - InstanceCreationTimeout
-          - ScalerEventSchedulePeriod
-          - ScalerMinPollInterval
+        - MinSize
+        - MaxSize
+        - OnDemandPercentage
+        - SpotAllocationStrategy
+        - ScaleOutFactor
+        - ScaleInIdlePeriod
+        - ScaleOutForWaitingJobs
+        - InstanceCreationTimeout
+        - ScalerEventSchedulePeriod
+        - ScalerMinPollInterval
 
       - Label:
           default: Cost Allocation Configuration
         Parameters:
-          - EnableCostAllocationTags
-          - CostAllocationTagName
-          - CostAllocationTagValue
+        - EnableCostAllocationTags
+        - CostAllocationTagName
+        - CostAllocationTagValue
 
       - Label:
           default: Docker Daemon Configuration
         Parameters:
-          - EnableDockerUserNamespaceRemap
-          - EnableDockerExperimental
+        - EnableDockerUserNamespaceRemap
+        - EnableDockerExperimental
 
       - Label:
           default: Docker Registry Configuration
         Parameters:
-          - ECRAccessPolicy
+        - ECRAccessPolicy
 
       - Label:
           default: Plugin Configuration
         Parameters:
-          - EnableSecretsPlugin
-          - EnableECRPlugin
-          - EnableDockerLoginPlugin
+        - EnableSecretsPlugin
+        - EnableECRPlugin
+        - EnableDockerLoginPlugin
 
 Parameters:
   KeyName:
@@ -228,7 +228,7 @@ Parameters:
   BuildkiteAgentSignalGracePeriod:
     Description: The number of seconds given to a subprocess to handle being sent `cancel-signal`. After this period has elapsed, SIGKILL will be sent.
     Type: Number
-    Default: -1
+    Default: 60
     MinValue: -1
 
   BuildkiteTerminateInstanceAfterJob:
@@ -623,1236 +623,295 @@ Parameters:
 Rules:
   HasToken:
     Assertions:
-      - Assert: !Or
-          - !Not
-            - !Equals
-              - !Ref BuildkiteAgentToken
-              - ""
-          - !Not
-            - !Equals
-              - !Ref BuildkiteAgentTokenParameterStorePath
-              - ""
+      - Assert:
+          !Or
+            - !Not
+              - !Equals
+                - !Ref BuildkiteAgentToken
+                - ""
+            - !Not
+              - !Equals
+                - !Ref BuildkiteAgentTokenParameterStorePath
+                - ""
         AssertDescription: "You must provide BuildkiteAgentToken or BuildkiteAgentTokenParameterStorePath"
   HasPipelineSigningKMSKey:
     Assertions:
-      - Assert: !Or
-          - !Equals
-            - !Ref PipelineSigningKMSKeyId
-            - ""
-          - !Equals
-            - !Ref PipelineSigningKMSKeySpec
-            - "none"
+      - Assert:
+          !Or
+            - !Equals
+              - !Ref PipelineSigningKMSKeyId
+              - ""
+            - !Equals
+              - !Ref PipelineSigningKMSKeySpec
+              - "none"
         AssertDescription: "You must provide either a PipelineSigningKMSKeyId, or select a PipelineSigningKMSKeySpec, but not both"
 
 Outputs:
   VpcId:
-    Value: !If [CreateVpcResources, !Ref Vpc, !Ref VpcId]
+    Value:
+      !If [ CreateVpcResources, !Ref Vpc, !Ref VpcId ]
     Export:
-      Name: !Sub "${AWS::StackName}-VpcId"
+      Name: !Sub '${AWS::StackName}-VpcId'
 
   ManagedSecretsBucket:
-    Value: !If [CreateSecretsBucket, !Ref ManagedSecretsBucket, "Undefined"]
+    Value:
+      !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, "Undefined" ]
     Export:
-      Name: !Sub "${AWS::StackName}-ManagedSecretsBucket"
+      Name: !Sub '${AWS::StackName}-ManagedSecretsBucket'
 
   ManagedSecretsLoggingBucket:
     Value:
-      !If [CreateSecretsBucket, !Ref ManagedSecretsLoggingBucket, "Undefined"]
+      !If [ CreateSecretsBucket, !Ref ManagedSecretsLoggingBucket, "Undefined" ]
     Export:
-      Name: !Sub "${AWS::StackName}-ManagedSecretsLoggingBucket"
+      Name: !Sub '${AWS::StackName}-ManagedSecretsLoggingBucket'
 
   PipelineSigningKMSKey:
-    Value: !If [CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, "none"]
+    Value:
+      !If [ CreatePipelineSigningKMSKey, !Ref PipelineSigningKMSKey, "none" ]
     Export:
-      Name: !Sub "${AWS::StackName}-PipelineSigningKMSKey"
+      Name: !Sub '${AWS::StackName}-PipelineSigningKMSKey'
 
   AutoScalingGroupName:
     Value: !Ref AgentAutoScaleGroup
     Export:
-      Name: !Sub "${AWS::StackName}-AutoScalingGroupName"
+      Name: !Sub '${AWS::StackName}-AutoScalingGroupName'
 
   InstanceRoleName:
     Value: !Ref IAMRole
     Export:
-      Name: !Sub "${AWS::StackName}-InstanceRoleName"
+      Name: !Sub '${AWS::StackName}-InstanceRoleName'
 
 Conditions:
-  CreateVpcResources: !Equals [!Ref VpcId, ""]
+    CreateVpcResources:
+      !Equals [ !Ref VpcId, "" ]
 
-  CreateSecurityGroup: !Equals [!Ref SecurityGroupIds, ""]
+    CreateSecurityGroup:
+      !Equals [ !Ref SecurityGroupIds, "" ]
 
-  CreateSecretsBucket: !And
-    - !Equals [!Ref EnableSecretsPlugin, "true"]
-    - !Equals [!Ref SecretsBucket, ""]
+    CreateSecretsBucket:
+      !And
+         - !Equals [ !Ref EnableSecretsPlugin, "true"]
+         - !Equals [ !Ref SecretsBucket, "" ]
 
-  EnforceSecretsBucketEncryption: !And
-    - !Condition CreateSecretsBucket
-    - !Equals [!Ref SecretsBucketEncryption, "true"]
+    EnforceSecretsBucketEncryption:
+      !And
+         - !Condition CreateSecretsBucket
+         - !Equals [ !Ref SecretsBucketEncryption, "true"]
 
-  SetInstanceRoleName: !Not [!Equals [!Ref InstanceRoleName, ""]]
+    SetInstanceRoleName:
+      !Not [ !Equals [ !Ref InstanceRoleName, "" ] ]
 
-  SetInstanceRolePermissionsBoundaryARN:
-    !Not [!Equals [!Ref InstanceRolePermissionsBoundaryARN, ""]]
+    SetInstanceRolePermissionsBoundaryARN:
+      !Not [ !Equals [ !Ref InstanceRolePermissionsBoundaryARN, "" ] ]
 
-  UseSpecifiedSecretsBucket: !Not [!Equals [!Ref SecretsBucket, ""]]
+    UseSpecifiedSecretsBucket:
+      !Not [ !Equals [ !Ref SecretsBucket, "" ] ]
 
-  HasSecretsBucket:
-    !Or [!Condition CreateSecretsBucket, !Condition UseSpecifiedSecretsBucket]
+    HasSecretsBucket:
+      !Or [ !Condition CreateSecretsBucket, !Condition UseSpecifiedSecretsBucket ]
 
-  UseSpecifiedAvailabilityZones:
-    !Not [!Equals [!Join ["", !Ref AvailabilityZones], ""]]
+    UseSpecifiedAvailabilityZones:
+      !Not [ !Equals [ !Join [ "", !Ref AvailabilityZones ], "" ]  ]
 
-  UseArtifactsBucket: !Not [!Equals [!Ref ArtifactsBucket, ""]]
+    UseArtifactsBucket:
+      !Not [ !Equals [ !Ref ArtifactsBucket, "" ] ]
 
-  HasImageId: !Not [!Equals [!Ref ImageId, ""]]
-  HasImageIdParameter: !Not [!Equals [!Ref ImageIdParameter, ""]]
+    HasImageId:
+      !Not [ !Equals [ !Ref ImageId, "" ] ]
+    HasImageIdParameter:
+      !Not [ !Equals [ !Ref ImageIdParameter, "" ] ]
 
-  UseDefaultInstanceCreationTimeout: !Equals [!Ref InstanceCreationTimeout, ""]
+    UseDefaultInstanceCreationTimeout:
+      !Equals [ !Ref InstanceCreationTimeout, "" ]
 
-  UseDefaultRootVolumeName: !Equals [!Ref RootVolumeName, ""]
+    UseDefaultRootVolumeName:
+      !Equals [ !Ref RootVolumeName, "" ]
 
-  UseInstanceType2:
-    !Not [
-      !Equals [
-        !Select [
-          "1",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType2:
+      !Not [ !Equals [ !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType3:
-    !Not [
-      !Equals [
-        !Select [
-          "2",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType3:
+      !Not [ !Equals [ !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType4:
-    !Not [
-      !Equals [
-        !Select [
-          "3",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType4:
+      !Not [ !Equals [ !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType5:
-    !Not [
-      !Equals [
-        !Select [
-          "4",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType5:
+      !Not [ !Equals [ !Select [ "4", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType6:
-    !Not [
-      !Equals [
-        !Select [
-          "5",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType6:
+      !Not [ !Equals [ !Select [ "5", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType7:
-    !Not [
-      !Equals [
-        !Select [
-          "6",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType7:
+      !Not [ !Equals [ !Select [ "6", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType8:
-    !Not [
-      !Equals [
-        !Select [
-          "7",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType8:
+      !Not [ !Equals [ !Select [ "7", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType9:
-    !Not [
-      !Equals [
-        !Select [
-          "8",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType9:
+      !Not [ !Equals [ !Select [ "8", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType10:
-    !Not [
-      !Equals [
-        !Select [
-          "9",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType10:
+      !Not [ !Equals [ !Select [ "9", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType11:
-    !Not [
-      !Equals [
-        !Select [
-          "10",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType11:
+      !Not [ !Equals [ !Select [ "10", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType12:
-    !Not [
-      !Equals [
-        !Select [
-          "11",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType12:
+      !Not [ !Equals [ !Select [ "11", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+    
+    UseInstanceType13:
+      !Not [ !Equals [ !Select [ "12", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType13:
-    !Not [
-      !Equals [
-        !Select [
-          "12",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType14:
+      !Not [ !Equals [ !Select [ "13", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+    
+    UseInstanceType15:
+      !Not [ !Equals [ !Select [ "14", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType14:
-    !Not [
-      !Equals [
-        !Select [
-          "13",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType16:
+      !Not [ !Equals [ !Select [ "15", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType15:
-    !Not [
-      !Equals [
-        !Select [
-          "14",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType17:
+      !Not [ !Equals [ !Select [ "16", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+    
+    UseInstanceType18:
+      !Not [ !Equals [ !Select [ "17", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+    
+    UseInstanceType19:
+      !Not [ !Equals [ !Select [ "18", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+    
+    UseInstanceType20:
+      !Not [ !Equals [ !Select [ "19", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType16:
-    !Not [
-      !Equals [
-        !Select [
-          "15",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType21:
+      !Not [ !Equals [ !Select [ "20", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType17:
-    !Not [
-      !Equals [
-        !Select [
-          "16",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType22:
+      !Not [ !Equals [ !Select [ "21", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType18:
-    !Not [
-      !Equals [
-        !Select [
-          "17",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType23:
+      !Not [ !Equals [ !Select [ "22", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
+    
+    UseInstanceType24:
+      !Not [ !Equals [ !Select [ "23", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType19:
-    !Not [
-      !Equals [
-        !Select [
-          "18",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseInstanceType25:
+      !Not [ !Equals [ !Select [ "24", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ], ""] ]
 
-  UseInstanceType20:
-    !Not [
-      !Equals [
-        !Select [
-          "19",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseManagedPolicyARN:
+      !Not [ !Equals [ !Join [ "", !Ref ManagedPolicyARNs ], "" ] ]
 
-  UseInstanceType21:
-    !Not [
-      !Equals [
-        !Select [
-          "20",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseECR:
+      !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
 
-  UseInstanceType22:
-    !Not [
-      !Equals [
-        !Select [
-          "21",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseCustomerManagedParameterPath:
+      !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
+    UseCustomerManagedKeyForParameterStore:
+      !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ] ]
+    CreateAgentTokenParameter:
+      !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ]
 
-  UseInstanceType23:
-    !Not [
-      !Equals [
-        !Select [
-          "22",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    HasVariableSize:
+      !Not [ !Equals [ !Ref MaxSize, !Ref MinSize ] ]
 
-  UseInstanceType24:
-    !Not [
-      !Equals [
-        !Select [
-          "23",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UseCostAllocationTags:
+      !Equals [ !Ref EnableCostAllocationTags, "true" ]
 
-  UseInstanceType25:
-    !Not [
-      !Equals [
-        !Select [
-          "24",
-          !Split [
-            ",",
-            !Join [
-              ",",
-              [
-                !Ref InstanceTypes,
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-              ],
-            ],
-          ],
-        ],
-        "",
-      ],
-    ]
+    UsePipelineSigningKMSKey:
+      !Not [ !Equals [ !Ref PipelineSigningKMSKeyId, "" ] ]
 
-  UseManagedPolicyARN: !Not [!Equals [!Join ["", !Ref ManagedPolicyARNs], ""]]
+    CreatePipelineSigningKMSKey:
+      !And
+      - !Equals [ !Ref PipelineSigningKMSKeyId, "" ]
+      - !Not [ !Equals [ !Ref PipelineSigningKMSKeySpec, "none" ] ]
 
-  UseECR: !Not [!Equals [!Ref ECRAccessPolicy, "none"]]
+    HasPipelineSigningKMSKey:
+      !Or [ !Condition CreatePipelineSigningKMSKey, !Condition UsePipelineSigningKMSKey ]
 
-  UseCustomerManagedParameterPath:
-    !Not [!Equals [!Ref BuildkiteAgentTokenParameterStorePath, ""]]
-  UseCustomerManagedKeyForParameterStore:
-    !Not [!Equals [!Ref BuildkiteAgentTokenParameterStoreKMSKey, ""]]
-  CreateAgentTokenParameter:
-    !Equals [!Ref BuildkiteAgentTokenParameterStorePath, ""]
+    HasSigningKMSAccessSignAndVerify:
+      !Equals [ !Ref PipelineSigningKMSAccess, "sign-and-verify" ]
 
-  HasVariableSize: !Not [!Equals [!Ref MaxSize, !Ref MinSize]]
+    PipelineSigningKMSKeyIsARN:
+      !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
 
-  UseCostAllocationTags: !Equals [!Ref EnableCostAllocationTags, "true"]
+    HasKeyName:
+      !Not [ !Equals [ !Ref KeyName, "" ] ]
 
-  UsePipelineSigningKMSKey: !Not [!Equals [!Ref PipelineSigningKMSKeyId, ""]]
+    EnableSshIngress:
+      !And
+        - { Condition : CreateSecurityGroup }
+        # Enable ingress if a key can be specified another way
+        - !Or
+          - { Condition: HasKeyName }
+          - !Not [ !Equals [ !Ref AuthorizedUsersUrl, "" ] ]
 
-  CreatePipelineSigningKMSKey: !And
-    - !Equals [!Ref PipelineSigningKMSKeyId, ""]
-    - !Not [!Equals [!Ref PipelineSigningKMSKeySpec, "none"]]
+    # Whether or not there's any managed polices to attach
+    HasManagedPolicies:
+      !Or [ { Condition: UseManagedPolicyARN }, { Condition: UseECR } ]
 
-  HasPipelineSigningKMSKey:
-    !Or [
-      !Condition CreatePipelineSigningKMSKey,
-      !Condition UsePipelineSigningKMSKey,
-    ]
+    UseWindowsAgents:
+      !Equals [ !Ref InstanceOperatingSystem, "windows" ]
 
-  HasSigningKMSAccessSignAndVerify:
-    !Equals [!Ref PipelineSigningKMSAccess, "sign-and-verify"]
+    UseLinuxAgents:
+      !Equals [ !Ref InstanceOperatingSystem, "linux" ]
 
-  PipelineSigningKMSKeyIsARN:
-    !Equals [!Select [0, !Split [":", !Ref PipelineSigningKMSKeyId]], "arn"]
+    # Unfortunately, Cloudformation's !Or intrinsic function only accepts
+    # between 2 and 10 arguments.  To get around this, we're grouping the
+    # instance families in sub-conditionals.  At least this doesn't force us
+    # into using a Custom Resource.
+    UsingArmInstances:
+      !Or
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "a1" ]
+        - !Or
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c6g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c6gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c6gn" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c7gn" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "c8g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "g5g" ]
+        - !Or
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "i4g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "Im4gn" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "Is4gen" ]
+        - !Or
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m6g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m6gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m7g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m7gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "m8g" ]
+        - !Or
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r6gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r7g" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r7gd" ]
+          - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "r8g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "t4g" ]
+        - !Equals [ !Select [ 0, !Split [ ".", !Ref InstanceTypes ] ], "x2gd" ]
 
-  HasKeyName: !Not [!Equals [!Ref KeyName, ""]]
+    UseStackNameForInstanceName:
+      !Equals [ !Ref InstanceName, "" ]
 
-  EnableSshIngress: !And
-    - { Condition: CreateSecurityGroup }
-    # Enable ingress if a key can be specified another way
-    - !Or
-      - { Condition: HasKeyName }
-      - !Not [!Equals [!Ref AuthorizedUsersUrl, ""]]
+    IsRootVolumeIsGp3:
+      !Equals [ !Ref RootVolumeType, "gp3" ]
 
-  # Whether or not there's any managed polices to attach
-  HasManagedPolicies:
-    !Or [{ Condition: UseManagedPolicyARN }, { Condition: UseECR }]
-
-  UseWindowsAgents: !Equals [!Ref InstanceOperatingSystem, "windows"]
-
-  UseLinuxAgents: !Equals [!Ref InstanceOperatingSystem, "linux"]
-
-  # Unfortunately, Cloudformation's !Or intrinsic function only accepts
-  # between 2 and 10 arguments.  To get around this, we're grouping the
-  # instance families in sub-conditionals.  At least this doesn't force us
-  # into using a Custom Resource.
-  UsingArmInstances: !Or
-    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "a1"]
-    - !Or
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c6g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c6gd"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c6gn"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c7g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c7gd"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c7gn"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "c8g"]
-    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "g5g"]
-    - !Or
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "i4g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "Im4gn"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "Is4gen"]
-    - !Or
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m6g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m6gd"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m7g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m7gd"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "m8g"]
-    - !Or
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r6g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r6gd"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r7g"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r7gd"]
-      - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "r8g"]
-    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "t4g"]
-    - !Equals [!Select [0, !Split [".", !Ref InstanceTypes]], "x2gd"]
-
-  UseStackNameForInstanceName: !Equals [!Ref InstanceName, ""]
-
-  IsRootVolumeIsGp3: !Equals [!Ref RootVolumeType, "gp3"]
-
-  IsRootVolumeIsIo1OrIo2OrGp3: !Or
-    - !Equals [!Ref RootVolumeType, "io1"]
-    - !Equals [!Ref RootVolumeType, "io2"]
-    - !Equals [!Ref RootVolumeType, "gp3"]
+    IsRootVolumeIsIo1OrIo2OrGp3:
+      !Or
+        - !Equals [ !Ref RootVolumeType, "io1" ]
+        - !Equals [ !Ref RootVolumeType, "io2" ]
+        - !Equals [ !Ref RootVolumeType, "gp3" ]
 
 Mappings:
   ECRManagedPolicy:
-    none: { Policy: "" }
-    readonly:
-      { Policy: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly" }
-    poweruser:
-      { Policy: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser" }
-    full:
-      { Policy: "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess" }
+    none      : { Policy: '' }
+    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
 
   # Generated from Makefile via build/mappings.yml
-  AWSRegion2AMI:
-    {
-      linuxamd64: !Ref ImageId,
-      linuxarm64: !Ref ImageId,
-      windows: !Ref ImageId,
-    }
+  AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId }
 
 Resources:
   Vpc:
@@ -1863,7 +922,7 @@ Resources:
       InstanceTenancy: default
       Tags:
         - Key: Name
-          Value: !Ref "AWS::StackName"
+          Value: !Ref 'AWS::StackName'
 
   Gateway:
     Type: AWS::EC2::InternetGateway
@@ -1871,7 +930,7 @@ Resources:
     Properties:
       Tags:
         - Key: Name
-          Value: !Ref "AWS::StackName"
+          Value: !Ref 'AWS::StackName'
 
   GatewayAttachment:
     Type: AWS::EC2::VPCGatewayAttachment
@@ -1886,15 +945,16 @@ Resources:
     DependsOn:
       - GatewayAttachment
     Properties:
-      AvailabilityZone: !If
-        - "UseSpecifiedAvailabilityZones"
-        - !Select [0, !Ref AvailabilityZones]
-        - !Select [0, !GetAZs ""]
+      AvailabilityZone:
+        !If
+          - "UseSpecifiedAvailabilityZones"
+          - !Select [ 0, !Ref AvailabilityZones ]
+          - !Select [ 0, !GetAZs '' ]
       CidrBlock: 10.0.1.0/24
       VpcId: !Ref Vpc
       Tags:
         - Key: Name
-          Value: !Ref "AWS::StackName"
+          Value: !Ref 'AWS::StackName'
 
   Subnet1:
     Type: AWS::EC2::Subnet
@@ -1902,15 +962,16 @@ Resources:
     DependsOn:
       - GatewayAttachment
     Properties:
-      AvailabilityZone: !If
-        - "UseSpecifiedAvailabilityZones"
-        - !Select [1, !Ref AvailabilityZones]
-        - !Select [1, !GetAZs ""]
+      AvailabilityZone:
+        !If
+          - "UseSpecifiedAvailabilityZones"
+          - !Select [ 1, !Ref AvailabilityZones ]
+          - !Select [ 1, !GetAZs '' ]
       CidrBlock: 10.0.2.0/24
       VpcId: !Ref Vpc
       Tags:
         - Key: Name
-          Value: !Ref "AWS::StackName"
+          Value: !Ref 'AWS::StackName'
 
   Routes:
     Type: AWS::EC2::RouteTable
@@ -1919,7 +980,7 @@ Resources:
       VpcId: !Ref Vpc
       Tags:
         - Key: Name
-          Value: !Ref "AWS::StackName"
+          Value: !Ref 'AWS::StackName'
 
   RouteDefault:
     Type: AWS::EC2::Route
@@ -1952,7 +1013,7 @@ Resources:
     Metadata:
       VpcResources: !If
         - CreateVpcResources
-        - [!Ref RouteDefault, !Ref Subnet0Routes, !Ref Subnet1Routes]
+        - [ !Ref RouteDefault, !Ref Subnet0Routes, !Ref Subnet1Routes ]
         - !Ref "AWS::NoValue"
 
   BuildkiteAgentTokenParameter:
@@ -1973,101 +1034,89 @@ Resources:
       KeyUsage: SIGN_VERIFY
       Tags:
         - Key: Name
-          Value: !Sub "${AWS::StackName}-PipelineSigningKey"
+          Value: !Sub '${AWS::StackName}-PipelineSigningKey'
 
   # Allow ec2 instances to assume a role and be granted the IAMPolicies
   IAMInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: /
-      Roles: [!Ref IAMRole]
+      Roles: [ !Ref IAMRole ]
 
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName:
-        !If [
-          SetInstanceRoleName,
-          !Ref InstanceRoleName,
-          !Sub "${AWS::StackName}-Role",
-        ]
-      PermissionsBoundary:
-        !If [
-          SetInstanceRolePermissionsBoundaryARN,
-          !Ref InstanceRolePermissionsBoundaryARN,
-          !Ref "AWS::NoValue",
-        ]
+      RoleName: !If [ SetInstanceRoleName, !Ref InstanceRoleName, !Sub "${AWS::StackName}-Role" ]
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       ManagedPolicyArns: !If
-        - HasManagedPolicies
-        # Support multiple policies to attach by merging the values together and splitting on ','
-        - !Split
-          - ","
-          # Join will skip over AWS::NoValue values
-          - !Join
-            - ","
-            - - !If
-                - UseECR
-                - !FindInMap [ECRManagedPolicy, !Ref ECRAccessPolicy, "Policy"]
-                - !Ref "AWS::NoValue"
-              # This may support multiple values of its own (separated by commas)
-              - !If
-                - UseManagedPolicyARN
-                - !Join [",", !Ref ManagedPolicyARNs]
-                - !Ref "AWS::NoValue"
-        - !Ref "AWS::NoValue"
+          - HasManagedPolicies
+          # Support multiple policies to attach by merging the values together and splitting on ','
+          - !Split
+            - ','
+            # Join will skip over AWS::NoValue values
+            - !Join
+             - ','
+             - - !If
+                 - UseECR
+                 - !FindInMap [ ECRManagedPolicy, !Ref ECRAccessPolicy, 'Policy' ]
+                 - !Ref 'AWS::NoValue'
+               # This may support multiple values of its own (separated by commas)
+               - !If
+                 - UseManagedPolicyARN
+                 - !Join [ ',', !Ref ManagedPolicyARNs ]
+                 - !Ref 'AWS::NoValue'
+          - !Ref 'AWS::NoValue'
       Policies:
         - !If
           - HasPipelineSigningKMSKey
           - PolicyName: PipelineSigningKMSKeyAccess
             PolicyDocument:
-              Version: "2012-10-17"
+              Version: '2012-10-17'
               Statement:
                 - Effect: Allow
-                  Action: !If
-                    - HasSigningKMSAccessSignAndVerify
-                    - - kms:Sign
-                      - kms:Verify
-                      - kms:GetPublicKey
-                    - - kms:Verify
-                      - kms:GetPublicKey
-                  Resource: !If
-                    - CreatePipelineSigningKMSKey
-                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                    - !If
-                      - PipelineSigningKMSKeyIsARN
-                      - !Ref PipelineSigningKMSKeyId
-                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
-          - !Ref "AWS::NoValue"
+                  Action:
+                    !If
+                      - HasSigningKMSAccessSignAndVerify
+                      - - kms:Sign
+                        - kms:Verify
+                        - kms:GetPublicKey
+                      - - kms:Verify
+                        - kms:GetPublicKey
+                  Resource:
+                    !If
+                      - CreatePipelineSigningKMSKey
+                      - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                      - !If
+                        - PipelineSigningKMSKeyIsARN
+                        - !Ref PipelineSigningKMSKeyId
+                        - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKeyId}
+          - !Ref 'AWS::NoValue'
         - !If
           - UseCustomerManagedKeyForParameterStore
           - PolicyName: DecryptAgentToken
             PolicyDocument:
-              Version: "2012-10-17"
+              Version: '2012-10-17'
               Statement:
                 - Effect: Allow
                   Action:
                     - kms:Decrypt
                   Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${BuildkiteAgentTokenParameterStoreKMSKey}
-          - !Ref "AWS::NoValue"
+          - !Ref 'AWS::NoValue'
         - PolicyName: ReadAgentToken
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action: ssm:GetParameter
-                Resource: !Sub
-                  - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ParameterPath}
-                  - ParameterPath:
-                      !If [
-                        UseCustomerManagedParameterPath,
-                        !Ref BuildkiteAgentTokenParameterStorePath,
-                        !Ref BuildkiteAgentTokenParameter,
-                      ]
+                Resource:
+                  !Sub
+                    - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ParameterPath}
+                    - ParameterPath: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [autoscaling.amazonaws.com, ec2.amazonaws.com]
+              Service: [ autoscaling.amazonaws.com, ec2.amazonaws.com ]
             Action: sts:AssumeRole
       Path: /
 
@@ -2087,20 +1136,10 @@ Resources:
               Resource:
                 - !Sub
                   - "arn:aws:s3:::${Bucket}/*"
-                  - Bucket:
-                      !If [
-                        CreateSecretsBucket,
-                        !Ref ManagedSecretsBucket,
-                        !Ref SecretsBucket,
-                      ]
+                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
                 - !Sub
                   - "arn:aws:s3:::${Bucket}"
-                  - Bucket:
-                      !If [
-                        CreateSecretsBucket,
-                        !Ref ManagedSecretsBucket,
-                        !Ref SecretsBucket,
-                      ]
+                  - Bucket: !If [ CreateSecretsBucket, !Ref ManagedSecretsBucket, !Ref SecretsBucket ]
             - !Ref "AWS::NoValue"
           - !If
             - UseArtifactsBucket
@@ -2172,11 +1211,13 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-      BucketEncryption: !If
+      BucketEncryption:
+        !If
         - EnforceSecretsBucketEncryption
-        - ServerSideEncryptionConfiguration:
-            - ServerSideEncryptionByDefault:
-                SSEAlgorithm: "AES256"
+        -
+          ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "AES256"
         - !Ref "AWS::NoValue"
       Tags:
         - !If
@@ -2194,44 +1235,46 @@ Resources:
         Id: ManagedSecretsLoggingBucketPolicy
         Version: "2012-10-17"
         Statement:
-          - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
-            Effect: Allow
-            Principal:
-              Service: "logging.s3.amazonaws.com"
-            Action:
-              - "s3:PutObject"
+        - Sid: S3ServerAccessLogsPolicy # Grant permissions to the logging service principal using a bucket policy (https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html)
+          Effect: Allow
+          Principal:
+            Service: 'logging.s3.amazonaws.com'
+          Action:
+          - 's3:PutObject'
+          Resource:
+          - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
+          - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
+          Condition:
+            ArnLike:
+              'aws:SourceArn': !GetAtt 'ManagedSecretsBucket.Arn'
+            StringEquals:
+              'aws:SourceAccount': !Ref 'AWS::AccountId'
+        - !If
+          - EnforceSecretsBucketEncryption
+          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
             Resource:
-              - !GetAtt "ManagedSecretsLoggingBucket.Arn"
-              - !Sub "${ManagedSecretsLoggingBucket.Arn}/*"
+            - !GetAtt 'ManagedSecretsLoggingBucket.Arn'
+            - !Sub '${ManagedSecretsLoggingBucket.Arn}/*'
             Condition:
-              ArnLike:
-                "aws:SourceArn": !GetAtt "ManagedSecretsBucket.Arn"
-              StringEquals:
-                "aws:SourceAccount": !Ref "AWS::AccountId"
-          - !If
-            - EnforceSecretsBucketEncryption
-            - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
-              Effect: Deny
-              Principal: "*"
-              Action: "s3:*"
-              Resource:
-                - !GetAtt "ManagedSecretsLoggingBucket.Arn"
-                - !Sub "${ManagedSecretsLoggingBucket.Arn}/*"
-              Condition:
-                Bool:
-                  "aws:SecureTransport": false
-            - !Ref "AWS::NoValue"
+              Bool:
+                'aws:SecureTransport': false
+          - !Ref "AWS::NoValue"
 
   ManagedSecretsBucket:
     Type: AWS::S3::Bucket
     Condition: CreateSecretsBucket
     DeletionPolicy: Retain
     Properties:
-      BucketEncryption: !If
+      BucketEncryption:
+        !If
         - EnforceSecretsBucketEncryption
-        - ServerSideEncryptionConfiguration:
-            - ServerSideEncryptionByDefault:
-                SSEAlgorithm: "AES256"
+        -
+          ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: "AES256"
         - !Ref "AWS::NoValue"
       LoggingConfiguration:
         DestinationBucketName: !Ref ManagedSecretsLoggingBucket
@@ -2258,16 +1301,16 @@ Resources:
         Id: ManagedSecretsBucketPolicy
         Version: "2012-10-17"
         Statement:
-          - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
-            Effect: Deny
-            Principal: "*"
-            Action: "s3:*"
-            Resource:
-              - !GetAtt "ManagedSecretsBucket.Arn"
-              - !Sub "${ManagedSecretsBucket.Arn}/*"
-            Condition:
-              Bool:
-                "aws:SecureTransport": false
+        - Sid: AllowSSLRequestsOnly # AWS Foundational Security Best Practices v1.0.0 S3.5
+          Effect: Deny
+          Principal: '*'
+          Action: 's3:*'
+          Resource:
+          - !GetAtt 'ManagedSecretsBucket.Arn'
+          - !Sub '${ManagedSecretsBucket.Arn}/*'
+          Condition:
+            Bool:
+              'aws:SecureTransport': false
 
   ImageIdParameterStack:
     Type: AWS::CloudFormation::Stack
@@ -2281,283 +1324,214 @@ Resources:
     Type: "AWS::EC2::LaunchTemplate"
     Properties:
       LaunchTemplateData:
-        NetworkInterfaces:
-          - DeviceIndex: 0
-            AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
-            Groups:
-              !Split [
-                ",",
-                !If [
-                  "CreateSecurityGroup",
-                  !Ref SecurityGroup,
-                  !Ref SecurityGroupIds,
-                ],
-              ]
-        KeyName: !If ["HasKeyName", !Ref KeyName, !Ref "AWS::NoValue"]
-        IamInstanceProfile:
-          Arn: !GetAtt "IAMInstanceProfile.Arn"
-        InstanceType:
-          !Select [
-            "0",
-            !Split [
-              ",",
-              !Join [
-                ",",
-                [
-                  !Ref InstanceTypes,
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                  "",
-                ],
-              ],
-            ],
-          ]
-        MetadataOptions:
-          HttpTokens: !Ref IMDSv2Tokens
-          # Allow containers using a Docker network on the host to receive IDMSv2 responses
-          HttpPutResponseHopLimit: 2
-          InstanceMetadataTags: enabled
-        Monitoring:
-          Enabled: !Ref EnableDetailedMonitoring
-        ImageId: !If
-          - HasImageId
-          - !Ref ImageId
-          - !If
-            - HasImageIdParameter
-            - !GetAtt ImageIdParameterStack.Outputs.ImageId
+          NetworkInterfaces:
+            - DeviceIndex: 0
+              AssociatePublicIpAddress: { Ref: AssociatePublicIpAddress }
+              Groups: !Split [ ",", !If [ "CreateSecurityGroup", !Ref SecurityGroup, !Ref SecurityGroupIds ] ]
+          KeyName: !If [ "HasKeyName", !Ref KeyName, !Ref 'AWS::NoValue' ]
+          IamInstanceProfile:
+            Arn: !GetAtt "IAMInstanceProfile.Arn"
+          InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ]
+          MetadataOptions:
+            HttpTokens: !Ref IMDSv2Tokens
+            # Allow containers using a Docker network on the host to receive IDMSv2 responses
+            HttpPutResponseHopLimit: 2
+            InstanceMetadataTags: enabled
+          Monitoring:
+            Enabled: !Ref EnableDetailedMonitoring
+          ImageId: !If
+            - HasImageId
+            - !Ref ImageId
             - !If
+              - HasImageIdParameter
+              - !GetAtt ImageIdParameterStack.Outputs.ImageId
+              - !If
+                - UseWindowsAgents
+                - !FindInMap
+                  - AWSRegion2AMI
+                  - !Ref 'AWS::Region'
+                  - 'windows'
+                - !If
+                  - UsingArmInstances
+                  - !FindInMap
+                    - AWSRegion2AMI
+                    - !Ref 'AWS::Region'
+                    - 'linuxarm64'
+                  - !FindInMap
+                    - AWSRegion2AMI
+                    - !Ref 'AWS::Region'
+                    - 'linuxamd64'
+          BlockDeviceMappings:
+            - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
+              Ebs:
+                VolumeSize: !Ref RootVolumeSize
+                VolumeType: !Ref RootVolumeType
+                Encrypted: !Ref RootVolumeEncrypted
+                Throughput: !If [ IsRootVolumeIsGp3, !Ref RootVolumeThroughput, !Ref "AWS::NoValue" ]
+                Iops: !If [ IsRootVolumeIsIo1OrIo2OrGp3, !Ref RootVolumeIops, !Ref "AWS::NoValue" ]
+          TagSpecifications:
+            - ResourceType: instance
+              Tags:
+                - Key: Role
+                  Value: buildkite-agent
+                - Key: Name
+                  Value: !If [ UseStackNameForInstanceName, !Ref "AWS::StackName", !Ref InstanceName ]
+                - Key: BuildkiteAgentRelease
+                  Value: !Ref BuildkiteAgentRelease
+                - Key: BuildkiteQueue
+                  Value: !Ref BuildkiteQueue
+                - !If
+                  - UseCostAllocationTags
+                  - Key: !Ref CostAllocationTagName
+                    Value: !Ref CostAllocationTagValue
+                  - !Ref "AWS::NoValue"
+            - ResourceType: volume
+              Tags:
+                - Key: Name
+                  Value: !If [ UseStackNameForInstanceName, !Ref "AWS::StackName", !Ref InstanceName ]
+                - Key: BuildkiteQueue
+                  Value: !Ref BuildkiteQueue
+                - !If
+                  - UseCostAllocationTags
+                  - Key: !Ref CostAllocationTagName
+                    Value: !Ref CostAllocationTagValue
+                  - !Ref "AWS::NoValue"
+
+          UserData:
+            Fn::Base64: !If
               - UseWindowsAgents
-              - !FindInMap
-                - AWSRegion2AMI
-                - !Ref "AWS::Region"
-                - "windows"
-              - !If
-                - UsingArmInstances
-                - !FindInMap
-                  - AWSRegion2AMI
-                  - !Ref "AWS::Region"
-                  - "linuxarm64"
-                - !FindInMap
-                  - AWSRegion2AMI
-                  - !Ref "AWS::Region"
-                  - "linuxamd64"
-        BlockDeviceMappings:
-          - DeviceName:
-              !If [
-                UseDefaultRootVolumeName,
-                !If [UseWindowsAgents, /dev/sda1, /dev/xvda],
-                !Ref RootVolumeName,
-              ]
-            Ebs:
-              VolumeSize: !Ref RootVolumeSize
-              VolumeType: !Ref RootVolumeType
-              Encrypted: !Ref RootVolumeEncrypted
-              Throughput:
-                !If [
-                  IsRootVolumeIsGp3,
-                  !Ref RootVolumeThroughput,
-                  !Ref "AWS::NoValue",
-                ]
-              Iops:
-                !If [
-                  IsRootVolumeIsIo1OrIo2OrGp3,
-                  !Ref RootVolumeIops,
-                  !Ref "AWS::NoValue",
-                ]
-        TagSpecifications:
-          - ResourceType: instance
-            Tags:
-              - Key: Role
-                Value: buildkite-agent
-              - Key: Name
-                Value:
-                  !If [
-                    UseStackNameForInstanceName,
-                    !Ref "AWS::StackName",
-                    !Ref InstanceName,
-                  ]
-              - Key: BuildkiteAgentRelease
-                Value: !Ref BuildkiteAgentRelease
-              - Key: BuildkiteQueue
-                Value: !Ref BuildkiteQueue
-              - !If
-                - UseCostAllocationTags
-                - Key: !Ref CostAllocationTagName
-                  Value: !Ref CostAllocationTagValue
-                - !Ref "AWS::NoValue"
-          - ResourceType: volume
-            Tags:
-              - Key: Name
-                Value:
-                  !If [
-                    UseStackNameForInstanceName,
-                    !Ref "AWS::StackName",
-                    !Ref InstanceName,
-                  ]
-              - Key: BuildkiteQueue
-                Value: !Ref BuildkiteQueue
-              - !If
-                - UseCostAllocationTags
-                - Key: !Ref CostAllocationTagName
-                  Value: !Ref CostAllocationTagValue
-                - !Ref "AWS::NoValue"
+              - !Sub
+                - |
+                  <powershell>
+                  $Env:DOCKER_USERNS_REMAP="${EnableDockerUserNamespaceRemap}"
+                  $Env:DOCKER_EXPERIMENTAL="${EnableDockerExperimental}"
+                  $Env:DOCKER_NETWORKING_PROTOCOL="${DockerNetworkingProtocol}"
+                  powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
 
-        UserData:
-          Fn::Base64: !If
-            - UseWindowsAgents
-            - !Sub
-              - |
-                <powershell>
-                $Env:DOCKER_USERNS_REMAP="${EnableDockerUserNamespaceRemap}"
-                $Env:DOCKER_EXPERIMENTAL="${EnableDockerExperimental}"
-                $Env:DOCKER_NETWORKING_PROTOCOL="${DockerNetworkingProtocol}"
-                powershell -file C:\buildkite-agent\bin\bk-configure-docker.ps1 >> C:\buildkite-agent\elastic-stack.log
-
-                $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
-                $Env:BUILDKITE_STACK_VERSION="%v"
-                $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
-                $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
-                $Env:BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}"
-                $Env:BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}"
-                $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
-                $Env:BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}"
-                $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
-                $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
-                $Env:BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}"
-                $Env:BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}"
-                $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
-                $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
-                $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}"
-                $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
-                $Env:BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}"
-                $Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}"
-                $Env:BUILDKITE_ENV_FILE_URL="${AgentEnvFileUrl}"
-                $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
-                $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
-                $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
-                $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
-                $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
-                $Env:AWS_DEFAULT_REGION="${AWS::Region}"
-                $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
-                $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
-                $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
-                $Env:AWS_REGION="${AWS::Region}"
-                powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
-                </powershell>
-              - LocalSecretsBucket: !If
-                  - CreateSecretsBucket
-                  - !Ref ManagedSecretsBucket
-                  - !Ref SecretsBucket
-                LocalSecretsBucketRegion: !If
-                  - CreateSecretsBucket
-                  - !Ref "AWS::Region"
-                  - !Ref SecretsBucketRegion
-                AgentTokenPath: !If
-                  - UseCustomerManagedParameterPath
-                  - !Ref BuildkiteAgentTokenParameterStorePath
-                  - !Ref BuildkiteAgentTokenParameter
-                PipelineSigningKMSKey: !If
-                  - CreatePipelineSigningKMSKey
-                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                  - !Ref PipelineSigningKMSKeyId
-            - !Sub
-              - |
-                Content-Type: multipart/mixed; boundary="==BOUNDARY=="
-                MIME-Version: 1.0
-                --==BOUNDARY==
-                Content-Type: text/cloud-config; charset="us-ascii"
-                #cloud-config
-                cloud_final_modules:
-                  - [scripts-user, always]
-                --==BOUNDARY==
-                Content-Type: text/x-shellscript; charset="us-ascii"
-                #!/bin/bash -v
-                BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
-                BUILDKITE_MOUNT_TMPFS_AT_TMP="${MountTmpfsAtTmp}" \
-                  /usr/local/bin/bk-mount-instance-storage.sh
-                --==BOUNDARY==
-                Content-Type: text/x-shellscript; charset="us-ascii"
-                #!/bin/bash -v
-                DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
-                DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
-                DOCKER_NETWORKING_PROTOCOL=${DockerNetworkingProtocol} \
-                BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
-                  /usr/local/bin/bk-configure-docker.sh
-                --==BOUNDARY==
-                Content-Type: text/x-shellscript; charset="us-ascii"
-                #!/bin/bash -v
-                BUILDKITE_STACK_NAME="${AWS::StackName}" \
-                BUILDKITE_STACK_VERSION="%v" \
-                BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}" \
-                BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
-                BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}" \
-                BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}" \
-                BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
-                BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}" \
-                BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
-                BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
-                BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
-                BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}" \
-                BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
-                BUILDKITE_AGENT_CANCEL_GRACE_PERIOD="${BuildkiteAgentCancelGracePeriod}" \
-                BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS="${BuildkiteAgentSignalGracePeriod}"\
-                BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}" \
-                BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
-                BUILDKITE_QUEUE="${BuildkiteQueue}" \
-                BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
-                BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
-                BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
-                BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
-                BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
-                BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
-                BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
-                BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
-                AWS_DEFAULT_REGION="${AWS::Region}" \
-                SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}" \
-                ECR_PLUGIN_ENABLED="${EnableECRPlugin}" \
-                DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}" \
-                DOCKER_EXPERIMENTAL="${EnableDockerExperimental}" \
-                DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
-                AWS_REGION="${AWS::Region}" \
-                  /usr/local/bin/bk-install-elastic-stack.sh
-                --==BOUNDARY==--
-              - LocalSecretsBucket: !If
-                  - CreateSecretsBucket
-                  - !Ref ManagedSecretsBucket
-                  - !Ref SecretsBucket
-                LocalSecretsBucketRegion: !If
-                  - CreateSecretsBucket
-                  - !Ref "AWS::Region"
-                  - !Ref SecretsBucketRegion
-                AgentTokenPath: !If
-                  - UseCustomerManagedParameterPath
-                  - !Ref BuildkiteAgentTokenParameterStorePath
-                  - !Ref BuildkiteAgentTokenParameter
-                PipelineSigningKMSKey: !If
-                  - CreatePipelineSigningKMSKey
-                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
-                  - !Ref PipelineSigningKMSKeyId
+                  $Env:BUILDKITE_STACK_NAME="${AWS::StackName}"
+                  $Env:BUILDKITE_STACK_VERSION="%v"
+                  $Env:BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}"
+                  $Env:BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}"
+                  $Env:BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}"
+                  $Env:BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}"
+                  $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
+                  $Env:BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}"
+                  $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
+                  $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
+                  $Env:BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}"
+                  $Env:BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}"
+                  $Env:BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}"
+                  $Env:BUILDKITE_QUEUE="${BuildkiteQueue}"
+                  $Env:BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}"
+                  $Env:BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}"
+                  $Env:BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}"
+                  $Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}"
+                  $Env:BUILDKITE_ENV_FILE_URL="${AgentEnvFileUrl}"
+                  $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
+                  $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
+                  $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
+                  $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
+                  $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
+                  $Env:AWS_DEFAULT_REGION="${AWS::Region}"
+                  $Env:SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}"
+                  $Env:ECR_PLUGIN_ENABLED="${EnableECRPlugin}"
+                  $Env:DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}"
+                  $Env:AWS_REGION="${AWS::Region}"
+                  powershell -file C:\buildkite-agent\bin\bk-install-elastic-stack.ps1 >> C:\buildkite-agent\elastic-stack.log
+                  </powershell>
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !Ref PipelineSigningKMSKeyId
+              - !Sub
+                - |
+                  Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+                  MIME-Version: 1.0
+                  --==BOUNDARY==
+                  Content-Type: text/cloud-config; charset="us-ascii"
+                  #cloud-config
+                  cloud_final_modules:
+                    - [scripts-user, always]
+                  --==BOUNDARY==
+                  Content-Type: text/x-shellscript; charset="us-ascii"
+                  #!/bin/bash -v
+                  BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                  BUILDKITE_MOUNT_TMPFS_AT_TMP="${MountTmpfsAtTmp}" \
+                    /usr/local/bin/bk-mount-instance-storage.sh
+                  --==BOUNDARY==
+                  Content-Type: text/x-shellscript; charset="us-ascii"
+                  #!/bin/bash -v
+                  DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+                  DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
+                  DOCKER_NETWORKING_PROTOCOL=${DockerNetworkingProtocol} \
+                  BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                    /usr/local/bin/bk-configure-docker.sh
+                  --==BOUNDARY==
+                  Content-Type: text/x-shellscript; charset="us-ascii"
+                  #!/bin/bash -v
+                  BUILDKITE_STACK_NAME="${AWS::StackName}" \
+                  BUILDKITE_STACK_VERSION="%v" \
+                  BUILDKITE_SCALE_IN_IDLE_PERIOD="${ScaleInIdlePeriod}" \
+                  BUILDKITE_SECRETS_BUCKET="${LocalSecretsBucket}" \
+                  BUILDKITE_SECRETS_BUCKET_REGION="${LocalSecretsBucketRegion}" \
+                  BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}" \
+                  BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
+                  BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}" \
+                  BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
+                  BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
+                  BUILDKITE_AGENT_EXPERIMENTS="${BuildkiteAgentExperiments}" \
+                  BUILDKITE_AGENT_TRACING_BACKEND="${BuildkiteAgentTracingBackend}" \
+                  BUILDKITE_AGENT_RELEASE="${BuildkiteAgentRelease}" \
+                  BUILDKITE_AGENT_CANCEL_GRACE_PERIOD="${BuildkiteAgentCancelGracePeriod}" \
+                  BUILDKITE_AGENT_SIGNAL_GRACE_PERIOD_SECONDS="${BuildkiteAgentSignalGracePeriod}" \
+                  BUILDKITE_AGENT_SIGNING_KMS_KEY="${PipelineSigningKMSKey}" \
+                  BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
+                  BUILDKITE_QUEUE="${BuildkiteQueue}" \
+                  BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
+                  BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
+                  BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
+                  BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
+                  BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
+                  BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
+                  BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
+                  BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
+                  AWS_DEFAULT_REGION="${AWS::Region}" \
+                  SECRETS_PLUGIN_ENABLED="${EnableSecretsPlugin}" \
+                  ECR_PLUGIN_ENABLED="${EnableECRPlugin}" \
+                  DOCKER_LOGIN_PLUGIN_ENABLED="${EnableDockerLoginPlugin}" \
+                  DOCKER_EXPERIMENTAL="${EnableDockerExperimental}" \
+                  DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
+                  AWS_REGION="${AWS::Region}" \
+                    /usr/local/bin/bk-install-elastic-stack.sh
+                  --==BOUNDARY==--
+                - LocalSecretsBucket: !If
+                    - CreateSecretsBucket
+                    - !Ref ManagedSecretsBucket
+                    - !Ref SecretsBucket
+                  LocalSecretsBucketRegion: !If
+                    - CreateSecretsBucket
+                    - !Ref "AWS::Region"
+                    - !Ref SecretsBucketRegion
+                  AgentTokenPath: !If
+                    - UseCustomerManagedParameterPath
+                    - !Ref BuildkiteAgentTokenParameterStorePath
+                    - !Ref BuildkiteAgentTokenParameter
+                  PipelineSigningKMSKey: !If
+                    - CreatePipelineSigningKMSKey
+                    - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
+                    - !Ref PipelineSigningKMSKeyId
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -2565,8 +1539,7 @@ Resources:
       - IAMPolicies
       - VpcComplete
     Properties:
-      VPCZoneIdentifier:
-        !If ["CreateVpcResources", [!Ref Subnet0, !Ref Subnet1], !Ref Subnets]
+      VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       MixedInstancesPolicy:
         InstancesDistribution:
           OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
@@ -2576,1003 +1549,103 @@ Resources:
             LaunchTemplateId: !Ref AgentLaunchTemplate
             Version: !GetAtt "AgentLaunchTemplate.LatestVersionNumber"
           Overrides:
-            - InstanceType:
-                !Select [
-                  "0",
-                  !Split [
-                    ",",
-                    !Join [
-                      ",",
-                      [
-                        !Ref InstanceTypes,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                        "",
-                      ],
-                    ],
-                  ],
-                ]
-            - !If
-              - UseInstanceType2
-              - InstanceType:
-                  !Select [
-                    "1",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType3
-              - InstanceType:
-                  !Select [
-                    "2",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType4
-              - InstanceType:
-                  !Select [
-                    "3",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType5
-              - InstanceType:
-                  !Select [
-                    "4",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType6
-              - InstanceType:
-                  !Select [
-                    "5",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType7
-              - InstanceType:
-                  !Select [
-                    "6",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType8
-              - InstanceType:
-                  !Select [
-                    "7",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType9
-              - InstanceType:
-                  !Select [
-                    "8",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType10
-              - InstanceType:
-                  !Select [
-                    "9",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType11
-              - InstanceType:
-                  !Select [
-                    "10",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType12
-              - InstanceType:
-                  !Select [
-                    "11",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType13
-              - InstanceType:
-                  !Select [
-                    "12",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType14
-              - InstanceType:
-                  !Select [
-                    "13",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType15
-              - InstanceType:
-                  !Select [
-                    "14",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType16
-              - InstanceType:
-                  !Select [
-                    "15",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType17
-              - InstanceType:
-                  !Select [
-                    "16",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType18
-              - InstanceType:
-                  !Select [
-                    "17",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType19
-              - InstanceType:
-                  !Select [
-                    "18",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType20
-              - InstanceType:
-                  !Select [
-                    "19",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType21
-              - InstanceType:
-                  !Select [
-                    "20",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType22
-              - InstanceType:
-                  !Select [
-                    "21",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType23
-              - InstanceType:
-                  !Select [
-                    "22",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType24
-              - InstanceType:
-                  !Select [
-                    "23",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
-            - !If
-              - UseInstanceType25
-              - InstanceType:
-                  !Select [
-                    "24",
-                    !Split [
-                      ",",
-                      !Join [
-                        ",",
-                        [
-                          !Ref InstanceTypes,
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                          "",
-                        ],
-                      ],
-                    ],
-                  ]
-              - !Ref "AWS::NoValue"
+          - InstanceType: !Select [ "0", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+          - !If
+            - UseInstanceType2
+            - InstanceType: !Select [ "1", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType3
+            - InstanceType: !Select [ "2", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType4
+            - InstanceType: !Select [ "3", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType5
+            - InstanceType: !Select [ "4", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType6
+            - InstanceType: !Select [ "5", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType7
+            - InstanceType: !Select [ "6", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType8
+            - InstanceType: !Select [ "7", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType9
+            - InstanceType: !Select [ "8", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType10
+            - InstanceType: !Select [ "9", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType11
+            - InstanceType: !Select [ "10", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType12
+            - InstanceType: !Select [ "11", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType13
+            - InstanceType: !Select [ "12", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType14
+            - InstanceType: !Select [ "13", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType15
+            - InstanceType: !Select [ "14", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType16
+            - InstanceType: !Select [ "15", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType17
+            - InstanceType: !Select [ "16", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType18
+            - InstanceType: !Select [ "17", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType19
+            - InstanceType: !Select [ "18", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType20
+            - InstanceType: !Select [ "19", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType21
+            - InstanceType: !Select [ "20", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType22
+            - InstanceType: !Select [ "21", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType23
+            - InstanceType: !Select [ "22", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType24
+            - InstanceType: !Select [ "23", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseInstanceType25
+            - InstanceType: !Select [ "24", !Split [ ",", !Join [ ",", [ !Ref InstanceTypes, "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "" ] ] ] ]
+            - !Ref "AWS::NoValue"
 
       MinSize: !Ref MinSize
       MaxSize: !Ref MaxSize
@@ -3592,12 +1665,7 @@ Resources:
       NewInstancesProtectedFromScaleIn: true
     CreationPolicy:
       ResourceSignal:
-        Timeout:
-          !If [
-            UseDefaultInstanceCreationTimeout,
-            !If [UseWindowsAgents, PT10M, PT5M],
-            !Ref InstanceCreationTimeout,
-          ]
+        Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, PT5M ], !Ref InstanceCreationTimeout ]
         Count: !Ref MinSize
     UpdatePolicy:
       AutoScalingReplacingUpdate:
@@ -3606,12 +1674,7 @@ Resources:
   AsgProcessSuspenderRole:
     Type: AWS::IAM::Role
     Properties:
-      PermissionsBoundary:
-        !If [
-          SetInstanceRolePermissionsBoundaryARN,
-          !Ref InstanceRolePermissionsBoundaryARN,
-          !Ref "AWS::NoValue",
-        ]
+      PermissionsBoundary: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -3630,13 +1693,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - "autoscaling:SuspendProcesses"
+                  - 'autoscaling:SuspendProcesses'
                 Resource: !Sub arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-AgentAutoScaleGroup-*
 
   AzRebalancingSuspenderFunction:
     Type: AWS::Lambda::Function
     Properties:
-      Description: "Disables AZ Rebalancing on the agent ASG"
+      Description: 'Disables AZ Rebalancing on the agent ASG'
       Code:
         ZipFile: |
           import cfnresponse
@@ -3655,7 +1718,7 @@ Resources:
               cfnresponse.send(event, context, cfnresponse.FAILED, {}, "CustomResourcePhysicalID")
       Handler: index.handler
       Role: !GetAtt AsgProcessSuspenderRole.Arn
-      Runtime: "python3.10"
+      Runtime: 'python3.10'
 
   AzRebalancingSuspender:
     Type: AWS::CloudFormation::CustomResource
@@ -3669,10 +1732,10 @@ Resources:
     Condition: CreateSecurityGroup
     Properties:
       GroupDescription: Enable access to agents
-      VpcId: !If ["CreateVpcResources", !Ref Vpc, !Ref VpcId]
+      VpcId: !If [ "CreateVpcResources",  !Ref Vpc, !Ref VpcId ]
       Tags:
-        - Key: Name
-          Value: !Ref "AWS::StackName"
+      - Key: Name
+        Value: !Ref 'AWS::StackName'
 
   SecurityGroupSshIngress:
     Condition: EnableSshIngress
@@ -3692,24 +1755,9 @@ Resources:
         ApplicationId: !Ref BuildkiteAgentScalerServerlessARN
         SemanticVersion: !Ref BuildkiteAgentScalerVersion
       Parameters:
-        BuildkiteAgentTokenParameter:
-          !If [
-            UseCustomerManagedParameterPath,
-            !Ref BuildkiteAgentTokenParameterStorePath,
-            !Ref BuildkiteAgentTokenParameter,
-          ]
-        BuildkiteAgentTokenParameterStoreKMSKey:
-          !If [
-            UseCustomerManagedKeyForParameterStore,
-            !Ref BuildkiteAgentTokenParameterStoreKMSKey,
-            "",
-          ]
-        RolePermissionsBoundaryARN:
-          !If [
-            SetInstanceRolePermissionsBoundaryARN,
-            !Ref InstanceRolePermissionsBoundaryARN,
-            "",
-          ]
+        BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
+        BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]
+        RolePermissionsBoundaryARN: !If [ SetInstanceRolePermissionsBoundaryARN, !Ref InstanceRolePermissionsBoundaryARN, "" ]
         AgentEndpoint: !Ref AgentEndpoint
         BuildkiteQueue: !Ref BuildkiteQueue
         AgentsPerInstance: !Ref AgentsPerInstance


### PR DESCRIPTION
## Changes

- Adds a `BuildkiteAgentSignalGracePeriod` parameter which sets `BUILDKITE_SIGNAL_GRACE_PERIOD_SECONDS`
    - Default is set to be `-1` as per the current implementation


Closes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1459
