### PR TITLE
Configure AMI builds as private, optionally public

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -57,7 +57,7 @@ steps:
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
     env:
-      AMI_PUBLIC: true
+      AMI_PUBLIC: false
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
@@ -125,7 +125,7 @@ steps:
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
     env:
-      AMI_PUBLIC: true
+      AMI_PUBLIC: false
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
@@ -192,7 +192,7 @@ steps:
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
     env:
-      AMI_PUBLIC: true
+      AMI_PUBLIC: false
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -56,6 +56,8 @@ steps:
     command: .buildkite/steps/packer.sh windows
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
+    env:
+      AMI_PUBLIC: true
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
@@ -122,6 +124,8 @@ steps:
     command: .buildkite/steps/packer.sh linux
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
+    env:
+      AMI_PUBLIC: true
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
@@ -187,6 +191,8 @@ steps:
     command: .buildkite/steps/packer.sh linux arm64
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
+    env:
+      AMI_PUBLIC: true
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -57,7 +57,7 @@ steps:
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
     env:
-      AMI_PUBLIC: false
+      AMI_PUBLIC: true
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
@@ -125,7 +125,7 @@ steps:
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
     env:
-      AMI_PUBLIC: false
+      AMI_PUBLIC: true
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:
@@ -192,7 +192,7 @@ steps:
     timeout_in_minutes: 60
     retry: { automatic: { limit: 3 } }
     env:
-      AMI_PUBLIC: false
+      AMI_PUBLIC: true
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     depends_on:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ WIN64_INSTANCE_TYPE ?= m7i.xlarge
 BUILDKITE_BUILD_NUMBER ?= none
 BUILDKITE_PIPELINE_DEFAULT_BRANCH ?= main
 
+# AMI visibility configuration
+AMI_PUBLIC ?= false
+AMI_USERS ?=
+
+# Convert comma-separated AMI_USERS to JSON array format
+AMI_USERS_JSON = $(if $(AMI_USERS),[$(shell echo '$(AMI_USERS)' | $(SED) 's/[^,][^,]*/"&"/g')],[])
+
 IS_RELEASED ?= false
 ifeq ($(BUILDKITE_BRANCH),$(BUILDKITE_PIPELINE_DEFAULT_BRANCH))
 	IS_RELEASED = true
@@ -109,6 +116,8 @@ packer-linux-amd64.output: $(PACKER_LINUX_FILES) build/fix-perms-linux-amd64
 			-var 'instance_type=$(AMD64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_JSON)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
@@ -144,6 +153,8 @@ packer-linux-arm64.output: $(PACKER_LINUX_FILES) build/fix-perms-linux-arm64
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
 			-var 'agent_version=$(CURRENT_AGENT_VERSION_LINUX)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_JSON)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
@@ -171,6 +182,8 @@ packer-windows-amd64.output: $(PACKER_WINDOWS_FILES)
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
 			-var 'agent_version=$(CURRENT_AGENT_VERSION_WINDOWS)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_JSON)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 # -----------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ AMI_PUBLIC ?= false
 AMI_USERS ?=
 
 # Convert comma-separated AMI_USERS to JSON array format
-AMI_USERS_JSON = $(if $(AMI_USERS),[$(shell echo '$(AMI_USERS)' | $(SED) 's/[^,][^,]*/"&"/g')],[])
+AMI_USERS_LIST = $(if $(AMI_USERS),[$(shell echo '$(AMI_USERS)' | $(SED) 's/[[:space:]]//g' | $(SED) 's/[^,][^,]*/"&"/g')],[])
 
 IS_RELEASED ?= false
 ifeq ($(BUILDKITE_BRANCH),$(BUILDKITE_PIPELINE_DEFAULT_BRANCH))
@@ -117,7 +117,7 @@ packer-linux-amd64.output: $(PACKER_LINUX_FILES) build/fix-perms-linux-amd64
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
 			-var 'ami_public=$(AMI_PUBLIC)' \
-			-var 'ami_users=$(AMI_USERS_JSON)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
@@ -154,7 +154,7 @@ packer-linux-arm64.output: $(PACKER_LINUX_FILES) build/fix-perms-linux-arm64
 			-var 'is_released=$(IS_RELEASED)' \
 			-var 'agent_version=$(CURRENT_AGENT_VERSION_LINUX)' \
 			-var 'ami_public=$(AMI_PUBLIC)' \
-			-var 'ami_users=$(AMI_USERS_JSON)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
@@ -183,7 +183,7 @@ packer-windows-amd64.output: $(PACKER_WINDOWS_FILES)
 			-var 'is_released=$(IS_RELEASED)' \
 			-var 'agent_version=$(CURRENT_AGENT_VERSION_WINDOWS)' \
 			-var 'ami_public=$(AMI_PUBLIC)' \
-			-var 'ami_users=$(AMI_USERS_JSON)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 # -----------------------------------------

