### PR TITLE
Fix Renovate escaping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,7 @@
       "commitMessageTopic": "buildkite-agent",
       "commitMessageExtra": "to v{{newVersion}}",
       "semanticCommitType": "chore",
-      "prBodyTemplate": "This PR updates the buildkite-agent from v{{currentVersion}} to v{{newVersion}}.\n\n### Agent Release Notes\n\nSee the [full release notes](https://github.com/buildkite/agent/releases/tag/v{{newVersion}}) for details about what's included in this update.\n\n{{{changelog}}}",
+      "prBodyTemplate": "This PR updates the buildkite-agent from v{{{currentVersion}}} to v{{{newVersion}}}.\n\n### Agent Release Notes\n\nSee the [full release notes](https://github.com/buildkite/agent/releases/tag/v{{{newVersion}}}) for details about what's included in this update.\n\n{{{changelog}}}",
       "labels": [
         "dependencies",
         "buildkite-agent"


### PR DESCRIPTION
Use `{{{` to properly escape variables in pull request description.

As per https://docs.renovatebot.com/configuration-options/#custommanagers:
> For template fields, use the triple brace {{{ }}} notation to avoid Handlebars escaping any special characters.