### PR TITLE
Fix versions.ps1 matching in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
       "customType": "regex",
       "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/stack/scripts/versions\\.ps1$"
+        "^packer/windows/base/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
         "export SESSION_MANAGER_PLUGIN_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+\\.\\d+)\"",
@@ -39,7 +39,7 @@
       "customType": "regex",
       "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/stack/scripts/versions\\.ps1$"
+        "^packer/windows/base/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
         "export AWS_CLI_LINUX_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
@@ -53,7 +53,7 @@
       "customType": "regex",
       "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/stack/scripts/versions\\.ps1$"
+        "^packer/windows/base/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
         "export GIT_LFS_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
@@ -79,7 +79,7 @@
       "customType": "regex",
       "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/stack/scripts/versions\\.ps1$"
+        "^packer/windows/base/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
         "export DOCKER_COMPOSE_V2_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
@@ -105,7 +105,7 @@
       "customType": "regex",
       "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/stack/scripts/versions\\.ps1$"
+        "^packer/windows/base/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
         "export LIFECYCLED_VERSION=\"v(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
@@ -119,7 +119,7 @@
       "customType": "regex",
       "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/stack/scripts/versions\\.ps1$"
+        "^packer/windows/base/scripts/versions\\.ps1$"
       ],
       "matchStrings": [
         "export S3_SECRETS_HELPER_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->
I forgot to update path for Windows in
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1686.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
