### PR TITLE
Allow configurable Docker default bridge networks

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -151,6 +151,16 @@ Metadata:
         - EnableDockerExperimental
 
       - Label:
+          default: Docker Networking Configuration
+        Parameters:
+        - DockerNetworkingProtocol
+        - DockerIPv4AddressPool1
+        - DockerIPv4AddressPool2
+        - DockerIPv6AddressPool
+        - DockerFixedCidrV4
+        - DockerFixedCidrV6
+
+      - Label:
           default: Docker Registry Configuration
         Parameters:
         - ECRAccessPolicy
@@ -835,6 +845,20 @@ Parameters:
     Type: String
     Description: IPv6 CIDR block for Docker default address pools in dualstack mode. Only applies to Linux instances, not Windows.
     Default: "2001:db8:2::/104"
+
+  DockerFixedCidrV4:
+    Type: String
+    Description: >
+      Optional IPv4 CIDR block for Docker's fixed-cidr option. Restricts the IP range Docker uses for container networking.
+      Leave empty to disable. Useful to prevent conflicts with external services like databases. Only applies to Linux instances, not Windows.
+    Default: ""
+
+  DockerFixedCidrV6:
+    Type: String
+    Description: >
+      IPv6 CIDR block for Docker's fixed-cidr-v6 option in dualstack mode. Restricts the IP range Docker uses for IPv6 container networking.
+      Only applies to Linux instances in dualstack mode, not Windows.
+    Default: "2001:db8:1::/64"
 
   EnableSecretsPlugin:
     Type: String
@@ -1942,6 +1966,8 @@ Resources:
                   DOCKER_IPV4_ADDRESS_POOL_1=${DockerIPv4AddressPool1} \
                   DOCKER_IPV4_ADDRESS_POOL_2=${DockerIPv4AddressPool2} \
                   DOCKER_IPV6_ADDRESS_POOL=${DockerIPv6AddressPool} \
+                  DOCKER_FIXED_CIDR_V4="${DockerFixedCidrV4}" \
+                  DOCKER_FIXED_CIDR_V6="${DockerFixedCidrV6}" \
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
                     /usr/local/bin/bk-configure-docker.sh
                   --==BOUNDARY==

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -835,16 +835,22 @@ Parameters:
     Type: String
     Description: Primary IPv4 CIDR block for Docker default address pools. Must not conflict with host network or VPC CIDR. Only applies to Linux instances, not Windows.
     Default: "172.17.0.0/12"
+    AllowedPattern: "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[12][0-9]|3[0-2])$"
+    ConstraintDescription: "Must be a valid IPv4 CIDR block (e.g., 172.17.0.0/12)"
 
   DockerIPv4AddressPool2:
     Type: String
     Description: Secondary IPv4 CIDR block for Docker default address pools. Only applies to Linux instances, not Windows.
     Default: "192.168.0.0/16"
+    AllowedPattern: "^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[12][0-9]|3[0-2])$"
+    ConstraintDescription: "Must be a valid IPv4 CIDR block (e.g., 192.168.0.0/16)"
 
   DockerIPv6AddressPool:
     Type: String
     Description: IPv6 CIDR block for Docker default address pools in dualstack mode. Only applies to Linux instances, not Windows.
     Default: "2001:db8:2::/104"
+    AllowedPattern: "^(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?::[0-9a-fA-F]{1,4}){1,6}|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:))\\/(?:[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$"
+    ConstraintDescription: "Must be a valid IPv6 CIDR block (e.g., 2001:db8:2::/104)"
 
   DockerFixedCidrV4:
     Type: String
@@ -853,6 +859,8 @@ Parameters:
       Must be a subset of the first pool in DockerIPv4AddressPool1 (Docker allocates docker0 from the first pool).
       Leave empty to disable. Useful to prevent conflicts with external services like databases. Only applies to Linux instances, not Windows.
     Default: ""
+    AllowedPattern: "^$|^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\/(?:[0-9]|[12][0-9]|3[0-2])$"
+    ConstraintDescription: "Must be empty or a valid IPv4 CIDR block (e.g., 172.17.1.0/24)"
 
   DockerFixedCidrV6:
     Type: String
@@ -860,6 +868,8 @@ Parameters:
       IPv6 CIDR block for Docker's fixed-cidr-v6 option in dualstack mode. Restricts the IP range Docker uses for IPv6 container networking.
       Only applies to Linux instances in dualstack mode, not Windows.
     Default: "2001:db8:1::/64"
+    AllowedPattern: "^(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?::[0-9a-fA-F]{1,4}){1,6}|:(?:(?::[0-9a-fA-F]{1,4}){1,7}|:))\\/(?:[0-9]|[1-9][0-9]|1[01][0-9]|12[0-8])$"
+    ConstraintDescription: "Must be a valid IPv6 CIDR block (e.g., 2001:db8:1::/64)"
 
   EnableSecretsPlugin:
     Type: String

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -849,7 +849,8 @@ Parameters:
   DockerFixedCidrV4:
     Type: String
     Description: >
-      Optional IPv4 CIDR block for Docker's fixed-cidr option. Restricts the IP range Docker uses for container networking.
+      Optional IPv4 CIDR block for Docker's fixed-cidr option. Restricts the IP range Docker uses for container networking on the default bridge.
+      Must be a subset of the first pool in DockerIPv4AddressPool1 (Docker allocates docker0 from the first pool).
       Leave empty to disable. Useful to prevent conflicts with external services like databases. Only applies to Linux instances, not Windows.
     Default: ""
 


### PR DESCRIPTION
Allows users to configure the default bridge network (`docker0`) for both IPv4 and IPv6.

Adds parameters:
- `DockerFixedCidrV4` (default: `""`)
  - Since we are setting `DockerIPv4AddressPool1`, Docker uses the first subnet from the first pool for `docker0`
  - **NOTE:** Must be configured as a subset of the first pool in `DockerIPv4AddressPool1` or the Docker daemon will fail to start with `network does not contain specified subnet`
- `DockerFixedCidrV6` (default: `2001:db8:1::/64`)

Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/512