### PR TITLE
Fix disk cleanup for multi-agent instances

### DIFF
--- a/packer/linux/stack/conf/bin/bk-check-disk-space.sh
+++ b/packer/linux/stack/conf/bin/bk-check-disk-space.sh
@@ -24,6 +24,10 @@ if [[ $disk_avail -lt $DISK_MIN_AVAILABLE ]]; then
     # Extract the agent-specific directory to avoid disrupting other agents on the same instance
     AGENT_ORG_PIPELINE_DIR="${BUILDKITE_BUILD_CHECKOUT_PATH#"${BUILDKITE_BUILD_PATH}/"}"
     AGENT_DIR="${AGENT_ORG_PIPELINE_DIR%%/*}"
+    if [[ -z "${AGENT_DIR}" ]]; then
+      echo "Unable to determine agent-specific build directory. Skipping purge to avoid deleting other agents' builds." >&2
+      exit 1
+    fi
     AGENT_BUILD_DIR="${BUILDKITE_BUILD_PATH}/${AGENT_DIR}"
 
     echo "Purging builds in ${AGENT_BUILD_DIR}"


### PR DESCRIPTION
## Description

Fixes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1255

In https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1567 additional logic was added to purge the builds directory when insufficient space was reclaimed from `docker <image|builder> prune` commands. This didn't correctly account for instances with multiple running agents. The build purge will now only target the job's agent directory.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
