### PR TITLE
Handle missing Docker config in disk space check

### DIFF
--- a/packer/linux/stack/conf/bin/bk-check-disk-space.sh
+++ b/packer/linux/stack/conf/bin/bk-check-disk-space.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 DISK_MIN_AVAILABLE=${DISK_MIN_AVAILABLE:-5242880} # 5GB
 DISK_MIN_INODES=${DISK_MIN_INODES:-250000}        # docker needs lots
 
-DOCKER_DIR="$(jq -r '."data-root" // "/var/lib/docker"' /etc/docker/daemon.json)"
+DOCKER_DIR="$(jq -r '."data-root" // "/var/lib/docker"' /etc/docker/daemon.json || true)"
+if [[ -z "$DOCKER_DIR" ]]; then
+  DOCKER_DIR="/var/lib/docker"
+fi
 
 disk_avail=$(df -k --output=avail "$DOCKER_DIR" | tail -n1)
 


### PR DESCRIPTION
## Description

Updating disk space check to gracefully handle cases where /etc/docker/daemon.json is missing or unreadable by defaulting DOCKER_DIR to /var/lib/docker.

Currently, this will return an empty string if the docker daemon json doesn't exist, which breaks the fallback in the jq to /var/lib/docker. As such, we're ensuring this is set if jq fails.

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
