### PR TITLE
Actually make base images private

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,8 @@ packer-base-linux-amd64.output: $(PACKER_LINUX_BASE_FILES)
 			-var 'instance_type=$(AMD64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
 			base.pkr.hcl | tee $@
 
 # Build base AMI for linux arm64
@@ -241,6 +243,8 @@ packer-base-linux-arm64.output: $(PACKER_LINUX_BASE_FILES)
 			-var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
 			base.pkr.hcl | tee $@
 
 # Build base AMI for windows amd64
@@ -262,6 +266,8 @@ packer-base-windows-amd64.output: $(PACKER_WINDOWS_BASE_FILES)
 			-var 'instance_type=$(WIN64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
 			base.pkr.hcl | tee $@
 
 # -----------------------------------------

--- a/packer/linux/base/base.pkr.hcl
+++ b/packer/linux/base/base.pkr.hcl
@@ -32,6 +32,18 @@ variable "is_released" {
   default = false
 }
 
+variable "ami_public" {
+  type        = bool
+  description = "Whether to make the AMI publicly available to all AWS users. Defaults to false for security."
+  default     = false
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "List of AWS account IDs that should have access to the AMI when ami_public is false."
+  default     = []
+}
+
 # Latest minimal Amazon Linux 2023 image for the given arch
 data "amazon-ami" "al2023" {
   filters = {
@@ -46,7 +58,8 @@ data "amazon-ami" "al2023" {
 
 source "amazon-ebs" "buildkite-base-ami" {
   ami_description                           = "Buildkite Golden Base (Amazon Linux 2023 w/ docker)"
-  ami_groups                                = ["all"]
+  ami_groups                                = var.ami_public ? ["all"] : []
+  ami_users                                 = var.ami_public ? [] : var.ami_users
   ami_name                                  = "buildkite-base-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region

--- a/packer/windows/base/base.pkr.hcl
+++ b/packer/windows/base/base.pkr.hcl
@@ -32,6 +32,18 @@ variable "is_released" {
   default = false
 }
 
+variable "ami_public" {
+  type        = bool
+  description = "Whether to make the AMI publicly available to all AWS users. Defaults to false for security."
+  default     = false
+}
+
+variable "ami_users" {
+  type        = list(string)
+  description = "List of AWS account IDs that should have access to the AMI when ami_public is false."
+  default     = []
+}
+
 # Latest Windows Server 2022 AMI
 data "amazon-ami" "windows-server-2022" {
   filters = {
@@ -45,7 +57,8 @@ data "amazon-ami" "windows-server-2022" {
 
 source "amazon-ebs" "buildkite-base" {
   ami_description = "Buildkite Golden Base (Windows Server 2022 w/ docker)"
-  ami_groups      = ["all"]
+  ami_groups      = var.ami_public ? ["all"] : []
+  ami_users       = var.ami_public ? [] : var.ami_users
   ami_name        = "buildkite-base-windows-${replace(timestamp(), ":", "-")}"
   communicator    = "winrm"
   instance_type   = var.instance_type


### PR DESCRIPTION
Continuation of #1657. I've noticed that we set `ami_groups` to `all` explicitely, without reading `AMI_PUBLIC` env var.