### PR TITLE
Bump agent scaler to v1.11.0

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -2725,6 +2725,7 @@ Resources:
                   - "ssm:SendCommand"
                 Resource:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}::document/AWS-RunShellScript
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}::document/AWS-RunPowerShellScript
         - PolicyName: StopBuildkiteInstances
           PolicyDocument:
             Version: 2012-10-17
@@ -2856,7 +2857,7 @@ Resources:
           - AgentScalerARN
           - "x86-64"
           - ARN
-        SemanticVersion: 1.10.1
+        SemanticVersion: 1.11.0
       Parameters:
         BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
         BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]
@@ -2888,7 +2889,7 @@ Resources:
           - AgentScalerARN
           - "arm64"
           - ARN
-        SemanticVersion: 1.10.1
+        SemanticVersion: 1.11.0
       Parameters:
         BuildkiteAgentTokenParameter: !If [ UseCustomerManagedParameterPath, !Ref BuildkiteAgentTokenParameterStorePath, !Ref BuildkiteAgentTokenParameter ]
         BuildkiteAgentTokenParameterStoreKMSKey: !If [ UseCustomerManagedKeyForParameterStore, !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ]

--- a/templates/service-role.yml
+++ b/templates/service-role.yml
@@ -295,6 +295,7 @@ Resources:
                 "autoscaling:DescribeAutoScalingInstances",
                 "autoscaling:DescribeLifecycleHooks",
                 "autoscaling:SetDesiredCapacity",
+                "autoscaling:SetInstanceHealth",
                 "autoscaling:PutLifecycleHook",
                 "autoscaling:DeleteLifecycleHook",
                 "autoscaling:SetInstanceProtection",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->

This version includes handling for dangling instances for Windows (when Elastic CI Mode is enabled via `ScalerEnableExperimentalElasticCIMode`), and swaps direct instance termination for marking instance as unhealthy in the Auto Scaling Group.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
