### PR TITLE
Buildkite Agent v3.97.0, was v3.94.0

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -15,7 +15,7 @@ sudo mkdir -p /var/lib/buildkite-agent/.aws
 sudo cp /tmp/conf/aws/config /var/lib/buildkite-agent/.aws/config
 sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
 
-AGENT_VERSION=3.94.0
+AGENT_VERSION=3.97.0
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
   "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.94.0"
+$AGENT_VERSION = "3.97.0"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
Buildkite Agent bumped to [v3.97.0](https://github.com/buildkite/agent/releases/tag/v3.97.0), previously [v3.94.0](https://github.com/buildkite/agent/releases/tag/v3.94.0).

Highlights from [CHANGELOG](https://github.com/buildkite/agent/blob/v3.97.0/CHANGELOG.md):
- Add pause and resume subcommands [#3273](https://github.com/buildkite/agent/pull/3273) (@DrJosh9000)
- Redact meta-data values and step attribute updates with warnings [#3243](https://github.com/buildkite/agent/pull/3243) (@DrJosh9000)
- Redact annotations [#3242](https://github.com/buildkite/agent/pull/3242) (@DrJosh9000)
- ANSI parser speedup [#3237](https://github.com/buildkite/agent/pull/3237) (@DrJosh9000)


Full [CHANGELOG](https://github.com/buildkite/agent/blob/v3.97.0/CHANGELOG.md) for this version range:


> ## [v3.97.0](https://github.com/buildkite/agent/tree/v3.97.0) (2025-04-16)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.96.0...v3.97.0)
> 
> ### Added
> - `api.Client` sends request headers specified by server in register & ping [#3268](https://github.com/buildkite/agent/pull/3268) (@pda)
> 
> ### Fixed
> - Ignore the ping interval if agent will disconnect after job [#3282](https://github.com/buildkite/agent/pull/3282) (@patrobinson)
> - fix: keep fetching status after interrupt [#3277](https://github.com/buildkite/agent/pull/3277) (@DrJosh9000)
> 
> ### Internal
> - chore: flag uniformity through embedding [#3276](https://github.com/buildkite/agent/pull/3276) (@DrJosh9000)
> - locally cache nginx mime types [#3284](https://github.com/buildkite/agent/pull/3284) (@patrobinson)
> 
> ### Dependency updates
> - build(deps): bump the container-images group across 5 directories with 3 updates [#3280](https://github.com/buildkite/agent/pull/3280) (@dependabot[bot])
> - build(deps): bump the cloud-providers group across 1 directory with 4 updates [#3281](https://github.com/buildkite/agent/pull/3281) (@dependabot[bot])
> - build(deps): bump golang.org/x/net from 0.38.0 to 0.39.0 in the golang-x group [#3278](https://github.com/buildkite/agent/pull/3278) (@dependabot[bot])
> 
> ## [v3.96.0](https://github.com/buildkite/agent/tree/v3.96.0) (2025-04-10)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.95.1...v3.96.0)
> 
> ### Added
> - Add pause and resume subcommands [#3273](https://github.com/buildkite/agent/pull/3273) (@DrJosh9000)
> 
> ### Internal
> - chore: Use golangci-lint for code checks [#3274](https://github.com/buildkite/agent/pull/3274) (@DrJosh9000)
> - `FakeAPIServer`'s `PingHandler` is passed the `*http.Request` [#3271](https://github.com/buildkite/agent/pull/3271) (@pda)
> - `FakeAPIServer` handles agent registration: `AddRegistration(tok, resp)` [#3272](https://github.com/buildkite/agent/pull/3272) (@pda)
> - fix: ISE message when json.Marshal fails [#3270](https://github.com/buildkite/agent/pull/3270) (@DrJosh9000)
> - agent_worker_test: tests for endpoint switching during register/ping [#3269](https://github.com/buildkite/agent/pull/3269) (@pda)
> - Refactor fake API server [#3264](https://github.com/buildkite/agent/pull/3264) (@DrJosh9000)
> - `AgentWorker` has `noWaitBetweenPingsForTesting` field [#3262](https://github.com/buildkite/agent/pull/3262) (@pda)
> - refactor: rename `AgentRegisterResponse` local vars to `reg` consistently [#3259](https://github.com/buildkite/agent/pull/3259) (@pda)
> 
> ### Dependencies
> - Bump the container-images group across 6 directories with 2 updates [#3266](https://github.com/buildkite/agent/pull/3266) (@dependabot[bot])
> - Bump the cloud-providers group across 1 directory with 3 updates [#3267](https://github.com/buildkite/agent/pull/3267) (@dependabot[bot])
> - Bump the golang-x group with 4 updates [#3265](https://github.com/buildkite/agent/pull/3265) (@dependabot[bot])
> - Bump golang.org/x/net from 0.37.0 to 0.38.0 in the golang-x group [#3256](https://github.com/buildkite/agent/pull/3256) (@dependabot[bot])
> - Bump the container-images group across 4 directories with 1 update [#3258](https://github.com/buildkite/agent/pull/3258) (@dependabot[bot])
> - Bump the cloud-providers group across 1 directory with 2 updates [#3252](https://github.com/buildkite/agent/pull/3252) (@dependabot[bot])
> - Bump the container-images group across 5 directories with 2 updates [#3251](https://github.com/buildkite/agent/pull/3251) (@dependabot[bot])
> - Bump gopkg.in/DataDog/dd-trace-go.v1 from 1.72.1 to 1.72.2 [#3250](https://github.com/buildkite/agent/pull/3250) (@dependabot[bot])
> 
> ## [v3.95.1](https://github.com/buildkite/agent/tree/v3.95.1) (2025-03-20)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.95.0...v3.95.1)
> 
> > [!IMPORTANT]
> > Secrets (as visible to the agent in environment variables) are now redacted from annotations, meta-data values, and step updates, similar to how secrets are redacted from job logs.
> > If needed, this can be disabled by passing the flag `--redacted-vars=''` to the `annotate`, `meta-data set`, or `step update` command.
> 
> ### Security
> - Fix incomplete processing in newly-redacted operations [#3246](https://github.com/buildkite/agent/pull/3246) (@DrJosh9000)
> - Bump github.com/golang-jwt/jwt/v5 from 5.2.1 to 5.2.2 (resolves CVE-2025-30204) [#3247](https://github.com/buildkite/agent/pull/3247) (@dependabot[bot])
> 
> ## [v3.95.0](https://github.com/buildkite/agent/tree/v3.95.0) (2025-03-20)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.94.0...v3.95.0)
> 
> > [!IMPORTANT]
> > Secrets (as visible to the agent in environment variables) are now redacted from annotations, meta-data values, and step updates, similar to how secrets are redacted from job logs.
> > If needed, this can be disabled by passing the flag `--redacted-vars=''` to the `annotate`, `meta-data set`, or `step update` command.
> 
> ### Changed
> - Redact meta-data values and step attribute updates with warnings [#3243](https://github.com/buildkite/agent/pull/3243) (@DrJosh9000)
> - Redact annotations [#3242](https://github.com/buildkite/agent/pull/3242) (@DrJosh9000)
> - ANSI parser speedup [#3237](https://github.com/buildkite/agent/pull/3237) (@DrJosh9000)
> 
> ### Fixed
> - Agents running with disconnect-after-job or disconnect-after-idle-timeout can now be kept alive with agent pausing [#3238](https://github.com/buildkite/agent/pull/3238) (@DrJosh9000)
> - The `pty-raw` experiment no longer causes a warning to be logged [#3241](https://github.com/buildkite/agent/pull/3241) (@DrJosh9000)
> 
> ### Dependency updates
> - Bump google.golang.org/api from 0.224.0 to 0.226.0 in the cloud-providers group [#3240](https://github.com/buildkite/agent/pull/3240) (@dependabot[bot])
> - Bump the container-images group across 7 directories with 3 updates [#3239](https://github.com/buildkite/agent/pull/3239) (@dependabot[bot])