### PR TITLE
Bumping S3 Secrets plugin to v2.5.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "plugins/secrets"]
 	path = plugins/secrets
 	url = https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks.git
-	branch = v2.1.6
+	branch = v2.5.0
 
 [submodule "plugins/ecr"]
 	path = plugins/ecr


### PR DESCRIPTION
Bumping version to v2.5.0 in order to enable the functionality of full secret redaction

Implements batch redaction of secrets using buildkite-agent's redactor command. Features JSON batching for v3.66.0+ and warns to upgrade for redaction on lower versions.

Fixes #1471 