### PR TITLE
Renovate: fix tag references for buildkite agent

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,7 @@
         "\\$AGENT_VERSION = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "github-releases",
+      "packageName": "buildkite/agent",
       "depNameTemplate": "buildkite/agent",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }


### PR DESCRIPTION
In the first PR opened by Renovate for the buildkite agent, we were missing tags in the PR description https://github.com/buildkite/elastic-ci-stack-for-aws/pull/151. This change should fix it.