### PR TITLE
Fix Renovate for tooling using versions.{sh,ps1} scripts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$",
+        "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/stack/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
@@ -38,7 +38,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$",
+        "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/stack/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
@@ -52,7 +52,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$",
+        "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/stack/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
@@ -66,7 +66,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$"
+        "^packer/linux/base/scripts/versions\\.sh$"
       ],
       "matchStrings": [
         "export GOSS_VERSION=\"v(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
@@ -78,7 +78,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$",
+        "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/stack/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
@@ -92,7 +92,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$"
+        "^packer/linux/base/scripts/versions\\.sh$"
       ],
       "matchStrings": [
         "export DOCKER_BUILDX_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
@@ -104,7 +104,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$",
+        "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/stack/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
@@ -118,7 +118,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/stack/scripts/versions\\.sh$",
+        "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/stack/scripts/versions\\.ps1$"
       ],
       "matchStrings": [


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->
`versions.{sh,ps1}` scripts were moved to the `base` directory, but Renovate expected them in `stack`, so we weren't receiving Renovate PRs for those.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
