### PR TITLE
Update log messages during disk space checks/cleanup ops

### DIFF
--- a/packer/linux/base/conf/docker/scripts/docker-low-disk-gc
+++ b/packer/linux/base/conf/docker/scripts/docker-low-disk-gc
@@ -34,12 +34,12 @@ trap mark_instance_unhealthy ERR
 ## if we really need to
 
 if ! /usr/local/bin/bk-check-disk-space.sh; then
-  echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL}"
+  echo "Cleaning up docker resources older than ${DOCKER_PRUNE_UNTIL} to free disk space"
   docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
   docker builder prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL}"
 
   if ! /usr/local/bin/bk-check-disk-space.sh; then
-    echo "Disk health checks failed" >&2 && false
+    echo "Insufficient disk space after cleanup." >&2 && false
     exit 1
   fi
 fi

--- a/packer/linux/stack/conf/bin/bk-check-disk-space.sh
+++ b/packer/linux/stack/conf/bin/bk-check-disk-space.sh
@@ -30,11 +30,11 @@ if [[ $disk_avail -lt $DISK_MIN_AVAILABLE ]]; then
       echo "Disk space sufficient after build purge. Continuing."
       exit 0
     else
-      echo "Disk health checks failed after build purge. Terminating agent." >&2
+      echo "Insufficient disk space remaining after build purge." >&2
       exit 1
     fi
   else
-    echo "Disk health checks failed. Build purge not enabled. Terminating agent." >&2
+    echo "Insufficient disk space. Build purge not enabled." >&2
     exit 1
   fi
 fi

--- a/packer/linux/stack/conf/buildkite-agent/hooks/environment
+++ b/packer/linux/stack/conf/buildkite-agent/hooks/environment
@@ -41,7 +41,7 @@ fi
 
 echo "Checking disk space"
 if ! /usr/local/bin/bk-check-disk-space.sh; then
-  echo "~~~ :broom: Pruning docker resources"
+  echo "~~~ :broom: Pruning docker resources to free disk space"
   docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL:-4h}" || true
 
   if [[ "${DOCKER_BUILDER_PRUNE_ENABLED:-false}" == "true" ]]; then
@@ -51,7 +51,7 @@ if ! /usr/local/bin/bk-check-disk-space.sh; then
   echo "Checking disk space again"
   # Capture disk space output for potential error logging
   if ! disk_check_output=$(/usr/local/bin/bk-check-disk-space.sh 2>&1); then
-    echo "--- :warning: Disk health checks failed."
+    echo "--- :warning: Insufficient disk space after cleanup."
     echo "${disk_check_output}"
 
     # Check if instance termination is enabled (default: false for backward compatibility)

--- a/packer/linux/stack/conf/buildkite-agent/hooks/pre-exit
+++ b/packer/linux/stack/conf/buildkite-agent/hooks/pre-exit
@@ -5,7 +5,7 @@ set -eu -o pipefail
 if [[ "${ENABLE_PRE_EXIT_DISK_CLEANUP:-false}" == "true" ]]; then
   echo "Checking disk space"
   if ! /usr/local/bin/bk-check-disk-space.sh; then
-    echo "~~~ :broom: Pruning docker resources"
+    echo "~~~ :broom: Pruning docker resources to free disk space"
     docker image prune --all --force --filter "until=${DOCKER_PRUNE_UNTIL:-4h}" || true
 
     if [[ "${DOCKER_BUILDER_PRUNE_ENABLED:-false}" == "true" ]]; then
@@ -15,7 +15,7 @@ if [[ "${ENABLE_PRE_EXIT_DISK_CLEANUP:-false}" == "true" ]]; then
     echo "Checking disk space again"
     # Capture disk space output for potential error logging
     if ! disk_check_output=$(/usr/local/bin/bk-check-disk-space.sh 2>&1); then
-      echo "--- :warning: Disk health checks failed."
+      echo "--- :warning: Insufficient disk space after cleanup."
       echo "${disk_check_output}"
 
       # Check if instance termination is enabled (default: false for backward compatibility)


### PR DESCRIPTION
## Description

Noticed log messages like `Disk health checks failed. Build purge not enabled. Terminating agent.` when the CF param for `BuildkiteTerminateInstanceOnDiskFull` was set to `false`. Updated some of the log messages to improve clarity during disk space checks and cleanup.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
