### PR TITLE
fix: align Go version with go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKER_WINDOWS_FILES = $(exec find packer/windows)
 # Allow passing an existing golden base AMI into packer via `BASE_AMI_ID` env var
 override BASE_AMI_ID ?=
 
-GO_VERSION ?= 1.23.6
+GO_VERSION ?= 1.24.0
 
 FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
 


### PR DESCRIPTION
Fixes:
```
docker run \
   -e CGO_ENABLED=0 \
   -e GOOS=linux \
   -e GOARCH=arm64 \
   -v "/var/lib/buildkite-agent/builds/elastic-stack-elastic-stack-i-00d1b9d0566b9caf1-4/buildkite-aws-stack/buildkite-aws-stack:/src" \
   -w /src \
   --rm \
   golang:1.23.6 \
   go build -v -buildvcs=false -o "build/fix-perms-linux-arm64" ./internal/fixperms
   go: go.mod requires go >= 1.24.0 (running go 1.23.6; GOTOOLCHAIN=local)
   make: *** [Makefile:280: build/fix-perms-linux-arm64] Error 1
   🚨 Error: The command exited with status 2
   user command error: exit status 2

```