### PR TITLE
Set agent-edge as default agent endpoint

### DIFF
--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -368,7 +368,7 @@ tags=$(
   IFS=,
   echo "${agent_metadata[*]}"
 )
-endpoint=${BUILDKITE_AGENT_ENDPOINT:-"https://agent.buildkite.com/v3"}
+endpoint=${BUILDKITE_AGENT_ENDPOINT:-"https://agent-edge.buildkite.com/v3"}
 tags-from-ec2-meta-data=true
 no-ansi-timestamps=${BUILDKITE_AGENT_NO_ANSI_TIMESTAMPS}
 timestamp-lines=${BUILDKITE_AGENT_TIMESTAMP_LINES}

--- a/packer/windows/stack/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/stack/conf/bin/bk-install-elastic-stack.ps1
@@ -96,7 +96,7 @@ set_always         "BUILDKITE_S3_DEFAULT_REGION" "$Env:BUILDKITE_S3_DEFAULT_REGI
 set_always         "BUILDKITE_S3_ACL" "$Env:BUILDKITE_S3_ACL"
 set_unless_present "AWS_DEFAULT_REGION" "$Env:AWS_REGION"
 set_unless_present "AWS_REGION" "$Env:AWS_REGION"
-set_unless_present "BUILDKITE_AGENT_ENDPOINT" "https://agent.buildkite.com/v3"
+set_unless_present "BUILDKITE_AGENT_ENDPOINT" "https://agent-edge.buildkite.com/v3"
 "@
 
 If ($Env:BUILDKITE_AGENT_RELEASE -eq "edge") {

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -238,7 +238,7 @@ Parameters:
       API endpoint URL for Buildkite agent communication. Most
       customers shouldn't need to change this unless using a custom endpoint agreed with the Buildkite team.
     Type: String
-    Default: "https://agent.buildkite.com/v3"
+    Default: "https://agent-edge.buildkite.com/v3"
 
   BuildkiteAgentTags:
     Description: >


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->

Since agent [v3.122.0](https://github.com/buildkite/agent/releases/tag/v3.122.0) introduced in
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1760, default agent endpoint changes from https://agent.buildkite.com/v3 to https://agent-edge.buildkite.com/v3, so this PR aligns with those defaults.

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
