### PR TITLE
Fix changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 **Full Changelog**: https://github.com/buildkite/agent/compare/v3.126.0...v3.127.0
 </details>
+
+
 ## [v6.65.0](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v6.64.0...v6.65.0) (2026-05-08)
 
 ### Changed


### PR DESCRIPTION
I missed newline in my earlier suggestion
https://github.com/buildkite/elastic-ci-stack-for-aws/pull/1786#discussion_r3287635728 which resulted in changelog entry for 6.65.0 squashed into 6.66.0.

