### PR TITLE
Missed a usage when renaming 'deleted_counter'

### DIFF
--- a/.buildkite/steps/clean-old-amis
+++ b/.buildkite/steps/clean-old-amis
@@ -156,6 +156,13 @@ summary = %Q[## #{operation} complete for `#{region}`
 
 puts summary
 
+buildkite_agent_bin = nil
+
 if system("command -v buildkite-agent")
-  `buildkite-agent annotate --context sweep-#{region} --style info '#{summary}'`
+  buildkite_agent_bin = 'buildkite-agent'
+elsif File.exist?('/usr/bin/buildkite-agent')
+  # If buildkite-agent is mounted in by the docker-compose plugin, this is where it will be.
+  buildkite_agent_bin = '/usr/bin/buildkite-agent'
 end
+
+`#{buildkite_agent_bin} annotate --context sweep-#{region} --style info '#{summary}'` unless buildkite_agent_bin.nil?


### PR DESCRIPTION
Fix a bug introduced in #1648, which causes [AMI cleanup builds to fail](https://buildkite.com/buildkite/elastic-stack-for-aws-ami-cleaner/builds/81/steps/table).

Bonus: display summarised results **much** more prominently.

See AMI cleanup build [here](https://buildkite.com/buildkite/elastic-stack-for-aws-ami-cleaner/builds/83/annotations).