### PR TITLE
fix: ensure AMI metadata is set for copy step when builds are skipped

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -396,7 +396,11 @@ steps:
 
   - id: "copy-ami"
     name: ":cloudformation: 🚚 🌎"
-    command: .buildkite/steps/copy.sh
+    command:
+      - .buildkite/steps/ensure_ami_metadata.py linux amd64
+      - .buildkite/steps/ensure_ami_metadata.py linux arm64
+      - .buildkite/steps/ensure_ami_metadata.py windows amd64
+      - .buildkite/steps/copy.sh
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/mappings.yml"


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->
Call ensure_ami_metadata.py for all architectures before copy.sh to fetch AMI IDs from main branch when builds are skipped.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
