### PR TITLE
Allow Docker default address pools to be changed

### DIFF
--- a/packer/linux/conf/bin/bk-configure-docker.sh
+++ b/packer/linux/conf/bin/bk-configure-docker.sh
@@ -57,8 +57,8 @@ if [[ "${DOCKER_NETWORKING_PROTOCOL}" == "ipv4" ]]; then
   # This is the default
   cat <<<"$(
     jq \
-      --arg pool1 "${DOCKER_ADDRESS_POOL_1:-172.17.0.0/12}" \
-      --arg pool2 "${DOCKER_ADDRESS_POOL_2:-192.168.0.0/16}" \
+      --arg pool1 "${DOCKER_IPV4_ADDRESS_POOL_1:-172.17.0.0/12}" \
+      --arg pool2 "${DOCKER_IPV4_ADDRESS_POOL_2:-192.168.0.0/16}" \
       '."default-address-pools"=[{"base":$pool1,"size":20},{"base":$pool2,"size":24}]' \
       /etc/docker/daemon.json
   )" >/etc/docker/daemon.json
@@ -68,9 +68,10 @@ elif [[ "${DOCKER_NETWORKING_PROTOCOL}" == "dualstack" ]]; then
   DOCKER_EXPERIMENTAL=true
   cat <<<"$(
     jq \
-      --arg pool1 "${DOCKER_ADDRESS_POOL_1:-172.17.0.0/12}" \
-      --arg pool2 "${DOCKER_ADDRESS_POOL_2:-192.168.0.0/16}" \
-      '.ipv6=true | ."fixed-cidr-v6"="2001:db8:1::/64" | .ip6tables=true | ."default-address-pools"=[{"base":$pool1,"size":20},{"base":$pool2,"size":24},{"base":"2001:db8:2::/104","size":112}]' \
+      --arg pool1 "${DOCKER_IPV4_ADDRESS_POOL_1:-172.17.0.0/12}" \
+      --arg pool2 "${DOCKER_IPV4_ADDRESS_POOL_2:-192.168.0.0/16}" \
+      --arg pool6 "${DOCKER_IPV6_ADDRESS_POOL:-2001:db8:2::/104}" \
+      '.ipv6=true | ."fixed-cidr-v6"="2001:db8:1::/64" | .ip6tables=true | ."default-address-pools"=[{"base":$pool1,"size":20},{"base":$pool2,"size":24},{"base":$pool6,"size":112}]' \
       /etc/docker/daemon.json
   )" >/etc/docker/daemon.json
 else

--- a/packer/linux/conf/bin/bk-configure-docker.sh
+++ b/packer/linux/conf/bin/bk-configure-docker.sh
@@ -57,7 +57,9 @@ if [[ "${DOCKER_NETWORKING_PROTOCOL}" == "ipv4" ]]; then
   # This is the default
   cat <<<"$(
     jq \
-      '."default-address-pools"=[{"base":"172.17.0.0/12","size":20},{"base":"192.168.0.0/16","size":24}]' \
+      --arg pool1 "${DOCKER_ADDRESS_POOL_1:-172.17.0.0/12}" \
+      --arg pool2 "${DOCKER_ADDRESS_POOL_2:-192.168.0.0/16}" \
+      '."default-address-pools"=[{"base":$pool1,"size":20},{"base":$pool2,"size":24}]' \
       /etc/docker/daemon.json
   )" >/etc/docker/daemon.json
 elif [[ "${DOCKER_NETWORKING_PROTOCOL}" == "dualstack" ]]; then
@@ -66,7 +68,9 @@ elif [[ "${DOCKER_NETWORKING_PROTOCOL}" == "dualstack" ]]; then
   DOCKER_EXPERIMENTAL=true
   cat <<<"$(
     jq \
