### PR TITLE
Add OnDemandBaseCapacity parameter

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -113,6 +113,7 @@ Metadata:
         - MinSize
         - MaxSize
         - InstanceBuffer
+        - OnDemandBaseCapacity
         - OnDemandPercentage
         - SpotAllocationStrategy
         - ScaleOutFactor
@@ -463,6 +464,12 @@ Parameters:
     Description: Minimum interval at which the auto scaler should poll the AWS API
     Type: String
     Default: "10s"
+
+  OnDemandBaseCapacity:
+    Description: Specify how much On-Demand capacity the Auto Scaling group should have for its base portion before scaling by percentages. The maximum group size will be increased (but not decreased) to this value.
+    Type: Number
+    Default: 0
+    MinValue: 0
 
   OnDemandPercentage:
     Description: Percentage of total instances that should launch as OnDemand. Default is 100% OnDemand - reduce this to use some Spot Instances when they're available and cheaper than the OnDemand price. A value of 70 means 70% OnDemand and 30% Spot Instances.
@@ -1696,6 +1703,7 @@ Resources:
       VPCZoneIdentifier: !If [ "CreateVpcResources", [ !Ref Subnet0, !Ref Subnet1 ], !Ref Subnets ]
       MixedInstancesPolicy:
         InstancesDistribution:
+          OnDemandBaseCapacity: !Ref OnDemandBaseCapacity
           OnDemandPercentageAboveBaseCapacity: !Ref OnDemandPercentage
           SpotAllocationStrategy: !Ref SpotAllocationStrategy
         LaunchTemplate:


### PR DESCRIPTION
Inspired by https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1364

Introduces the `OnDemandBaseCapacity` [parameter](https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html#API_InstancesDistribution_Contents) which ensures a minimum amount of On-Demand instances:
> The minimum amount of the Auto Scaling group's capacity that must be fulfilled by On-Demand Instances. This base portion is launched first as your group scales.

Examples of what this would look like in combination with `OnDemandPercentage`:
```
Base=2, Percentage=50%, Desired=10
  Instances:
    2 base On-Demand + 4 more On-Demand (50% of remaining 8) + 4 Spot = 6 On-Demand, 4 Spot (10 total instances)

Base=0, Percentage=70%, Desired=10
  Instances:
    0 base On-Demand + 7 On-Demand (70% of remaining 10) + 3 Spot = 7 On-Demand, 3 Spot (10 total instances)

Base=10, Percentage=0%, Desired=10
  Instances:
    10 base On-Demand + 0 On-Demand (0% of remaining 0) + 0 Spot = 10 On-Demand, 0 Spot (10 total instances)
```