### PR TITLE
feat: pave road to resource limit control

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,42 @@ If you want to explicitly specify which actions CloudFormation can perform on yo
 aws cloudformation deploy --template-file templates/service-role.yml --stack-name buildkite-elastic-ci-stack-service-role --region us-east-1 --capabilities CAPABILITY_IAM
 ```
 
+### Experimental Resource Limits
+
+The Elastic CI Stack includes configurable systemd resource limits to prevent resource exhaustion. These limits can be configured using CloudFormation parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `ExperimentalEnableResourceLimits` | Enable systemd resource limits for the Buildkite agent | `false` |
+| `ResourceLimitsMemoryHigh` | MemoryHigh limit (e.g., '90%' or '4G') | `90%` |
+| `ResourceLimitsMemoryMax` | MemoryMax limit (e.g., '90%' or '4G') | `90%` |
+| `ResourceLimitsMemorySwapMax` | MemorySwapMax limit (e.g., '90%' or '4G') | `90%` |
+| `ResourceLimitsCPUWeight` | CPU weight (1-10000) | `100` |
+| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%' or '1800m' for 1.8 CPUs) | `90%` |
+| `ResourceLimitsIOWeight` | I/O weight (1-10000) | `80` |
+
+### Example Configuration
+
+To enable resource limits with custom values, include these parameters in your CloudFormation template or config file:
+
+```yaml
+{
+  "Parameters": {
+    "ExperimentalEnableResourceLimits": "true",
+    "ResourceLimitsMemoryHigh": "80%",
+    "ResourceLimitsMemoryMax": "85%",
+    "ResourceLimitsMemorySwapMax": "90%",
+    "ResourceLimitsCPUWeight": "100",
+    "ResourceLimitsCPUQuota": "85%",
+    "ResourceLimitsIOWeight": "75"
+  }
+}
+```
+
+### Notes
+- Resource limits are disabled by default
+- Values can be specified as percentages or absolute values (for memory-related parameters)
+
 ## Development
 
 To get started with customizing your own stack, or contributing fixes and features:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,42 @@ To enable resource limits with custom values, include these parameters in your C
 - Resource limits are disabled by default
 - Values can be specified as percentages or absolute values (for memory-related parameters)
 
+### Experimental Resource Limits
+
+The Elastic CI Stack includes configurable systemd resource limits to prevent resource exhaustion. These limits can be configured using CloudFormation parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `ExperimentalEnableResourceLimits` | Enable systemd resource limits for the Buildkite agent | `false` |
+| `ResourceLimitsMemoryHigh` | MemoryHigh limit (e.g., '90%' or '4G') | `90%` |
+| `ResourceLimitsMemoryMax` | MemoryMax limit (e.g., '90%' or '4G') | `90%` |
+| `ResourceLimitsMemorySwapMax` | MemorySwapMax limit (e.g., '90%' or '4G') | `90%` |
+| `ResourceLimitsCPUWeight` | CPU weight (1-10000) | `100` |
+| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%' or '1800m' for 1.8 CPUs) | `90%` |
+| `ResourceLimitsIOWeight` | I/O weight (1-10000) | `80` |
+
+### Example Configuration
+
+To enable resource limits with custom values, include these parameters in your CloudFormation template or config file:
+
+```yaml
+{
+  "Parameters": {
+    "ExperimentalEnableResourceLimits": "true",
+    "ResourceLimitsMemoryHigh": "80%",
+    "ResourceLimitsMemoryMax": "85%",
+    "ResourceLimitsMemorySwapMax": "90%",
+    "ResourceLimitsCPUWeight": "100",
+    "ResourceLimitsCPUQuota": "85%",
+    "ResourceLimitsIOWeight": "75"
+  }
+}
+```
+
+### Notes
+- Resource limits are disabled by default
+- Values can be specified as percentages or absolute values (for memory-related parameters)
+
 ## Development
 
 To get started with customizing your own stack, or contributing fixes and features:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The Elastic CI Stack includes configurable systemd resource limits to prevent re
 | `ResourceLimitsMemoryMax` | MemoryMax limit (e.g., '90%' or '4G') | `90%` |
 | `ResourceLimitsMemorySwapMax` | MemorySwapMax limit (e.g., '90%' or '4G') | `90%` |
 | `ResourceLimitsCPUWeight` | CPU weight (1-10000) | `100` |
-| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%' or '1800m' for 1.8 CPUs) | `90%` |
+| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%') | `90%` |
 | `ResourceLimitsIOWeight` | I/O weight (1-10000) | `80` |
 
 ### Example Configuration
@@ -103,7 +103,7 @@ The Elastic CI Stack includes configurable systemd resource limits to prevent re
 | `ResourceLimitsMemoryMax` | MemoryMax limit (e.g., '90%' or '4G') | `90%` |
 | `ResourceLimitsMemorySwapMax` | MemorySwapMax limit (e.g., '90%' or '4G') | `90%` |
 | `ResourceLimitsCPUWeight` | CPU weight (1-10000) | `100` |
-| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%' or '1800m' for 1.8 CPUs) | `90%` |
+| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%') | `90%` |
 | `ResourceLimitsIOWeight` | I/O weight (1-10000) | `80` |
 
 ### Example Configuration

--- a/README.md
+++ b/README.md
@@ -56,43 +56,7 @@ If you want to explicitly specify which actions CloudFormation can perform on yo
 aws cloudformation deploy --template-file templates/service-role.yml --stack-name buildkite-elastic-ci-stack-service-role --region us-east-1 --capabilities CAPABILITY_IAM
 ```
 
