### PR TITLE
AWS CLI v2 in Windows AMI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -77,6 +77,8 @@ steps:
     name: ":packer: :windows:"
     command: .buildkite/steps/packer.sh windows
     timeout_in_minutes: 60
+    env:
+      AMI_PUBLIC: true
     retry: { automatic: { limit: 3 } }
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
@@ -104,6 +106,8 @@ steps:
   - id: "test-windows-amd64"
     name: ":cloudformation: :windows: AMD64 Test"
     command:
+      - aws --version
+      - jq --version
       - git --version
       - docker info
       - docker run --rm mcr.microsoft.com/windows/nanoserver:ltsc2022 cmd.exe /c echo hello
@@ -146,6 +150,8 @@ steps:
     name: ":packer: :linux: AMD64"
     command: .buildkite/steps/packer.sh linux
     timeout_in_minutes: 60
+    env:
+      AMI_PUBLIC: true
     retry: { automatic: { limit: 3 } }
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
@@ -174,6 +180,8 @@ steps:
   - id: "test-linux-amd64"
     name: ":cloudformation: :linux: AMD64 Test"
     command:
+      - aws --version
+      - jq --version
       - git --version
       - sudo goss validate --format documentation
     timeout_in_minutes: 5
@@ -216,6 +224,8 @@ steps:
     name: ":packer: :linux: ARM64"
     command: .buildkite/steps/packer.sh linux arm64
     timeout_in_minutes: 60
+    env:
+      AMI_PUBLIC: true
     retry: { automatic: { limit: 3 } }
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
@@ -243,6 +253,8 @@ steps:
   - id: "test-linux-arm64"
     name: ":cloudformation: :linux: ARM64 Test"
     command:
+      - aws --version
+      - jq --version
       - git --version
       - sudo goss validate --format documentation
     retry: { automatic: { limit: 3 } }

--- a/packer/linux/scripts/install-utils.sh
+++ b/packer/linux/scripts/install-utils.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+AWS_CLI_LINUX_VERSION=2.28.15
+
 case $(uname -m) in
 x86_64) ARCH=amd64 ;;
 aarch64) ARCH=arm64 ;;
@@ -15,7 +17,6 @@ echo Installing utils...
 sudo dnf install -yq \
   amazon-ssm-agent \
   aws-cfn-bootstrap \
-  awscli-2 \
   ec2-instance-connect \
   git \
   jq \
@@ -41,6 +42,24 @@ sudo dnf -yq groupinstall "Development Tools"
 
 sudo systemctl enable --now amazon-ssm-agent
 sudo systemctl enable --now rsyslog
+
+echo "Installing AWS CLI v2 ${AWS_CLI_LINUX_VERSION}..."
+pushd "$(mktemp -d)"
+case $(uname -m) in
+x86_64)
+  curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_LINUX_VERSION}.zip" -o "awscliv2.zip"
+  ;;
+aarch64)
+  curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-${AWS_CLI_LINUX_VERSION}.zip" -o "awscliv2.zip"
+  ;;
+*)
+  echo "Unsupported architecture for AWS CLI v2"
+  exit 1
+  ;;
+esac
+unzip -qq awscliv2.zip
+sudo ./aws/install
+popd
 
 GIT_LFS_VERSION=3.4.0
 echo "Installing git lfs ${GIT_LFS_VERSION}..."


### PR DESCRIPTION
Updates the Windows AMI to use AWS CLI v2. Successfully tested building, pushing and pulling Docker images to/from private ECR repo with `ecr` plugin (`v2.9.1`) to perform the necessary `aws ecr get-login-password` and the `docker-compose` plugin (`v5.10.0`) from Elastic CI Stack agents using a Windows AMI built with these changes.

Pipeline changes from adjacent [PR](https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1557) included here to facilitate testing of this Windows AMI.

Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1304 https://github.com/buildkite/elastic-ci-stack-for-aws/issues/843
Relates to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/670 https://github.com/buildkite-plugins/ecr-buildkite-plugin/issues/37