### PR TITLE
Install AWS ECR Credential Helper

### DIFF
--- a/packer/linux/scripts/install-docker.sh
+++ b/packer/linux/scripts/install-docker.sh
@@ -58,3 +58,6 @@ sudo systemctl start docker-binfmt.service
 
 echo "show docker-binfmt status..."
 systemctl status docker-binfmt.service
+
+echo "Installing Amazon ECR credential helper..."
+sudo dnf install -y amazon-ecr-credential-helper

--- a/packer/windows/scripts/install-docker.ps1
+++ b/packer/windows/scripts/install-docker.ps1
@@ -10,3 +10,11 @@ $docker_compose_version="2.35.1"
 Write-Output "Installing docker-compose..."
 choco install -y docker-compose --version $docker_compose_version
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+Write-Output "Installing Amazon ECR credential helper..."
+$ecr_cred_helper_version = "0.10.1"
+$ecr_cred_helper_url = "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/$ecr_cred_helper_version/windows-amd64/docker-credential-ecr-login.exe"
+$docker_plugins_dir = "${env:ProgramFiles}\Docker"
+New-Item -ItemType Directory -Force -Path $docker_plugins_dir | Out-Null
+Invoke-WebRequest -Uri $ecr_cred_helper_url -OutFile "$docker_plugins_dir\docker-credential-ecr-login.exe"
+Write-Output "Amazon ECR credential helper v$ecr_cred_helper_version installed to $docker_plugins_dir"


### PR DESCRIPTION
Partially implements https://github.com/buildkite/elastic-ci-stack-for-aws/pull/763

* Installs the [AWS ECR Credential Helper](https://github.com/awslabs/amazon-ecr-credential-helper) for both Linux and Windows. To be used in the future by the ECR plugin (pending [PR](https://github.com/buildkite-plugins/ecr-buildkite-plugin/pull/118))
  * To be implemented with `export BUILDKITE_PLUGIN_ECR_CREDENTIAL_HELPER=true` in the agent `environment` hooks for both [Linux](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/1b98a2d27f2ee29a87791bf58d618c119baf48af/packer/linux/conf/buildkite-agent/hooks/environment#L109C51-L125) and [Windows](https://github.com/buildkite/elastic-ci-stack-for-aws/blob/1b98a2d27f2ee29a87791bf58d618c119baf48af/packer/windows/conf/buildkite-agent/hooks/environment#L55-L71).