### PR TITLE
Fix agent's signal-grace-period-seconds

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -293,6 +293,7 @@ disconnect-after-idle-timeout=${BUILDKITE_SCALE_IN_IDLE_PERIOD}
 disconnect-after-job=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
 tracing-backend=${BUILDKITE_AGENT_TRACING_BACKEND}
 cancel-grace-period=${BUILDKITE_AGENT_CANCEL_GRACE_PERIOD}
+signal-grace-period-seconds=${BUILDKITE_AGENT_SIGNAL_GRACE_PERIOD_SECONDS}
 signing-aws-kms-key=${BUILDKITE_AGENT_SIGNING_KMS_KEY}
 verification-failure-behavior=${BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR}
 EOF

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -245,7 +245,7 @@ Parameters:
   BuildkiteAgentSignalGracePeriod:
     Description: The number of seconds given to a subprocess to handle being sent `cancel-signal`. After this period has elapsed, SIGKILL will be sent.
     Type: Number
-    Default: 60
+    Default: -1
     MinValue: -1
 
   BuildkiteTerminateInstanceAfterJob:


### PR DESCRIPTION
We've added `signal-grace-period-seconds` to the CloudFormation in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1468, but it wasn't referenced in the configuration file's template.

Also, change default value to `-1`, aligning with [agent's defaults](https://buildkite.com/docs/agent/v3/cli-bootstrap#signal-grace-period-seconds).

Fixes #1530