### PR TITLE
Renovate: set versioning template for bk agent

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,8 @@
         "\\$AGENT_VERSION = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "github-releases",
-      "packageName": "buildkite/agent",
       "depNameTemplate": "buildkite/agent",
+      "versioningTemplate": "semver",
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ],


### PR DESCRIPTION
In #1513 I used invalid attribute misled by some other configurations found.  This PR should address the issue with missing version refs that I meant to fix in #1513.

Closes #1514