### PR TITLE
chore: go to 1.23.6 (just fixes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PACKER_VERSION ?= 1.11.2
 PACKER_LINUX_FILES = $(exec find packer/linux)
 PACKER_WINDOWS_FILES = $(exec find packer/windows)
 
-GO_VERSION ?= 1.23
+GO_VERSION ?= 1.23.6
 
 FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/elastic-ci-stack-for-aws/v6
 
-go 1.23.0
+go 1.23.6
 
 toolchain go1.24.2
 


### PR DESCRIPTION
## Changes

- update `go` version to `1.23.6`, according to https://go.dev/doc/devel/release#go1.23.0 only fixes have been implented
