### PR TITLE
Fix buildkite agent version reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,7 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "buildkite/agent",
-      "versioningTemplate": "semver",
-      "extractVersionTemplate": "^v?(?<version>.*)$"
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Remove the extractVersionTemplate line from your Renovate config to preserve the full version tags