### PR TITLE
add python3.14 variants

### DIFF
--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -34,6 +34,8 @@ sudo dnf install -yq \
   python3.12-pip \
   python3.13 \
   python3.13-pip \
+  python3.14 \
+  python3.14-pip \
   unzip \
   wget \
   zip


### PR DESCRIPTION
## Description

Closes https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1741

Adds Python 3.14 variants as per the requirements outlined in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1702

