### PR TITLE
cleanup: Don't hold public AMIs sacred

### DIFF
--- a/.buildkite/steps/clean-old-amis
+++ b/.buildkite/steps/clean-old-amis
@@ -93,6 +93,7 @@ def cfn_template_amis(version)
 end
 
 one_year_ago = Time.now - (60 * 60 * 24 * 365)
+six_months_ago = Time.now - (60 * 60 * 24 * 184) # Jul+Aug+Sep+Oct+Nov+Dec = 184 days
 
 counters = {
   deleted: 0,
@@ -116,15 +117,15 @@ all_images.each do |image|
 
   counters[:checked] += 1
 
-  if image.last_launched_time && DateTime.parse(image.last_launched_time).to_time >= one_year_ago
-    counters[:launched_recently] += 1
-    puts "- keep (launched recently)\n\n"
-    next
-  end
-
   if DateTime.parse(image.creation_date).to_time >= one_year_ago
     counters[:created_recently] += 1
     puts "- keep (created recently)\n\n"
+    next
+  end
+
+  if image.last_launched_time && DateTime.parse(image.last_launched_time).to_time >= one_year_ago
+    counters[:launched_recently] += 1
+    puts "- keep (launched recently)\n\n"
     next
   end
 
@@ -173,9 +174,11 @@ end
 operation = (dry_run ? "Dry run" : "Cleanup")
 summary = %Q[## #{operation} complete for `#{Region}`
 
-| Checked | Deregistered | Eligible for deregistration | Shared publicly | Shared privately | Created recently | Launched recently |
+NB: This table lists the *primary* reason for deciding to keep an image. If there are multiple reasons (e.g. public AND created recently), only the first one is counted here.
+
+| Checked | Deregistered | Eligible for deregistration | Created recently | Launched recently | Shared publicly | Shared privately |
 |:-------:|:------------:|:---------------------------:|:---------------:|:----------------:|:----------------:|:-----------------:|
-| #{counters[:checked]} | #{counters[:deleted]} | #{counters[:eligible_for_deletion]} | #{counters[:public]} | #{counters[:shared]} | #{counters[:created_recently]} | #{counters[:launched_recently]} |
+| #{counters[:checked]} | #{counters[:deleted]} | #{counters[:eligible_for_deletion]} | #{counters[:created_recently]} | #{counters[:launched_recently]} | #{counters[:public]} | #{counters[:shared]} |
 ]
 
 puts summary


### PR DESCRIPTION
## Description

We found that not every public AMI needs to be kept, and we are retaining quite a few we don't need!

This change introduces an extra check before keeping a public AMI: it checks the CloudFormation template(s) for the version(s) that the AMI is tagged with, and ensures that the AMI is actually used by at least one of those templates.

If it's not used, we fall through to the existing checks on age and last launch date.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

No changes to public API.

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