-      '.ipv6=true | ."fixed-cidr-v6"="2001:db8:1::/64" | .ip6tables=true | ."default-address-pools"=[{"base":"172.17.0.0/12","size":20},{"base":"192.168.0.0/16","size":24},{"base":"2001:db8:2::/104","size":112}]' \
+      --arg pool1 "${DOCKER_ADDRESS_POOL_1:-172.17.0.0/12}" \
+      --arg pool2 "${DOCKER_ADDRESS_POOL_2:-192.168.0.0/16}" \
+      '.ipv6=true | ."fixed-cidr-v6"="2001:db8:1::/64" | .ip6tables=true | ."default-address-pools"=[{"base":$pool1,"size":20},{"base":$pool2,"size":24},{"base":"2001:db8:2::/104","size":112}]' \
       /etc/docker/daemon.json
   )" >/etc/docker/daemon.json
 else

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -587,15 +587,20 @@ Parameters:
       - "dualstack"
     Default: "ipv4"
 
-  DockerAddressPool1:
+  DockerIPv4AddressPool1:
     Type: String
-    Description: Primary CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
+    Description: Primary IPv4 CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
     Default: "172.17.0.0/12"
 
-  DockerAddressPool2:
+  DockerIPv4AddressPool2:
     Type: String
-    Description: Secondary CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
+    Description: Secondary IPv4 CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
     Default: "192.168.0.0/16"
+
+  DockerIPv6AddressPool:
+    Type: String
+    Description: IPv6 CIDR block for Docker default address pools in dualstack mode. Only applies to Linux instances, not Windows.
+    Default: "2001:db8:2::/104"
 
   EnableSecretsPlugin:
     Type: String
@@ -1581,8 +1586,9 @@ Resources:
                   DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
                   DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
                   DOCKER_NETWORKING_PROTOCOL=${DockerNetworkingProtocol} \
-                  DOCKER_ADDRESS_POOL_1=${DockerAddressPool1} \
-                  DOCKER_ADDRESS_POOL_2=${DockerAddressPool2} \
+                  DOCKER_IPV4_ADDRESS_POOL_1=${DockerIPv4AddressPool1} \
+                  DOCKER_IPV4_ADDRESS_POOL_2=${DockerIPv4AddressPool2} \
+                  DOCKER_IPV6_ADDRESS_POOL=${DockerIPv6AddressPool} \
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
                     /usr/local/bin/bk-configure-docker.sh
                   --==BOUNDARY==

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -589,7 +589,7 @@ Parameters:
 
   DockerIPv4AddressPool1:
     Type: String
-    Description: Primary IPv4 CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
+    Description: Primary IPv4 CIDR block for Docker default address pools. Must not conflict with host network or VPC CIDR. Only applies to Linux instances, not Windows.
     Default: "172.17.0.0/12"
 
   DockerIPv4AddressPool2:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -587,6 +587,16 @@ Parameters:
       - "dualstack"
     Default: "ipv4"
 
+  DockerAddressPool1:
+    Type: String
+    Description: Primary CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
+    Default: "172.17.0.0/12"
+
+  DockerAddressPool2:
+    Type: String
+    Description: Secondary CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
+    Default: "192.168.0.0/16"
+
   EnableSecretsPlugin:
     Type: String
     Description: Enables s3-secrets plugin for all pipelines
@@ -1571,6 +1581,8 @@ Resources:
                   DOCKER_USERNS_REMAP=${EnableDockerUserNamespaceRemap} \
                   DOCKER_EXPERIMENTAL=${EnableDockerExperimental} \
                   DOCKER_NETWORKING_PROTOCOL=${DockerNetworkingProtocol} \
+                  DOCKER_ADDRESS_POOL_1=${DockerAddressPool1} \
+                  DOCKER_ADDRESS_POOL_2=${DockerAddressPool2} \
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
                     /usr/local/bin/bk-configure-docker.sh
                   --==BOUNDARY==


### PR DESCRIPTION
Make the Docker default address pools configurable parameters. This will allow users the ability to change the CIDRs if these addresses conflict with the VPC IP range the Elastic CI Stack has been deployed to.

Fixes: https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1512