### PR TITLE
Fix: skip publish when only templates change

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -50,7 +50,6 @@ x-if-changed:
     - "packer/linux/base/**"
     - "plugins/**"
     - "build/**"
-    - "templates/**"
 
 steps:
   - group: ":lint-roller: Linting"


### PR DESCRIPTION
Remove templates/** from if_changed_publish_all. When only templates changed, copy-ami would skip but publish would run due to matching if_changed, causing the dependency chain to break and publish to run at pipeline start.