### PR TITLE
Add BuildkiteQueue and AgentsPerInstance tags to Agent Autoscaling groups

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -2550,13 +2550,13 @@ Resources:
         - OldestLaunchConfiguration
         - ClosestToNextInstanceHour
       NewInstancesProtectedFromScaleIn: !Ref InstanceScaleInProtection
-        Tags:
-          - Key: BuildkiteQueue
-            PropagateAtLaunch: false
-            Value: !Ref BuildkiteQueue
-          - Key: AgentsPerInstance
-            PropagateAtLaunch: false
-            Value: !Ref AgentsPerInstance
+      Tags:
+        - Key: BuildkiteQueue
+          PropagateAtLaunch: false
+          Value: !Ref BuildkiteQueue
+        - Key: AgentsPerInstance
+          PropagateAtLaunch: false
+          Value: !Ref AgentsPerInstance
     CreationPolicy:
       ResourceSignal:
         Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, PT5M ], !Ref InstanceCreationTimeout ]


### PR DESCRIPTION
## Description
Adds `BuildkiteQueue` and `AgentsPerInstance` tags to the AgentAutoscaleGroup resource, referencing the parameters of the same name.  This makes it a little easier to correlate different resources in tools like Datadog, where you can now rely on a single Template Variable to filter EC2 instances _and_ autoscaling Groups, as well as determining how many actual agents are running.

Deliberately set the tags not to propagate to the EC2 instances created by the ASG, as that tagging is handled by the LaunchTemplate.

Template changes validate fine using AWS CLI.

## Checklist

- [ ] Tests pass locally
- [x] Added tests for new features/fixes
- [x] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