-### Experimental Resource Limits
-
-The Elastic CI Stack includes configurable systemd resource limits to prevent resource exhaustion. These limits can be configured using CloudFormation parameters:
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `ExperimentalEnableResourceLimits` | Enable systemd resource limits for the Buildkite agent | `false` |
-| `ResourceLimitsMemoryHigh` | MemoryHigh limit (e.g., '90%' or '4G') | `90%` |
-| `ResourceLimitsMemoryMax` | MemoryMax limit (e.g., '90%' or '4G') | `90%` |
-| `ResourceLimitsMemorySwapMax` | MemorySwapMax limit (e.g., '90%' or '4G') | `90%` |
-| `ResourceLimitsCPUWeight` | CPU weight (1-10000) | `100` |
-| `ResourceLimitsCPUQuota` | CPU quota (e.g., '90%') | `90%` |
-| `ResourceLimitsIOWeight` | I/O weight (1-10000) | `80` |
-
-### Example Configuration
-
-To enable resource limits with custom values, include these parameters in your CloudFormation template or config file:
-
-```yaml
-{
-  "Parameters": {
-    "ExperimentalEnableResourceLimits": "true",
-    "ResourceLimitsMemoryHigh": "80%",
-    "ResourceLimitsMemoryMax": "85%",
-    "ResourceLimitsMemorySwapMax": "90%",
-    "ResourceLimitsCPUWeight": "100",
-    "ResourceLimitsCPUQuota": "85%",
-    "ResourceLimitsIOWeight": "75"
-  }
-}
-```
-
-### Notes
-- Resource limits are disabled by default
-- Values can be specified as percentages or absolute values (for memory-related parameters)
-
-### Experimental Resource Limits
+## Experimental Resource Limits
 
 The Elastic CI Stack includes configurable systemd resource limits to prevent resource exhaustion. These limits can be configured using CloudFormation parameters:
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -255,6 +255,8 @@ Parameters:
       The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
     Type: String
     Default: '90%'
+    AllowedPattern: '^(\d+([KkMmGgTt])?|\d+%|infinity)$'
+    ConstraintDescription: "Must be a percentage (e.g., 90%), a value in bytes with an optional unit [K,M,G,T] (e.g., 4G), or 'infinity'."
 
   ResourceLimitsMemoryMax:
     Description: >
