### PR TITLE
fix: add new parameters to labeled sections

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -98,6 +98,13 @@ Metadata:
         - IMDSv2Tokens
         - EnableDetailedMonitoring
         - InstanceName
+        - ExperimentalEnableResourceLimits
+        - ResourceLimitsMemoryHigh
+        - ResourceLimitsMemoryMax
+        - ResourceLimitsMemorySwapMax
+        - ResourceLimitsCPUWeight
+        - ResourceLimitsCPUQuota
+        - ResourceLimitsIOWeight
 
       - Label:
           default: Auto-scaling Configuration
@@ -112,6 +119,7 @@ Metadata:
         - InstanceCreationTimeout
         - ScalerEventSchedulePeriod
         - ScalerMinPollInterval
+        - ScalerEnableExperimentalElasticCIMode
 
       - Label:
           default: Cost Allocation Configuration


### PR DESCRIPTION
This fixes issue with missing parameters like `ExperimentalEnableResourceLimits` in https://buildkite.com/docs/agent/v3/aws/elastic-ci-stack/ec2-linux-and-windows/template-parameters Add rest of missing params