### PR TITLE
Require agent-scaler 1.9.5 or newer

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -210,8 +210,8 @@ Parameters:
   BuildkiteAgentScalerVersion:
     Description: "Version of the buildkite-agent-scaler to use."
     Type: String
-    AllowedPattern: '^(?:(?:[2-9]|[1-9]\d+)\.\d+\.\d+|1\.(?:[1-9]\d+\.\d+|9\.[1-9]\d*))$'
-    ConstraintDescription: "The agent scaler release must be greater than 1.9.0 as a new parameter was introduced in 1.9.1"
+    AllowedPattern: '^(?:(?:[2-9]|[1-9]\d+)\.\d+\.\d+|1\.(?:[1-9]\d+\.\d+|9\.(?:[5-9]|[1-9]\d+)))$'
+    ConstraintDescription: "The agent scaler release must be 1.9.5 or newer."
     Default: "1.9.5"
 
   ScalerEnableExperimentalElasticCIMode:


### PR DESCRIPTION
While upgrading to Elastic CI Stack v6.40.0 or newer, users may face a deployment issue when setting their own value for `BuildkiteAgentScalerVersion`. This is due to a new parameter added in agent-scaler 1.9.3 (https://github.com/buildkite/buildkite-agent-scaler/releases/tag/v1.9.3) that's missing in older versions of the agent-scaler.