### PR TITLE
Add missing params to ParameterGroups

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -58,6 +58,7 @@ Metadata:
         - BuildkiteAgentCancelGracePeriod
         - BuildkiteAgentSignalGracePeriod
         - BuildkiteTerminateInstanceAfterJob
+        - BuildkiteAgentDisconnectAfterUptime
         - BuildkiteTerminateInstanceOnDiskFull
         - BuildkitePurgeBuildsOnDiskFull
         - BuildkiteAdditionalSudoPermissions
@@ -104,6 +105,8 @@ Metadata:
         - RootVolumeName
         - RootVolumeType
         - RootVolumeEncrypted
+        - RootVolumeIops
+        - RootVolumeThroughput
         - ManagedPolicyARNs
         - InstanceRoleName
         - InstanceRolePermissionsBoundaryARN
@@ -125,11 +128,14 @@ Metadata:
         - MinSize
         - MaxSize
         - InstanceBuffer
+        - DisableScaleIn
         - OnDemandBaseCapacity
         - OnDemandPercentage
         - SpotAllocationStrategy
         - ScaleOutFactor
+        - ScaleOutCooldownPeriod
         - ScaleInIdlePeriod
+        - ScaleInCooldownPeriod
         - ScaleOutForWaitingJobs
         - InstanceCreationTimeout
         - ScalerEventSchedulePeriod


### PR DESCRIPTION
Similar to https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1635, there were a few other parameters that were missing from `ParameterGroups` and not showing up in our docs.