### PR TITLE
Implement new agent disconnect-after-uptime config

### DIFF
--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -291,6 +291,7 @@ spawn=${BUILDKITE_AGENTS_PER_INSTANCE}
 no-color=true
 disconnect-after-idle-timeout=${BUILDKITE_SCALE_IN_IDLE_PERIOD}
 disconnect-after-job=${BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
+disconnect-after-uptime=${BUILDKITE_AGENT_DISCONNECT_AFTER_UPTIME}
 tracing-backend=${BUILDKITE_AGENT_TRACING_BACKEND}
 cancel-grace-period=${BUILDKITE_AGENT_CANCEL_GRACE_PERIOD}
 signal-grace-period-seconds=${BUILDKITE_AGENT_SIGNAL_GRACE_PERIOD_SECONDS}

--- a/packer/windows/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/conf/bin/bk-install-elastic-stack.ps1
@@ -155,6 +155,7 @@ no-color=true
 shell=powershell
 disconnect-after-idle-timeout=${Env:BUILDKITE_SCALE_IN_IDLE_PERIOD}
 disconnect-after-job=${Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB}
+disconnect-after-uptime=${Env:BUILDKITE_AGENT_DISCONNECT_AFTER_UPTIME}
 tracing-backend=${Env:BUILDKITE_AGENT_TRACING_BACKEND}
 signing-aws-kms-key=${Env:BUILDKITE_AGENT_SIGNING_KMS_KEY}
 verification-failure-behavior=${Env:BUILDKITE_AGENT_SIGNING_FAILURE_BEHAVIOR}

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -285,6 +285,15 @@ Parameters:
       - "false"
     Default: "false"
 
+  BuildkiteAgentDisconnectAfterUptime:
+    Description: >
+      The maximum uptime in seconds before the agent stops accepting new jobs and shuts down
+      after any running jobs complete. Set to 0 to disable uptime-based termination.
+      This helps regularly cycle out machines and prevent resource accumulation issues.
+    Type: Number
+    Default: 0
+    MinValue: 0
+
   ExperimentalEnableResourceLimits:
     Description: >
       (Experimental) If true, enables systemd resource limits for the Buildkite agent.
@@ -1573,6 +1582,7 @@ Resources:
                   $Env:BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}"
                   $Env:BUILDKITE_ECR_POLICY="${ECRAccessPolicy}"
                   $Env:BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}"
+                  $Env:BUILDKITE_AGENT_DISCONNECT_AFTER_UPTIME="${BuildkiteAgentDisconnectAfterUptime}"
                   $Env:BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}"
                   $Env:BUILDKITE_WINDOWS_ADMINISTRATOR="${BuildkiteWindowsAdministrator}"
                   $Env:AWS_DEFAULT_REGION="${AWS::Region}"
@@ -1652,6 +1662,7 @@ Resources:
                   BUILDKITE_AUTHORIZED_USERS_URL="${AuthorizedUsersUrl}" \
                   BUILDKITE_ECR_POLICY="${ECRAccessPolicy}" \
                   BUILDKITE_TERMINATE_INSTANCE_AFTER_JOB="${BuildkiteTerminateInstanceAfterJob}" \
+                  BUILDKITE_AGENT_DISCONNECT_AFTER_UPTIME="${BuildkiteAgentDisconnectAfterUptime}" \
                   BUILDKITE_TERMINATE_INSTANCE_ON_DISK_FULL="${BuildkiteTerminateInstanceOnDiskFull}" \
                   BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS="${BuildkiteAdditionalSudoPermissions}" \
                   AWS_DEFAULT_REGION="${AWS::Region}" \


### PR DESCRIPTION
Inspired by https://github.com/buildkite/elastic-ci-stack-for-aws/pull/839
Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1012

* This adds the newly released agent config [`disconnect-after-uptime`](https://buildkite.com/docs/agent/v3/cli-start#disconnect-after-uptime), present in release [`v3.102.0`](https://github.com/buildkite/agent/releases/tag/v3.102.0).
* This allows a max lifetime for agents to be configured.
* Any running jobs will be completed and the agent will then shut down.
* When the `buildkite-agent` service is stopped, its EC2 instance will also be terminated.