@@ -262,6 +264,8 @@ Parameters:
       The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
     Type: String
     Default: '90%'
+    AllowedPattern: '^(\d+([KkMmGgTt])?|\d+%|infinity)$'
+    ConstraintDescription: "Must be a percentage (e.g., 90%), a value in bytes with an optional unit [K,M,G,T] (e.g., 4G), or 'infinity'."
 
   ResourceLimitsMemorySwapMax:
     Description: >
@@ -269,6 +273,8 @@ Parameters:
       The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
     Type: String
     Default: '90%'
+    AllowedPattern: '^(\d+([KkMmGgTt])?|\d+%|infinity)$'
+    ConstraintDescription: "Must be a percentage (e.g., 90%), a value in bytes with an optional unit [K,M,G,T] (e.g., 4G), or 'infinity'."
 
   ResourceLimitsCPUWeight:
     Description: >
@@ -282,65 +288,11 @@ Parameters:
   ResourceLimitsCPUQuota:
     Description: >
       (Experimental) Sets the CPU quota for the Buildkite agent slice.
-      Can be a percentage (e.g., '90%') or a value with units (e.g., '1800m' for 1.8 CPUs).
+      Takes a percentage value, suffixed with "%" .
     Type: String
     Default: '90%'
-
-  ResourceLimitsIOWeight:
-    Description: >
-      (Experimental) Sets the I/O weight for the Buildkite agent slice (1-10000, default 80).
-      Higher values give more I/O bandwidth to the agent.
-    Type: Number
-    Default: 80
-    MinValue: 1
-    MaxValue: 10000
-
-  ExperimentalEnableResourceLimits:
-    Description: >
-      (Experimental) If true, enables systemd resource limits for the Buildkite agent.
-      This helps prevent resource exhaustion by limiting CPU, memory, and I/O usage.
-    Type: String
-    AllowedValues:
-      - "true"
-      - "false"
-    Default: "false"
-
-  ResourceLimitsMemoryHigh:
-    Description: >
-      (Experimental) Sets the MemoryHigh limit for the Buildkite agent slice.
-      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
-    Type: String
-    Default: '90%'
-
-  ResourceLimitsMemoryMax:
-    Description: >
-      (Experimental) Sets the MemoryMax limit for the Buildkite agent slice.
-      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
-    Type: String
-    Default: '90%'
-
-  ResourceLimitsMemorySwapMax:
-    Description: >
-      (Experimental) Sets the MemorySwapMax limit for the Buildkite agent slice.
-      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
-    Type: String
-    Default: '90%'
-
-  ResourceLimitsCPUWeight:
-    Description: >
-      (Experimental) Sets the CPU weight for the Buildkite agent slice (1-10000, default 100).
-      Higher values give more CPU time to the agent.
-    Type: Number
-    Default: 100
-    MinValue: 1
-    MaxValue: 10000
-
-  ResourceLimitsCPUQuota:
-    Description: >
-      (Experimental) Sets the CPU quota for the Buildkite agent slice.
-      Can be a percentage (e.g., '90%') or a value with units (e.g., '1800m' for 1.8 CPUs).
-    Type: String
-    Default: '90%'
+    AllowedPattern: '^\d+%$'
+    ConstraintDescription: "Must be a percentage value (e.g., 90%)."
 
   ResourceLimitsIOWeight:
     Description: >

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -239,6 +239,62 @@ Parameters:
       - "false"
     Default: "false"
 
