### PR TITLE
Install add'l python3.x versions

### DIFF
--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -28,6 +28,12 @@ sudo dnf install -yq \
   python \
   python-pip \
   python-setuptools \
+  python3.11 \
+  python3.11-pip \
+  python3.12 \
+  python3.12-pip \
+  python3.13 \
+  python3.13-pip \
   unzip \
   wget \
   zip


### PR DESCRIPTION
## Description

Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1701

Adds the following versions of Python to the Linux AMI:
- Python 3.11.13
- Python 3.12.11
- Python 3.13.3

Per Amazon [documentation](https://docs.aws.amazon.com/linux/al2023/ug/python.html) additional/newer versions of Python can be installed alongside Python 3.9 (System Python), as long as the `/usr/bin/python3` symlink is not changed.

These additional Python versions can be accessed with:
- `python3.11`
- `python3.12`
- `python3.13`

```
$ which python3.11
/usr/bin/python3.11

$ python3.13 -V
Python 3.13.3
```

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
