### PR TITLE
Ivannalisetska/sup 4658

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- shellcheck disable=SC1009,SC1072,SC1073 -->
 <h1><img alt="Elastic CI Stack for AWS" src="images/banner.png?raw=true"></h1>
 
 [![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=main)](https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/latest?branch=main)

--- a/README.md
+++ b/README.md
@@ -312,6 +312,52 @@ This verification:
 
 For alternative verification methods (like keyless verification with Chainguard images), see the [Kaniko documentation](https://github.com/GoogleContainerTools/kaniko#verifying-signed-kaniko-images).
 
+### Debugging with Kaniko Debug Image
+
+When troubleshooting build issues, you can use the Kaniko debug image which includes additional debugging tools. The debug image contains utilities like `busybox` and `sh` for interactive debugging.
+
+To enable debug mode, set the `KANIKO_DEBUG` environment variable in your pipeline:
+
+```yaml
+steps:
+  - label: ":whale: Kaniko Debug"
+    env:
+      AWS_REGION: "us-east-1"
+      ECR_ACCOUNT_ID: "111122223333"
+      ECR_REPO: "hello-kaniko"
+      KANIKO_DEBUG: "1"  # Enable debug image
+    commands:
+      - bash .buildkite/steps/kaniko.sh
+```
+
+The debug image provides several debugging options:
+
+- **Interactive shell access**: Set `KANIKO_SHELL=1` to get an interactive shell inside the Kaniko container
+- **Verbose logging**: Use `KANIKO_VERBOSITY=debug` for detailed build logs
+- **No-push mode**: Set `KANIKO_NO_PUSH=1` to build without pushing to registry
+
+Example debug script configuration:
+
+```bash
+# Enable debug mode
+KANIKO_DEBUG=1
+KANIKO_VERBOSITY=debug
+
+# Optional: Interactive shell for troubleshooting
+KANIKO_SHELL=1
+
+# Optional: Build without pushing
+KANIKO_NO_PUSH=1
+```
+
+The debug image is particularly useful for:
+- Investigating build failures
+- Examining the build context and Dockerfile
+- Testing different Kaniko parameters
+- Debugging authentication issues
+
+For more information about the debug image capabilities, see the [Chainguard Kaniko documentation](https://github.com/chainguard-dev/kaniko?tab=readme-ov-file#debug-image).
+
 ## Development
 
 To get started with customizing your own stack, or contributing fixes and features:

--- a/README.md
+++ b/README.md
@@ -284,6 +284,34 @@ The example script uses these environment variables:
 
 **Note**: This example uses ECR, but Kaniko works with any container registry. Adjust the authentication and destination URL accordingly for other registries like Docker Hub, GCR, or Azure Container Registry.
 
+### Verifying Signed Kaniko Images
+
+For enhanced security, you can verify the signature of the Kaniko image before using it. This ensures you're running the authentic, unmodified Kaniko executor.
+
+Add this verification step to your script before running Kaniko:
+
+```bash
+# Verify the Kaniko image signature with cosign (public key)
+cat > cosign.pub <<'EOF'
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9aAfAcgAxIFMTstJUv8l/AMqnSKw
+P+vLu3NnnBDHCfREQpV/AJuiZ1UtgGpFpHlJLCNPmFkzQTnfyN5idzNl6Q==
+-----END PUBLIC KEY-----
+EOF
+
+echo "Verifying signature of ${KANIKO_IMG} ..."
+docker run --rm -v "$PWD:/work" -w /work cgr.dev/chainguard/cosign \
+  verify -key cosign.pub "${KANIKO_IMG}"
+echo "Signature verified OK for ${KANIKO_IMG}"
+```
+
+This verification:
+- Uses the official Kaniko public key from their [GitHub repository](https://github.com/GoogleContainerTools/kaniko#verifying-signed-kaniko-images)
+- Ensures the Kaniko image hasn't been tampered with
+- Runs before your build process to catch any security issues early
+
+For alternative verification methods (like keyless verification with Chainguard images), see the [Kaniko documentation](https://github.com/GoogleContainerTools/kaniko#verifying-signed-kaniko-images).
+
 ## Development
 
 To get started with customizing your own stack, or contributing fixes and features:

--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ console.log("Hello from Kaniko on Buildkite Elastic CI Stack!");
 
 **Buildkite Step Script (.buildkite/steps/kaniko.sh):**
 ```bash
-#!/usr/bin/env bash
-set -Eeuo pipefail
 
 # ---- Required env from the step ----
 AWS_REGION="${AWS_REGION:?missing AWS_REGION}"
@@ -393,7 +391,7 @@ By default, AMIs are built as private. You can control AMI visibility and build 
 - `AMI_USERS` - A comma-separated list of AWS account IDs that should have access to private AMIs (ignored when `AMI_PUBLIC=true`).
 - `AWS_REGION` - The AWS region where AMIs should be built (defaults to `us-east-1`).
 
-```bash
+```bash 
 # Build private AMIs (default - recommended for security)
 make packer
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- shellcheck disable=SC1009,SC1072,SC1073 -->
 <h1><img alt="Elastic CI Stack for AWS" src="images/banner.png?raw=true"></h1>
 
 [![Build status](https://badge.buildkite.com/d178ab942e2f606a83e79847704648437d82a9c5fdb434b7ae.svg?branch=main)](https://buildkite.com/buildkite-aws-stack/buildkite-aws-stack/builds/latest?branch=main)


### PR DESCRIPTION
<img width="882" height="599" alt="Screenshot 2025-09-22 at 5 09 38 PM" src="https://github.com/user-attachments/assets/1b05ac15-8b92-41e1-b748-84284a8e8231" />
<img width="857" height="39" alt="Screenshot 2025-09-22 at 5 12 35 PM" src="https://github.com/user-attachments/assets/8f7e10fd-a2ad-406e-af93-09f134947edf" />
<img width="886" height="409" alt="Screenshot 2025-09-22 at 5 12 53 PM" src="https://github.com/user-attachments/assets/e74e9694-0ccc-475e-a794-543f9819e33d" />
I updated our Buildkite Elastic CI Stack docs with guide for using Kaniko. It shows how to build and push images in a pipeline without needing the Docker daemon, with copy-paste examples (pipeline config plus a tiny Node app: Dockerfile, package.json, app.js) and a ready-to-use kaniko.sh. The script handles errors, tags images with the commit and build number, supports both Docker config and the ECR credential helper, and can save a tar so you can run the image locally. I also added security: we verify the Kaniko image with cosign and the official public key. For troubleshooting, you can switch to the Kaniko debug image to get a shell, verbose logs, and a no-push dry run. 