### PR TITLE
Add link from build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1><img alt="Elastic CI Stack for AWS" src="images/banner.png?raw=true"></h1>
 
-![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=main)
+[![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=main)](https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/latest?branch=main)
 
 ## Buildkite Elastic CI Stack for AWS
 


### PR DESCRIPTION
I clicked on this badge expecting it to take me to the pipeline. Instead it selected the text in the SVG 😅  

For folks without access this will 404, but that seems fine to me. Eventually I think we'd like to make the pipeline public, so this problem will eventually solve itself.