### PR TITLE
Implement AgentsPerCPU (agent's `spawn-per-cpu`) parameter

### DIFF
--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -78,6 +78,10 @@ cat <<EOF >config.json
     "ParameterValue": "3"
   },
   {
+    "ParameterKey": "AgentsPerCPU",
+    "ParameterValue": "0"
+  },
+  {
     "ParameterKey": "ECRAccessPolicy",
     "ParameterValue": "readonly"
   },

--- a/README.md
+++ b/README.md
@@ -92,6 +92,40 @@ To enable resource limits with custom values, include these parameters in your C
 - Resource limits are disabled by default
 - Values can be specified as percentages or absolute values (for memory-related parameters)
 
+## Agent Scaling Configuration
+
+The Elastic CI Stack supports two methods for configuring the number of Buildkite agents per instance:
+
+### Static Agent Count (Default)
+Use `AgentsPerInstance` to set a fixed number of agents per instance regardless of CPU count.
+
+### Dynamic CPU-based Scaling
+Use `AgentsPerCPU` to automatically scale agents based on the number of CPU cores available. This is particularly useful for spot instances where you might receive instances with more CPU cores than originally requested.
+
+**Note**: Requires Buildkite agent version 3.70.0 or later.
+
+| Parameter           | Description                                            | Default | Range |
+|--------------------|--------------------------------------------------------|---------|-------|
+| `AgentsPerInstance`| Number of agents per instance (ignored when AgentsPerCPU > 0) | `1` | 1+ |
+| `AgentsPerCPU` | Number of agents per CPU core (0 = disabled)          | `0`     | 0-10 |
+
+### Example Configuration
+
+To enable CPU-based scaling with 2 agents per CPU core:
+
+```yaml
+{
+  "Parameters": {
+    "AgentsPerCPU": "2"
+  }
+}
+```
+
+### Notes
+- **Requires Buildkite agent version 3.70.0 or later** (`spawn-per-cpu` added to Buildkite agent)
+- When `AgentsPerCPU` is set to a value greater than 0, it overrides `AgentsPerInstance`
+- Maximum value is capped at 10 agents per CPU core to prevent resource exhaustion on large instances
+
 ## Development
 
 To get started with customizing your own stack, or contributing fixes and features:

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -273,7 +273,6 @@ BUILDKITE_AGENT_TOKEN="$(
     --output text
 )"
 
-
 # DO NOT write this file to logs. It contains secrets.
 cat <<EOF >/etc/buildkite-agent/buildkite-agent.cfg
 name="${BUILDKITE_STACK_NAME}-${INSTANCE_ID}-%spawn"

--- a/packer/linux/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/conf/bin/bk-install-elastic-stack.sh
@@ -305,10 +305,10 @@ EOF
 
 # Add spawn configuration based on the scaling method
 if [ "${BUILDKITE_AGENTS_PER_CPU:-0}" -gt 0 ]; then
-  echo "spawn-per-cpu=${BUILDKITE_AGENTS_PER_CPU}" >> /etc/buildkite-agent/buildkite-agent.cfg
+  echo "spawn-per-cpu=${BUILDKITE_AGENTS_PER_CPU}" >>/etc/buildkite-agent/buildkite-agent.cfg
   echo "Using CPU-based scaling: ${BUILDKITE_AGENTS_PER_CPU} agents per CPU core"
 else
-  echo "spawn=${BUILDKITE_AGENTS_PER_INSTANCE}" >> /etc/buildkite-agent/buildkite-agent.cfg
+  echo "spawn=${BUILDKITE_AGENTS_PER_INSTANCE}" >>/etc/buildkite-agent/buildkite-agent.cfg
   echo "Using static scaling: ${BUILDKITE_AGENTS_PER_INSTANCE} agents per instance"
 fi
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -84,6 +84,7 @@ Metadata:
         - EnableInstanceStorage
         - MountTmpfsAtTmp
         - AgentsPerInstance
+        - AgentsPerCPU
         - KeyName
         - SecretsBucket
         - SecretsBucketRegion
@@ -413,9 +414,22 @@ Parameters:
     Description: >
       Number of Buildkite agents to run on each instance. This determines the initial count of agents launched when an instance starts.
       If an individual agent is terminated (e.g., due to a job failure or manual shutdown), it will not be automatically restarted, resulting in fewer agents on that instance (N-1). The ScaleInIdlePeriod parameter does not affect this agent count.
+      This parameter is ignored when AgentsPerCPU is set to a value greater than 0.
     Type: Number
     Default: 1
     MinValue: 1
+
+  AgentsPerCPU:
+    Description: >
+      Number of Buildkite agents to run per CPU core on each instance. When set to a value greater than 0, this overrides AgentsPerInstance.
+      The total number of agents will be calculated as: AgentsPerCPU * CPU_CORE_COUNT.
+      This allows dynamic scaling based on instance size, maximizing utilization of spot instances with varying CPU counts.
+      Set to 0 to disable CPU-based scaling and use AgentsPerInstance instead.
+      Requires Buildkite agent version 3.70.0 or later.
+    Type: Number
+    Default: 0
+    MinValue: 0
+    MaxValue: 10
 
   SecretsBucket:
     Description: Optional - Name of an existing S3 bucket containing pipeline secrets (Created if left blank)
@@ -1700,6 +1714,7 @@ Resources:
                   $Env:BUILDKITE_S3_ACL="${ArtifactsS3ACL}"
                   $Env:BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}"
                   $Env:BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}"
+                  $Env:BUILDKITE_AGENTS_PER_CPU="${AgentsPerCPU}"
                   $Env:BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}"
                   $Env:BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}"
                   $Env:BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}"
@@ -1789,6 +1804,7 @@ Resources:
                   BUILDKITE_S3_ACL="${ArtifactsS3ACL}" \
                   BUILDKITE_AGENT_TOKEN_PATH="${AgentTokenPath}" \
                   BUILDKITE_AGENTS_PER_INSTANCE="${AgentsPerInstance}" \
+                  BUILDKITE_AGENTS_PER_CPU="${AgentsPerCPU}" \
                   BUILDKITE_AGENT_ENDPOINT="${AgentEndpoint}" \
                   BUILDKITE_AGENT_TAGS="${BuildkiteAgentTags}" \
                   BUILDKITE_AGENT_TIMESTAMP_LINES="${BuildkiteAgentTimestampLines}" \
@@ -2223,6 +2239,7 @@ Resources:
         AgentEndpoint: !Ref AgentEndpoint
         BuildkiteQueue: !Ref BuildkiteQueue
         AgentsPerInstance: !Ref AgentsPerInstance
+        AgentsPerCPU: !Ref AgentsPerCPU
         MinSize: !Ref MinSize
         MaxSize: !Ref MaxSize
         InstanceBuffer: !Ref InstanceBuffer

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -2239,7 +2239,6 @@ Resources:
         AgentEndpoint: !Ref AgentEndpoint
         BuildkiteQueue: !Ref BuildkiteQueue
         AgentsPerInstance: !Ref AgentsPerInstance
-        AgentsPerCPU: !Ref AgentsPerCPU
         MinSize: !Ref MinSize
         MaxSize: !Ref MaxSize
         InstanceBuffer: !Ref InstanceBuffer


### PR DESCRIPTION
Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/986

Create new `AgentsPerCPU` parameter that implements the agent's `spawn-per-cpu` [configuration option](https://buildkite.com/docs/agent/v3/cli-start#spawn-per-cpu).
* Mutually exclusive with `AgentsPerInstance` and will override `AgentsPerInstance` when `AgentsPerCPU` not set to `0`