### PR TITLE
Temporarily remove build conditional for base AMI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -69,7 +69,6 @@ steps:
     depends_on:
       - "linting"
       - "fixperms-tests"
-    if_changed: '{packer/windows/.trigger-base-build,packer/windows/base.pkr.hcl,packer/windows/conf/**,packer/windows/scripts/enable-containers.ps1,packer/windows/scripts/install-cloudwatch-agent.ps1,packer/windows/scripts/install-docker.ps1,packer/windows/scripts/install-lifecycled.ps1,packer/windows/scripts/install-session-manager-plugin.ps1,packer/windows/scripts/install-utils.ps1}'
     plugins:
       - *aws_role_plugin
 
@@ -142,7 +141,6 @@ steps:
     depends_on:
       - "linting"
       - "fixperms-tests"
-    if_changed: '{packer/linux/.trigger-base-build,packer/linux/base.pkr.hcl,packer/linux/conf/**,packer/linux/scripts/cleanup.sh,packer/linux/scripts/install-cloudwatch-agent.sh,packer/linux/scripts/install-docker.sh,packer/linux/scripts/install-session-manager-plugin.sh,packer/linux/scripts/install-utils.sh}'
     plugins:
       - *aws_role_plugin
 
@@ -216,7 +214,6 @@ steps:
     depends_on:
       - "linting"
       - "fixperms-tests"
-    if_changed: '{packer/linux/.trigger-base-build,packer/linux/base.pkr.hcl,packer/linux/conf/**,packer/linux/scripts/cleanup.sh,packer/linux/scripts/install-cloudwatch-agent.sh,packer/linux/scripts/install-docker.sh,packer/linux/scripts/install-session-manager-plugin.sh,packer/linux/scripts/install-utils.sh}'
     plugins:
       - *aws_role_plugin
 


### PR DESCRIPTION
Remove `if_changed` conditional for the base image as we hit a Catch 22 now for base AMI ID detection.
To be reverted once base AMI ID reference is published to S3.