### PR TITLE
Fix incorrect username in SSH access doc

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -140,7 +140,7 @@ Metadata:
 
 Parameters:
   KeyName:
-    Description: Optional - SSH keypair used to access the buildkite instances via ec2_user, setting this will enable SSH ingress
+    Description: Optional - SSH keypair used to access the buildkite instances via ec2-user, setting this will enable SSH ingress
     Type: String
     Default: ""
 
@@ -298,7 +298,7 @@ Parameters:
     Default: ""
 
   AuthorizedUsersUrl:
-    Description: Optional - HTTPS or S3 URL to periodically download ssh authorized_keys from, setting this will enable SSH ingress. authorized_keys are applied to ec2_user
+    Description: Optional - HTTPS or S3 URL to periodically download ssh authorized_keys from, setting this will enable SSH ingress. authorized_keys are applied to ec2-user
     Type: String
     Default: ""
 


### PR DESCRIPTION
The documentation of parameters available for use with the AWS elastic stack lists the wrong username for SSH access to agents - it should be `ec2-user` rather than `ec2_user.` Just correcting this.