### PR TITLE
Increases the default IOPS for gp3 volume

### DIFF
--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -779,7 +779,7 @@ Parameters:
   RootVolumeIops:
     Description: If the `RootVolumeType` is gp3, io1, or io2, the number of IOPS to provision for the root volume.
     Type: Number
-    Default: 1000
+    Default: 3000
 
   RootVolumeEncrypted:
     Description: Indicates whether the EBS volume is encrypted.


### PR DESCRIPTION
## Description

The baseline for `gp3` is 3000 IOPS, but we have it set at 1000, leaving a free 2000 on the table. Given we set `gp3` as the default value, we should use `3000` as the default for IOPS for optimal performance.

Likely a legacy setting from `gp2`, but is a potential performance improvement that we can add without any cost (it's the baseline for free tier, too)

Ref: https://aws.amazon.com/ebs/general-purpose/
