### PR TITLE
SUP-4081 - Update config.json.example for installing Elastic CI stack with the AWS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The current release is ![](https://img.shields.io/github/release/buildkite/elast
 
 > Although the stack creates its own VPC by default, Buildkite highly recommends following best practices by setting up a separate development AWS account and using role switching and consolidated billing — see the [Delegate Access Across AWS Accounts tutorial](http://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more information.
 
-If you want to use the [AWS CLI](https://aws.amazon.com/cli/), download [`config.json.example`](config.json.example), rename it to `config.json`, and then run the below command:
+If you want to use the [AWS CLI](https://aws.amazon.com/cli/), download [`config.json.example`](config.json.example), rename it to `config.json`, update it with your agent token, then run the below AWS CLI command to create the AWS CloudFormation stack:
 
 ```bash
 aws cloudformation create-stack \

--- a/config.json.example
+++ b/config.json.example
@@ -1,14 +1,6 @@
 [
   {
     "ParameterKey": "BuildkiteAgentToken",
-    "ParameterValue": "TokenGoesHere"
-  },
-  {
-    "ParameterKey": "KeyName",
-    "ParameterValue": "default"
-  },
-  {
-    "ParameterKey": "ImageId",
-    "ParameterValue": ""
+    "ParameterValue": "<insert-your-token>"
   }
 ]


### PR DESCRIPTION
Removed the optional parameters `KeyName` and `ImageId` to ensure portability