### PR TITLE
Close <details> tag in 6.39.0 CHANGELOG.md entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1047,7 +1047,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [#3298](https://github.com/buildkite/agent/pull/3298), [#3300](https://github.com/buildkite/agent/pull/3300), [#3301](https://github.com/buildkite/agent/pull/3301), [#3299](https://github.com/buildkite/agent/pull/3299), [#3287](https://github.com/buildkite/agent/pull/3287), [#3290](https://github.com/buildkite/agent/pull/3290), [#3291](https://github.com/buildkite/agent/pull/3291) (@dependabot[bot])
 
-<details>
+</details>
 
 ## [v6.38.0](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v6.37.0...v6.38.0) (2025-05-13)
 


### PR DESCRIPTION
## Description

I was reviewing the changelog to do a large upgrade, and discovered that the CHANGELOG.md looks truncated at 6.39.0. The "Agent changelog" `<details>` section isn't closed correctly, and 6.38.0 and earlier are hidden inside double `<details>` collapses.

This is a very minor typo, but it makes reading those old changelogs much harder.

Validation: searching + counting says there's now 35 `<details>` tags, and 35 `</details>` tags in this file. (Previously 36 and 34.)


## Checklist

All of these are not applicable, I think:

- [x] Tests pass locally
- [x] Added tests for new features/fixes
- [x] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
