### PR TITLE
Bump Agent v3.97.0 -> v3.98.1

### DIFF
--- a/packer/linux/scripts/install-buildkite-agent.sh
+++ b/packer/linux/scripts/install-buildkite-agent.sh
@@ -15,7 +15,7 @@ sudo mkdir -p /var/lib/buildkite-agent/.aws
 sudo cp /tmp/conf/aws/config /var/lib/buildkite-agent/.aws/config
 sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
 
-AGENT_VERSION=3.97.0
+AGENT_VERSION=3.98.1
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
   "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"

--- a/packer/windows/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/scripts/install-buildkite-agent.ps1
@@ -1,7 +1,7 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-$AGENT_VERSION = "3.97.0"
+$AGENT_VERSION = "3.98.1"
 
 Write-Output "Creating bin dir..."
 New-Item -ItemType directory -Path C:\buildkite-agent\bin


### PR DESCRIPTION
Updates the agent version to [v3.98.1](https://github.com/buildkite/agent/releases/tag/v3.98.1), was [v3.97.0](https://github.com/buildkite/agent/releases/tag/v3.97.0)

## Highlights from [CHANGELOG](https://github.com/buildkite/agent/blob/v3.98.1/CHANGELOG.md):

> [v3.98.1](https://github.com/buildkite/agent/tree/v3.98.1) (2025-06-04)
[Full Changelog](https://github.com/buildkite/agent/compare/v3.98.0...v3.98.1)
Fixed
Gracefully Handle Missing GitHub PR refs/pull/%s/head in Checkout https://github.com/buildkite/agent/pull/3294 (@123sarahj123)
Fix bootstrap subprocess handling https://github.com/buildkite/agent/pull/3331 (@DrJosh9000)
Reduce git fetch from twice to once for typical Github PR build https://github.com/buildkite/agent/pull/3327 (@zhming0)
Set job log tempfile permissions to 644 (was 600) https://github.com/buildkite/agent/pull/3330 (@moskyb)
Internal
Tag tests with os / arch https://github.com/buildkite/agent/pull/3326 (@catkins)

## Full [Changelog](https://github.com/buildkite/agent/blob/v3.98.1/CHANGELOG.md) for versions in range: 

> [v3.98.1](https://github.com/buildkite/agent/tree/v3.98.1) (2025-06-04)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.98.0...v3.98.1)
> 
> Fixed
> Gracefully Handle Missing GitHub PR refs/pull/%s/head in Checkout https://github.com/buildkite/agent/pull/3294 (@123sarahj123)
> Fix bootstrap subprocess handling https://github.com/buildkite/agent/pull/3331 (@DrJosh9000)
> Reduce git fetch from twice to once for typical Github PR build https://github.com/buildkite/agent/pull/3327 (@zhming0)
> Set job log tempfile permissions to 644 (was 600) https://github.com/buildkite/agent/pull/3330 (@moskyb)
> Internal
> Tag tests with os / arch https://github.com/buildkite/agent/pull/3326 (@catkins)
> [v3.98.0](https://github.com/buildkite/agent/tree/v3.98.0) (2025-05-27)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.97.2...v3.98.0)
> 
> Added
> Add build URL to log fields https://github.com/buildkite/agent/pull/3317 (@ChrisBr)
> Add kubernetes-bootstrap subcommand https://github.com/buildkite/agent/pull/3306, https://github.com/buildkite/agent/pull/3314, https://github.com/buildkite/agent/pull/3316 (@DrJosh9000)
> Fixed
> Fix redactor add --format json help string https://github.com/buildkite/agent/pull/3322 (@francoiscampbell)
> Dependency updates
> https://github.com/buildkite/agent/pull/3320, https://github.com/buildkite/agent/pull/3318, https://github.com/buildkite/agent/pull/3319, https://github.com/buildkite/agent/pull/3323, https://github.com/buildkite/agent/pull/3321 (@dependabot[bot])
> [v3.97.2](https://github.com/buildkite/agent/tree/v3.97.2) (2025-05-13)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.97.1...v3.97.2)
> 
> Fixed
> fix: Don't disconnect-after-idle when just given a job https://github.com/buildkite/agent/pull/3312 (@DrJosh9000)
> Dependency updates
> https://github.com/buildkite/agent/pull/3307, https://github.com/buildkite/agent/pull/3311, https://github.com/buildkite/agent/pull/3308, https://github.com/buildkite/agent/pull/3309, https://github.com/buildkite/agent/pull/3310 (@dependabot[bot])
> [v3.97.1](https://github.com/buildkite/agent/tree/v3.97.1) (2025-05-12)
> [Full Changelog](https://github.com/buildkite/agent/compare/v3.97.0...v3.97.1)
> 
> Fixed
> Fix unusable BUILDKITE_AGENT_TAGS_FROM_EC2_TAGS env var https://github.com/buildkite/agent/pull/3285 (@shanesmith)
> Set ignore_agent_in_dispatches when finishing with disconnect-after-job https://github.com/buildkite/agent/pull/3297 (@DrJosh9000)
> Internal
> Introduce a structure where coverage can increase on githttp checkout code https://github.com/buildkite/agent/pull/3296 (@wolfeidau)
> TE-3708-follow-up: Use go test -cover to generate coverage report https://github.com/buildkite/agent/pull/3295 (@zhming0)
> TE-3708: use bktec on agent https://github.com/buildkite/agent/pull/3292 (@zhming0)
> Dependency updates
> https://github.com/buildkite/agent/pull/3298, https://github.com/buildkite/agent/pull/3300, https://github.com/buildkite/agent/pull/3301, https://github.com/buildkite/agent/pull/3299, https://github.com/buildkite/agent/pull/3287, https://github.com/buildkite/agent/pull/3290, https://github.com/buildkite/agent/pull/3291 (@dependabot[bot])
