### PR TITLE
Trigger base AMI base AMI rebuild

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -69,7 +69,6 @@ steps:
     depends_on:
       - "linting"
       - "fixperms-tests"
-    if_changed: "packer/windows/**"
     plugins:
       - *aws_role_plugin
 
@@ -142,7 +141,6 @@ steps:
     depends_on:
       - "linting"
       - "fixperms-tests"
-    if_changed: "packer/linux/**"
     plugins:
       - *aws_role_plugin
 
@@ -216,7 +214,6 @@ steps:
     depends_on:
       - "linting"
       - "fixperms-tests"
-    if_changed: "packer/linux/**"
     plugins:
       - *aws_role_plugin
 

--- a/packer/linux/.trigger-base-build
+++ b/packer/linux/.trigger-base-build
@@ -1,1 +1,1 @@
-# Last updated: 2025-09-10 14:03:43 UTC
+# Last updated: 2025-09-18 07:20:09 UTC

--- a/packer/windows/.trigger-base-build
+++ b/packer/windows/.trigger-base-build
@@ -1,1 +1,1 @@
-# Last updated: 2025-09-10 14:03:43 UTC
+# Last updated: 2025-09-18 07:20:09 UTC


### PR DESCRIPTION
After merging
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1590 we'd need to build new base AMI without plugins, so the hash is built.

Also, remove `if_changed` conditional since `packer.sh` handles the logic based on the hash whether to rebuild base.
