### PR TITLE
chore: add cfn-lint to the pipeline

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,6 +7,17 @@ steps:
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 
+  - id: "cfn-lint"
+    name: ":mag: cfn-lint"
+    command: .buildkite/steps/cfn-lint.sh
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    soft_fail:
+    # https://github.com/aws-cloudformation/cfn-lint#exit-codes
+      - exit_status: 4 # Warning
+      - exit_status: 8 # Informational
+      - exit_status: 12 # Warning and informational
+
   - label: ":bash: shfmt"
     key: fmt
     command: .buildkite/steps/shfmt.sh
@@ -30,6 +41,7 @@ steps:
     depends_on:
       - "fmt"
       - "lint"
+      - "cfn-lint"
       - "fixperms-tests"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
@@ -45,6 +57,7 @@ steps:
     depends_on:
       - "fmt"
       - "lint"
+      - "cfn-lint"
       - "fixperms-tests"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
@@ -98,6 +111,7 @@ steps:
     depends_on:
       - "fmt"
       - "lint"
+      - "cfn-lint"
       - "fixperms-tests"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:
@@ -150,6 +164,7 @@ steps:
     depends_on:
       - "fmt"
       - "lint"
+      - "cfn-lint"
       - "fixperms-tests"
     plugins:
       - aws-assume-role-with-web-identity#v1.1.0:

--- a/.buildkite/steps/cfn-lint.sh
+++ b/.buildkite/steps/cfn-lint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- Installing cfn-lint"
+pip install -q cfn-lint==1.36.0
+
+echo "--- Running cfn-lint on templates in templates/"
+# cfn-lint will scan all *.json, *.yaml, *.yml, *.template files in the directory and subdirectories.
+/var/lib/buildkite-agent/.local/bin/cfn-lint templates/*

--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,2 @@
+ignore_checks:
+  - E1011

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -861,9 +861,6 @@ Conditions:
     UseWindowsAgents:
       !Equals [ !Ref InstanceOperatingSystem, "windows" ]
 
-    UseLinuxAgents:
-      !Equals [ !Ref InstanceOperatingSystem, "linux" ]
-
     # Unfortunately, Cloudformation's !Or intrinsic function only accepts
     # between 2 and 10 arguments.  To get around this, we're grouping the
     # instance families in sub-conditionals.  At least this doesn't force us
@@ -1035,6 +1032,7 @@ Resources:
   PipelineSigningKMSKey:
     Type: AWS::KMS::Key
     Condition: CreatePipelineSigningKMSKey
+    UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
     Properties:
       Description: Key used to sign and verify pipelines
@@ -1212,6 +1210,7 @@ Resources:
   ManagedSecretsLoggingBucket:
     Type: AWS::S3::Bucket
     Condition: CreateSecretsBucket
+    UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
     Properties:
       PublicAccessBlockConfiguration:
@@ -1274,6 +1273,7 @@ Resources:
   ManagedSecretsBucket:
     Type: AWS::S3::Bucket
     Condition: CreateSecretsBucket
+    UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
     Properties:
       BucketEncryption:


### PR DESCRIPTION
Add cfn-lint (https://github.com/aws-cloudformation/cfn-lint), so we catch potential issues with CloudFormation templates early.

Fixes:
- W8001 
- W3011

https://github.com/aws-cloudformation/cfn-lint/blob/4c5154ea07645742262090a390081efc3de25e87/docs/rules.md 