+  ExperimentalEnableResourceLimits:
+    Description: >
+      (Experimental) If true, enables systemd resource limits for the Buildkite agent.
+      This helps prevent resource exhaustion by limiting CPU, memory, and I/O usage.
+    Type: String
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
+  ResourceLimitsMemoryHigh:
+    Description: >
+      (Experimental) Sets the MemoryHigh limit for the Buildkite agent slice.
+      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsMemoryMax:
+    Description: >
+      (Experimental) Sets the MemoryMax limit for the Buildkite agent slice.
+      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsMemorySwapMax:
+    Description: >
+      (Experimental) Sets the MemorySwapMax limit for the Buildkite agent slice.
+      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsCPUWeight:
+    Description: >
+      (Experimental) Sets the CPU weight for the Buildkite agent slice (1-10000, default 100).
+      Higher values give more CPU time to the agent.
+    Type: Number
+    Default: 100
+    MinValue: 1
+    MaxValue: 10000
+
+  ResourceLimitsCPUQuota:
+    Description: >
+      (Experimental) Sets the CPU quota for the Buildkite agent slice.
+      Can be a percentage (e.g., '90%') or a value with units (e.g., '1800m' for 1.8 CPUs).
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsIOWeight:
+    Description: >
+      (Experimental) Sets the I/O weight for the Buildkite agent slice (1-10000, default 80).
+      Higher values give more I/O bandwidth to the agent.
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 10000
+
   BuildkiteAdditionalSudoPermissions:
     Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo. Note that the commands should be fully qualified paths to executables.
     Type: String
@@ -1514,6 +1570,13 @@ Resources:
                   DOCKER_EXPERIMENTAL="${EnableDockerExperimental}" \
                   DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
                   AWS_REGION="${AWS::Region}" \
+                  ENABLE_RESOURCE_LIMITS="${ExperimentalEnableResourceLimits}" \
+                  RESOURCE_LIMITS_MEMORY_HIGH="${ResourceLimitsMemoryHigh}" \
+                  RESOURCE_LIMITS_MEMORY_MAX="${ResourceLimitsMemoryMax}" \
+                  RESOURCE_LIMITS_MEMORY_SWAP_MAX="${ResourceLimitsMemorySwapMax}" \
+                  RESOURCE_LIMITS_CPU_WEIGHT="${ResourceLimitsCPUWeight}" \
+                  RESOURCE_LIMITS_CPU_QUOTA="${ResourceLimitsCPUQuota}" \
+                  RESOURCE_LIMITS_IO_WEIGHT="${ResourceLimitsIOWeight}" \
                     /usr/local/bin/bk-install-elastic-stack.sh
                   --==BOUNDARY==--
                 - LocalSecretsBucket: !If

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -263,7 +263,7 @@ Parameters:
       The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
     Type: String
     Default: '90%'
-    AllowedPattern: '^(\d+([KkMmGgTt])?|\d+%|infinity)$'
+    AllowedPattern: '^(\d+([KkMmGgTt])?|(?:[1-9][0-9]?|100)%|infinity)$'
     ConstraintDescription: "Must be a percentage (e.g., 90%), a value in bytes with an optional unit [K,M,G,T] (e.g., 4G), or 'infinity'."
 
   ResourceLimitsMemoryMax:
@@ -272,7 +272,7 @@ Parameters:
       The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
     Type: String
     Default: '90%'
-    AllowedPattern: '^(\d+([KkMmGgTt])?|\d+%|infinity)$'
+    AllowedPattern: '^(\d+([KkMmGgTt])?|(?:[1-9][0-9]?|100)%|infinity)$'
     ConstraintDescription: "Must be a percentage (e.g., 90%), a value in bytes with an optional unit [K,M,G,T] (e.g., 4G), or 'infinity'."
 
   ResourceLimitsMemorySwapMax:
@@ -281,7 +281,7 @@ Parameters:
       The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
     Type: String
     Default: '90%'
-    AllowedPattern: '^(\d+([KkMmGgTt])?|\d+%|infinity)$'
+    AllowedPattern: '^(\d+([KkMmGgTt])?|(?:[1-9][0-9]?|100)%|infinity)$'
     ConstraintDescription: "Must be a percentage (e.g., 90%), a value in bytes with an optional unit [K,M,G,T] (e.g., 4G), or 'infinity'."
 
   ResourceLimitsCPUWeight:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -295,6 +295,62 @@ Parameters:
     MinValue: 1
     MaxValue: 10000
 
