### PR TITLE
Fix missing refresh_authorized_keys.timer

### DIFF
--- a/packer/linux/base/base.pkr.hcl
+++ b/packer/linux/base/base.pkr.hcl
@@ -87,14 +87,8 @@ build {
   }
 
   provisioner "file" {
-    destination = "/tmp/shared-conf"
+    destination = "/tmp/conf/"
     source      = "../shared/conf/"
-  }
-
-  provisioner "shell" {
-    inline = [
-      "sudo cp -r /tmp/shared-conf/* /tmp/conf/ 2>/dev/null || true"
-    ]
   }
 
   # Essential utilities & updates

--- a/packer/linux/base/base.pkr.hcl
+++ b/packer/linux/base/base.pkr.hcl
@@ -87,8 +87,14 @@ build {
   }
 
   provisioner "file" {
-    destination = "/tmp/conf"
+    destination = "/tmp/shared-conf"
     source      = "../shared/conf/"
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo cp -r /tmp/shared-conf/* /tmp/conf/ 2>/dev/null || true"
+    ]
   }
 
   # Essential utilities & updates


### PR DESCRIPTION
After merging
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1597, goss test started failing with missing refresh_authorized_keys.timer.

Looking closer, it looks like Packer overrides `/tmp/conf` directory with content of `../shared/conf`.
___

Verifying base AMI built with this change, we got the timer back:
```
systemctl status refresh_authorized_keys.timer
○ refresh_authorized_keys.timer - Download ssh authorized_keys file from s3
     Loaded: loaded (/etc/systemd/system/refresh_authorized_keys.timer; disabled; preset: disabled)
     Active: inactive (dead)
    Trigger: n/a
   Triggers: ● refresh_authorized_keys.service
```