### PR TITLE
Implement IAM permissions required to use ECR Private Registry as pull through cache

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -575,7 +575,7 @@ Parameters:
     Default: ""
 
   RootVolumeType:
-    Description: Type of root volume to use
+    Description: Type of root volume to use. If you are specifying `io1` or `io2`, you will most likely want to specify `RootVolumeIOPS` as well.
     Type: String
     Default: "gp3"
 
@@ -651,11 +651,13 @@ Parameters:
 
   ECRAccessPolicy:
     Type: String
-    Description: ECR access policy to give container instances
+    Description: ECR access policy to give instances. The `-pullthrough` variants add ECR pull-through cache permissions (including `ecr:CreateRepository`, `ecr:BatchImportUpstreamImage`, `ecr:GetImageCopyStatus`, and upload permissions) to enable transparent upstream registry caching.
     AllowedValues:
       - none
       - readonly
+      - readonly-pullthrough
       - poweruser
+      - poweruser-pullthrough
       - full
     Default: "none"
 
@@ -1015,6 +1017,11 @@ Conditions:
     UseECR:
       !Not [ !Equals [ !Ref ECRAccessPolicy, "none" ] ]
 
+    AddECRPullThrough:
+      !Or
+        - !Equals [ !Ref ECRAccessPolicy, "readonly-pullthrough" ]
+        - !Equals [ !Ref ECRAccessPolicy, "poweruser-pullthrough" ]
+
     UseCustomerManagedParameterPath:
       !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStorePath, "" ] ]
     UseCustomerManagedKeyForParameterStore:
@@ -1116,10 +1123,12 @@ Conditions:
 
 Mappings:
   ECRManagedPolicy:
-    none      : { Policy: '' }
-    readonly  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
-    poweruser : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
-    full      : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
+    none                  : { Policy: '' }
+    readonly              : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    readonly-pullthrough  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly' }
+    poweruser             : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    poweruser-pullthrough : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser' }
+    full                  : { Policy: 'arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess' }
 
   # Generated from Makefile via build/mappings.yml
   AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId }
@@ -1283,6 +1292,23 @@ Resources:
                  - !Ref 'AWS::NoValue'
           - !Ref 'AWS::NoValue'
       Policies:
+        - !If
+          - AddECRPullThrough
+          - PolicyName: ECRPullThrough
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - ecr:CreateRepository
+                    - ecr:BatchImportUpstreamImage
+                    - ecr:GetImageCopyStatus
+                    - ecr:InitiateLayerUpload
+                    - ecr:UploadLayerPart
+                    - ecr:CompleteLayerUpload
+                    - ecr:PutImage
+                  Resource: "*"
+          - !Ref 'AWS::NoValue'
         - !If
           - HasPipelineSigningKMSKey
           - PolicyName: PipelineSigningKMSKeyAccess


### PR DESCRIPTION
Inspired by https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1270

Adds the necessary [permissions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-private.html#pull-through-cache-private-permissions) in order to allow the IAM Role to [use](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache-working-pulling.html) an __existing__ ECR Private Registry as a [pull through cache](https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html).