### PR TITLE
Create additional dependencies for VPC creation completion

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1150,7 +1150,11 @@ Resources:
       VpcResources: !If
         - CreateVpcResources
         - [ !Ref RouteDefault, !Ref Subnet0Routes, !Ref Subnet1Routes ]
-        - !Ref "AWS::NoValue"
+        - []
+      # By referencing these resources, CloudFormation creates implicit dependencies
+      Subnet0RouteCheck: !If [ CreateVpcResources, !Ref Subnet0Routes, !Ref "AWS::NoValue" ]
+      Subnet1RouteCheck: !If [ CreateVpcResources, !Ref Subnet1Routes, !Ref "AWS::NoValue" ]
+      RouteDefaultCheck: !If [ CreateVpcResources, !Ref RouteDefault, !Ref "AWS::NoValue" ]
 
   BuildkiteAgentTokenParameter:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1466

Additional dependencies to ensure that the subnets are ready and available.