### PR TITLE
Fix test stack ASG deletion – SUP-5220

### DIFF
--- a/.buildkite/steps/delete.sh
+++ b/.buildkite/steps/delete.sh
@@ -15,6 +15,24 @@ secrets_logging_bucket=$(aws cloudformation describe-stacks \
   --query "Stacks[0].Outputs[?OutputKey=='ManagedSecretsLoggingBucket'].OutputValue" \
   --output text)
 
+echo "--- Force terminating instances for $stack_name"
+# Find instances by CloudFormation stack tag
+instance_ids=$(aws ec2 describe-instances \
+  --filters "Name=tag:aws:cloudformation:stack-name,Values=${stack_name}" \
+  "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+  --query "Reservations[*].Instances[*].InstanceId" \
+  --output text)
+
+if [[ -n "${instance_ids}" ]]; then
+  echo "Force terminating instances: ${instance_ids}"
+  # shellcheck disable=SC2086
+  aws ec2 terminate-instances --instance-ids ${instance_ids} || true
+
+  echo "Waiting for instances to terminate..."
+  # shellcheck disable=SC2086
+  aws ec2 wait instance-terminated --instance-ids ${instance_ids} || true
+fi
+
 echo "--- Deleting stack $stack_name"
 aws cloudformation delete-stack --stack-name "$stack_name"
 aws cloudformation wait stack-delete-complete --stack-name "$stack_name"


### PR DESCRIPTION
When tearing down stacks spawned during testing, sometimes delete hangs on AutoScaling Group, most likely due to
`NewInstancesProtectedFromScaleIn: true`. 
While this parameter makes sense for production workload, it's not needed for testing stacks. `delete.sh` now removes protection and force instance termination before attemtping stack deletion.