### PR TITLE
Fix Renovate placeholders references

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,7 +33,7 @@
       "commitMessageTopic": "buildkite-agent",
       "commitMessageExtra": "to v{{newVersion}}",
       "semanticCommitType": "chore",
-      "prBodyTemplate": "This PR updates the buildkite-agent from v{{{currentVersion}}} to v{{{newVersion}}}.\n\n### Agent Release Notes\n\nSee the [full release notes](https://github.com/buildkite/agent/releases/tag/v{{{newVersion}}}) for details about what's included in this update.\n\n{{{changelog}}}",
+      "prBodyTemplate": "This PR updates the buildkite-agent from v{{{currentValue}}} to v{{{newValue}}}.\n\n### Agent Release Notes\n\nSee the [full release notes](https://github.com/buildkite/agent/releases/tag/v{{{newValue}}}) for details about what's included in this update.\n\n{{{changelog}}}",
       "labels": [
         "dependencies",
         "buildkite-agent"


### PR DESCRIPTION
Use correct placeholders exposed by the regex group. Somehow `newVersion` works in the commit message, but not in the PR description, even though both are present in Renovate's run. If that doesn't work, I'll remove PR body template completely.