### PR TITLE
Updates to clarify `BootstrapScriptUrl` and `AgentEnvFileUrl` Stack params

### DIFF
--- a/packer/windows/stack/conf/bin/bk-fetch.ps1
+++ b/packer/windows/stack/conf/bin/bk-fetch.ps1
@@ -3,10 +3,40 @@ param ([parameter(Mandatory=$true)][string]$From, [parameter(Mandatory=$true)][s
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
+# Fetch content from various URI schemes:
+# - s3://bucket/key: S3 object URI (uses AWS CLI)
+# - ssm:/path/to/param: SSM parameter path (uses AWS CLI)
+# - https://example.com/file: HTTPS URL (uses Invoke-WebRequest)
+# - file:///path/to/file: Local file path (uses Invoke-WebRequest)
+# - http://example.com/file: HTTP URL (uses Invoke-WebRequest)
+
 If ($From -Like "s3://*") {
+  # S3 object URI - use AWS CLI to fetch
   aws s3 cp $From $To
   If ($lastexitcode -ne 0) { Exit $lastexitcode }
 }
+ElseIf ($From -Like "ssm:*") {
+  # SSM parameter path - fetch parameters recursively
+  $SsmPath = $From -replace "^ssm:", ""
+
+  # Get parameters from SSM
+  $Parameters = aws ssm get-parameters-by-path `
+    --path $SsmPath `
+    --recursive `
+    --with-decryption `
+    --query 'Parameters[*].{Name: Name, Value: Value}' `
+    --output json | ConvertFrom-Json
+
+  If ($lastexitcode -ne 0) { Exit $lastexitcode }
+
+  # Format as environment variables: KEY="value"
+  $Parameters | ForEach-Object {
+    $Name = ($_.Name -split "/")[-1].ToUpper()
+    $Value = $_.Value
+    "$Name=`"$Value`""
+  } | Out-File -FilePath $To -Encoding UTF8
+}
 Else {
+  # All other URIs (HTTPS, HTTP, file://) - use Invoke-WebRequest
   Invoke-WebRequest -Uri $From -OutFile $To
 }

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -555,13 +555,18 @@ Parameters:
     Default: "private"
 
   BootstrapScriptUrl:
-    Description: Optional - HTTPS or S3 URL for a script to run on each instance during boot.
+    Description: >
+      Optional - URI for a script to run on each instance during boot.
+      Supported URI schemes: S3 object URI (s3://bucket/key),
+      HTTPS URL (https://example.com/script.sh), or local file path (file:///path/to/script).
     Type: String
     Default: ""
 
   AgentEnvFileUrl:
     Description: >
-        Optional - HTTPS or S3 URL containing environment variables for the Buildkite agent process itself (not for builds).
+        Optional - URI containing environment variables for the Buildkite agent process itself (not for builds).
+        Supported URI schemes: S3 object URI (s3://bucket/key), SSM parameter path (ssm:/path/to/param),
+        HTTPS URL (https://example.com/script.sh), or local file path (file:///path/to/script).
         These variables configure agent behavior like proxy settings or debugging options.
         For build environment variables, use pipeline 'env' configuration instead.
     Type: String


### PR DESCRIPTION
* Updated descriptions to clarify the values that can be provided to both `BootstrapScriptUrl` and `AgentEnvFileUrl`
* Updated `bk-fetch.sh` and `bk-fetch.ps1` scripts to clarify their functionality
* Updated `bk-fetch.ps1` Windows script with SSM path support for parity to Linux script