### PR TITLE
Ensure AWS_ECR_LOGIN is passed into ECR plugin

### DIFF
--- a/packer/linux/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/conf/buildkite-agent/hooks/environment
@@ -115,6 +115,11 @@ if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" 
     export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
   fi
 
+  # map AWS_ECR_LOGIN into the plugin format
+  if [[ -n "${AWS_ECR_LOGIN:-}" ]]; then
+    export BUILDKITE_PLUGIN_ECR_LOGIN="${AWS_ECR_LOGIN}"
+  fi
+
   # shellcheck source=/dev/null
   source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/environment
 fi

--- a/packer/windows/conf/buildkite-agent/hooks/environment
+++ b/packer/windows/conf/buildkite-agent/hooks/environment
@@ -61,6 +61,11 @@ if [[ "${BUILDKITE_ECR_POLICY:-}" != "none" && "${ECR_PLUGIN_ENABLED:-}" == "1" 
     export BUILDKITE_PLUGIN_ECR_ACCOUNT_IDS_0="${AWS_ECR_LOGIN_REGISTRY_IDS}"
   fi
 
+  # map AWS_ECR_LOGIN into the plugin format
+  if [[ -n "${AWS_ECR_LOGIN:-}" ]]; then
+    export BUILDKITE_PLUGIN_ECR_LOGIN="${AWS_ECR_LOGIN}"
+  fi
+
   # shellcheck source=/dev/null
   source /usr/local/buildkite-aws-stack/plugins/ecr/hooks/environment
 fi


### PR DESCRIPTION
Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1444

Ensure that `AWS_ECR_LOGIN` is assigned to `BUILDKITE_PLUGIN_ECR_LOGIN` for use with ECR plugin, when plugin is enabled.