### PR TITLE
fix: update agent-scaler to 1.9.4

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -203,7 +203,7 @@ Parameters:
     Type: String
     AllowedPattern: '^(?:(?:[2-9]|[1-9]\d+)\.\d+\.\d+|1\.(?:[1-9]\d+\.\d+|9\.[1-9]\d*))$'
     ConstraintDescription: "The agent scaler release must be greater than 1.9.0 as a new parameter was introduced in 1.9.1"
-    Default: "1.9.3"
+    Default: "1.9.4"
 
   ScalerEnableExperimentalElasticCIMode:
     Description: "[EXPERIMENTAL] Enable the Elastic CI Mode with enhanced features like safety checks, agent sorting, dangling instance detection, and graceful termination"


### PR DESCRIPTION
Addresses:
 - golang/go#71988 which were not backported to 1.22
 - correct permissions to handle instances in ElasticCIMode