+  ExperimentalEnableResourceLimits:
+    Description: >
+      (Experimental) If true, enables systemd resource limits for the Buildkite agent.
+      This helps prevent resource exhaustion by limiting CPU, memory, and I/O usage.
+    Type: String
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "false"
+
+  ResourceLimitsMemoryHigh:
+    Description: >
+      (Experimental) Sets the MemoryHigh limit for the Buildkite agent slice.
+      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsMemoryMax:
+    Description: >
+      (Experimental) Sets the MemoryMax limit for the Buildkite agent slice.
+      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsMemorySwapMax:
+    Description: >
+      (Experimental) Sets the MemorySwapMax limit for the Buildkite agent slice.
+      The value can be a percentage (e.g., '90%') or an absolute value (e.g., '4G').
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsCPUWeight:
+    Description: >
+      (Experimental) Sets the CPU weight for the Buildkite agent slice (1-10000, default 100).
+      Higher values give more CPU time to the agent.
+    Type: Number
+    Default: 100
+    MinValue: 1
+    MaxValue: 10000
+
+  ResourceLimitsCPUQuota:
+    Description: >
+      (Experimental) Sets the CPU quota for the Buildkite agent slice.
+      Can be a percentage (e.g., '90%') or a value with units (e.g., '1800m' for 1.8 CPUs).
+    Type: String
+    Default: '90%'
+
+  ResourceLimitsIOWeight:
+    Description: >
+      (Experimental) Sets the I/O weight for the Buildkite agent slice (1-10000, default 80).
+      Higher values give more I/O bandwidth to the agent.
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 10000
+
   BuildkiteAdditionalSudoPermissions:
     Description: Optional - Comma separated list of commands to allow the buildkite-agent user to run using sudo. Note that the commands should be fully qualified paths to executables.
     Type: String


### PR DESCRIPTION
Introduce configurable [systemd resource limits](https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html) for the Buildkite agent to prevent resource exhaustion. The implementation allows control over CPU, memory, and I/O limits through CloudFormation parameters.

## Changes
* Add `ExperimentalEnableResourceLimits` parameter to toggle resource limits
* Add configurable parameters for memory, CPU, and I/O limits with sensible defaults
* Add systemd slice and drop-in configuration in `bk-install-elastic-stack.sh`

Resource limits can be configured using these CloudFormation parameters:
`ResourceLimitsMemoryHigh`: MemoryHigh limit (default: 90%)
`ResourceLimitsMemoryMax`: MemoryMax limit (default: 90%)
`ResourceLimitsMemorySwapMax`: MemorySwapMax limit (default: 90%)
`ResourceLimitsCPUWeight`: CPU weight (default: 100)
`ResourceLimitsCPUQuota`: CPU quota (default: 90%)
`ResourceLimitsIOWeight`: I/O weight (default: 80)

## Testing
* Deploy Elastic CI Stack with `aws-stack.yml` produced with this branch
* Set `ExperimentalEnableResourceLimits` to `true`
* Run pipeline with `stress-ng`, e.g.: 
	```yaml
	steps:
	    - label: "stress-ng"
	      plugins: 
	        - docker#v5.12.0:
	            command: ["--cpu", "0", "--io", "2", "--vm", "1", "--vm-bytes", "95%", "--timeout", "300s", "--metrics-brief"]
	            image: ghcr.io/colinianking/stress-ng
	```
* SSM into EC2
* Run `systemd-cgtop` to verify if our service slice is applied
* Run `dmesg -T` — you should see entries like `[Fri May 30 09:23:05 2025] __vm_enough_memory: pid: 2689, comm: stress-ng-vm, no enough memory for the allocation` indicating that resources were contained within limits