--- a/README.md
+++ b/README.md
@@ -115,18 +115,36 @@ aws-vault exec some-profile -- make create-stack
 ```
 
 If you need to build your own AMI (because you've changed something in the
-`packer` directory), run packer with AWS credentials in your shell environment:
+`packer` directory), run packer with AWS credentials in your shell environment.
+
+By default, AMIs are built as private (only accessible to the AWS account that created them) for security. You can control AMI visibility and build location using these variables:
+
+- **`AMI_PUBLIC`** - Set to `true` to make AMIs publicly accessible to all AWS users, or `false` (default) for private AMIs
+- **`AMI_USERS`** - Comma-separated list of AWS account IDs that should have access to private AMIs (ignored when `AMI_PUBLIC=true`)
+- **`AWS_REGION`** - AWS region where AMIs should be built (defaults to `us-east-1`)
 
 ```bash
+# Build private AMIs (default - recommended for security)
 make packer
+
+# Build public AMIs (available to all AWS users)
+make packer AMI_PUBLIC=true
+
+# Build private AMIs with access for specific AWS accounts
+make packer AMI_USERS="123456789012,987654321098,555666777888"
+
+# Combined: private AMIs with specific account access in a different region
+make packer AMI_PUBLIC=false AMI_USERS="123456789012,987654321098" AWS_REGION=us-west-2
 ```
 
-This will boot and image three AWS EC2 instances in your account’s `us-east-1`
-default VPC:
+This will boot and image three AWS EC2 instances in your account's `us-east-1`
+default VPC (or the region specified by `AWS_REGION`):
 
 - Linux (64-bit x86)
 - Linux (64-bit Arm)
 - Windows (64-bit x86)
+
+**Security Note:** Making AMIs public (`AMI_PUBLIC=true`) can expose any secrets accidentally baked into the image. The default private setting helps prevent accidental exposure of sensitive information.
 
 ## Support Policy
 

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -62,7 +62,7 @@ data "amazon-ami" "al2023" {
 
 source "amazon-ebs" "elastic-ci-stack-ami" {
   ami_description                           = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
-  ami_groups                                = var.ami_public ? ["all"] : ["self"]
+  ami_groups                                = var.ami_public ? ["all"] : []
   ami_users                                 = var.ami_public ? [] : var.ami_users
   ami_name                                  = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type

--- a/packer/linux/buildkite-ami.pkr.hcl
+++ b/packer/linux/buildkite-ami.pkr.hcl
@@ -37,6 +37,18 @@ variable "is_released" {
   default = false
 }
 
+variable "ami_public" {
+  type        = bool
+  description = "Whether to make the AMI publicly available to all AWS users. Defaults to false for security."
+  default     = false
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "List of AWS account IDs that should have access to the AMI when ami_public is false."
+  default     = []
+}
+
 data "amazon-ami" "al2023" {
   filters = {
     architecture        = var.arch
@@ -50,7 +62,8 @@ data "amazon-ami" "al2023" {
 
 source "amazon-ebs" "elastic-ci-stack-ami" {
   ami_description                           = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
-  ami_groups                                = ["all"]
+  ami_groups                                = var.ami_public ? ["all"] : ["self"]
+  ami_users                                 = var.ami_public ? [] : var.ami_users
   ami_name                                  = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region

--- a/packer/windows/buildkite-ami.pkr.hcl
+++ b/packer/windows/buildkite-ami.pkr.hcl
@@ -37,6 +37,18 @@ variable "is_released" {
   default = false
 }
 
+variable "ami_public" {
+  type        = bool
+  description = "Whether to make the AMI publicly available to all AWS users. Defaults to false for security."
+  default     = false
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "List of AWS account IDs that should have access to the AMI when ami_public is false."
+  default     = []
+}
+
 data "amazon-ami" "windows-server-2022" {
   filters = {
     name                = "Windows_Server-2022-English-Full-Base-*"
@@ -49,7 +61,8 @@ data "amazon-ami" "windows-server-2022" {
 
 source "amazon-ebs" "elastic-ci-stack" {
   ami_description = "Buildkite Elastic Stack (Windows Server 2022 w/ docker)"
-  ami_groups      = ["all"]
+  ami_groups      = var.ami_public ? ["all"] : ["self"]
+  ami_users       = var.ami_public ? [] : var.ami_users
   ami_name        = "buildkite-stack-windows-${replace(timestamp(), ":", "-")}"
   communicator    = "winrm"
   instance_type   = var.instance_type

--- a/packer/windows/buildkite-ami.pkr.hcl
+++ b/packer/windows/buildkite-ami.pkr.hcl
@@ -61,7 +61,7 @@ data "amazon-ami" "windows-server-2022" {
 
 source "amazon-ebs" "elastic-ci-stack" {
   ami_description = "Buildkite Elastic Stack (Windows Server 2022 w/ docker)"
-  ami_groups      = var.ami_public ? ["all"] : ["self"]
+  ami_groups      = var.ami_public ? ["all"] : []
   ami_users       = var.ami_public ? [] : var.ami_users
   ami_name        = "buildkite-stack-windows-${replace(timestamp(), ":", "-")}"
   communicator    = "winrm"


### PR DESCRIPTION
Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/323

* Sets AMI visibility to Private, by default. Uses new variable `AMI_PUBLIC`.
* Introduces the ability to configure `ami_users` to allow specifying AWS account IDs. Uses new variable `AMI_USERS`.