### PR TITLE
Improve fix-perms with parallelism and progress output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/google/go-cmp v0.7.0
 	golang.org/x/sys v0.44.0
 )
+
+require golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/fixperms/fdfs/fdfs.go
+++ b/internal/fixperms/fdfs/fdfs.go
@@ -5,14 +5,24 @@
 package fdfs
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
 
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 )
 
-const resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_MAGICLINKS | unix.RESOLVE_NO_XDEV
+const (
+	resolveFlags = unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_MAGICLINKS | unix.RESOLVE_NO_XDEV
+
+	heartbeatInterval = 30 * time.Second
+)
 
 // FS uses a file descriptor for a directory as the base of a fs.FS.
 type FS struct {
@@ -82,6 +92,7 @@ func (s *FS) Sub(dir string) (*FS, error) {
 }
 
 // RecursiveChown lchowns everything within the receiver.
+// Not safe for concurrent calls on the same receiver.
 func (s *FS) RecursiveChown(uid, gid int) error {
 	// Q: Why not fs.WalkDir(... s.Lchown(path, uid, gid) ... ) ?
 	// A: fs.WalkDir gives the callback a subpath to each item. So although
@@ -94,49 +105,187 @@ func (s *FS) RecursiveChown(uid, gid int) error {
 		return err
 	}
 
-	// This closure exists so sd.Close happens before the next loop iteration,
-	// rather than at the end of RecursiveChown.
-	chownSubdir := func(name string) error {
-		sd, err := s.Sub(name)
-		if err != nil {
-			return err
-		}
-		defer sd.Close()
-		return sd.RecursiveChown(uid, gid)
-	}
+	g, ctx := errgroup.WithContext(context.Background())
+	g.SetLimit(min(128, max(1, 2*runtime.GOMAXPROCS(0))))
 
-	// The "file" within an *FS should always be a directory.
-	ds, err := s.file.ReadDir(-1)
-	if err != nil {
+	var files, dirs atomic.Uint64
+	stop := startHeartbeat(&files, &dirs)
+	defer stop()
+
+	g.Go(func() error {
+		return walkContents(ctx, g, s, uid, gid, &files, &dirs)
+	})
+	return g.Wait()
+}
+
+// walkContents walks fsys's entries and dispatches subdirs via g.TryGo
+// with inline fallback (avoids deadlock when every worker is in
+// dispatch). Does not close fsys.
+func walkContents(ctx context.Context, g *errgroup.Group, fsys *FS, uid, gid int, files, dirs *atomic.Uint64) error {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	ds, err := fsys.file.ReadDir(-1)
+	if err != nil {
+		if raceErr(err) {
+			return nil
+		}
+		return err
+	}
+	dirs.Add(1)
+
 	for _, d := range ds {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		if !d.IsDir() {
 			// Skip lchown if the uid and gid already match. This avoids updating
 			// the ctime of files unnecessarily.
-			stat, err := s.Stat(d.Name())
+			stat, err := fsys.Stat(d.Name())
 			if err != nil {
+				if raceErr(err) {
+					continue
+				}
 				return err
 			}
+			files.Add(1)
 			if int(stat.Uid) == uid && int(stat.Gid) == gid {
 				continue
 			}
-
-			if err := s.Lchown(d.Name(), uid, gid); err != nil {
+			if err := fsys.Lchown(d.Name(), uid, gid); err != nil {
+				if raceErr(err) {
+					continue
+				}
 				return err
 			}
 			continue
 		}
 
 		// Defensively check we're not about to recurse on a symlink.
-		// (The openat2 call in s.Sub will block it anyway.)
+		// (The openat2 call in fsys.Sub will block it anyway.)
 		if d.Type()&fs.ModeSymlink != 0 {
 			continue
 		}
 
-		if err := chownSubdir(d.Name()); err != nil {
+		sub, err := fsys.Sub(d.Name())
+		if err != nil {
+			if raceErr(err) {
+				continue
+			}
 			return err
+		}
+		walk := func() error {
+			defer sub.Close()
+			if err := sub.Lchown(".", uid, gid); err != nil {
+				if raceErr(err) {
+					return nil
+				}
+				return err
+			}
+			return walkContents(ctx, g, sub, uid, gid, files, dirs)
+		}
+		if !g.TryGo(walk) {
+			if err := walk(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// startHeartbeat emits a progress line to stderr every heartbeatInterval
+// with a verdict for stalled walks. Returns a func that stops the
+// goroutine and waits for exit.
+func startHeartbeat(files, dirs *atomic.Uint64) func() {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		startWall := time.Now()
+		var lastRU unix.Rusage
+		_ = unix.Getrusage(unix.RUSAGE_SELF, &lastRU)
+
+		lastWall := startWall
+		lastFiles := uint64(0)
+		problemTicks := 0
+		hintShown := false
+
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case now := <-ticker.C:
+				f := files.Load()
+				d := dirs.Load()
+
+				interval := now.Sub(lastWall).Seconds()
+				rate := 0.0
+				if interval > 0 {
+					rate = float64(f-lastFiles) / interval
+				}
+
+				var ru unix.Rusage
+				_ = unix.Getrusage(unix.RUSAGE_SELF, &ru)
+				intervalCPU := rusageCPU(ru) - rusageCPU(lastRU)
+				cpuPerCore := 0.0
+				if interval > 0 {
+					cpuPerCore = 100 * intervalCPU.Seconds() / interval / float64(runtime.GOMAXPROCS(0))
+				}
+				wall := now.Sub(startWall)
+
+				verdict := ""
+				switch {
+				case rate < 100:
+					verdict = " — barely making progress (check for disk hang or severe EBS throttling)"
+					problemTicks++
+				case rate < 2000 && cpuPerCore < 25:
+					verdict = " — EBS-bound (mostly blocked on disk I/O)"
+					problemTicks++
+				default:
+					problemTicks = 0
+				}
+				if problemTicks >= 2 && !hintShown {
+					verdict += " — set DOCKER_USERNS_REMAP=true to skip fix-perms entirely, or provision more EBS IOPS"
+					hintShown = true
+				}
+
+				fmt.Fprintf(os.Stderr,
+					"fix-perms: %d files (%.0f/s), %d dirs in %s, CPU %.0f%%/core%s\n",
+					f, rate, d, wall.Round(time.Second), cpuPerCore, verdict,
+				)
+
+				lastFiles = f
+				lastWall = now
+				lastRU = ru
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	return func() {
+		close(stop)
+		<-done
+	}
+}
+
+// raceErr reports errors indicating the entry changed concurrently
+// (unlinked, replaced, cross-mount). Real failures are returned.
+func raceErr(err error) bool {
+	return errors.Is(err, unix.ENOENT) ||
+		errors.Is(err, unix.ELOOP) ||
+		errors.Is(err, unix.ENOTDIR) ||
+		errors.Is(err, unix.EXDEV)
+}
+
+// rusageCPU returns user+system CPU time from a Rusage.
+func rusageCPU(r unix.Rusage) time.Duration {
+	user := time.Duration(r.Utime.Sec)*time.Second + time.Duration(r.Utime.Usec)*time.Microsecond
+	sys := time.Duration(r.Stime.Sec)*time.Second + time.Duration(r.Stime.Usec)*time.Microsecond
+	return user + sys
 }

--- a/internal/fixperms/fdfs/fdfs_test.go
+++ b/internal/fixperms/fdfs/fdfs_test.go
@@ -3,14 +3,23 @@
 package fdfs
 
 import (
+	"context"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
+
+	"golang.org/x/sync/errgroup"
 )
 
 func TestTOCTOUShenanigans(t *testing.T) {
-	path := "/tmp/TestTOCTOUShenanigans/foo"
+	base := t.TempDir()
+	path := filepath.Join(base, "foo")
 	if err := os.MkdirAll(path, 0o777); err != nil {
 		t.Fatalf("os.MkdirAll(%s, %o) = %v", path, 0o777, err)
 	}
@@ -19,7 +28,7 @@ func TestTOCTOUShenanigans(t *testing.T) {
 		t.Fatalf("os.WriteFile(%s, nil, 0o666) = %v", fp, err)
 	}
 
-	path2 := "/tmp/TestTOCTOUShenanigans/crimes"
+	path2 := filepath.Join(base, "crimes")
 	if err := os.MkdirAll(path2, 0o777); err != nil {
 		t.Fatalf("os.MkdirAll(%s, %o) = %v", path2, 0o777, err)
 	}
@@ -30,19 +39,19 @@ func TestTOCTOUShenanigans(t *testing.T) {
 
 	// Do it in two steps, to simulate a trusted directory and an untrusted
 	// subpath.
-	fsys, err := DirFS("/tmp/TestTOCTOUShenanigans")
+	fsys, err := DirFS(base)
 	if err != nil {
-		t.Fatalf("DirFS(/tmp/TestTOCTOUShenanigans) error = %v", err)
+		t.Fatalf("DirFS(%s) error = %v", base, err)
 	}
 	defer fsys.Close()
 	fooFS, err := fsys.Sub("foo")
 	if err != nil {
-		t.Fatalf("DirFS(/tmp/TestTOCTOUShenanigans).Sub(foo) error = %v", err)
+		t.Fatalf("DirFS(%s).Sub(foo) error = %v", base, err)
 	}
 	defer fooFS.Close()
 
 	// Replace foo with a symlink to crimes...
-	path3 := "/tmp/TestTOCTOUShenanigans/foo.bak"
+	path3 := filepath.Join(base, "foo.bak")
 	if err := os.Rename(path, path3); err != nil {
 		t.Fatalf("os.Rename(%s, %s) = %v", path, path3, err)
 	}
@@ -57,5 +66,303 @@ func TestTOCTOUShenanigans(t *testing.T) {
 	}
 	if got, want := string(df), "innocent"; got != want {
 		t.Fatalf("fs.ReadFile(DirFS(%s), data) contents = %q, want %q", path, got, want)
+	}
+}
+
+// TestRecursiveChown_TreeShapes walks shapes that exercise both the
+// spawn-a-worker and fall-back-to-inline branches of dispatch, and
+// checks counter accuracy. Chown is a no-op (uid matches), so no root.
+func TestRecursiveChown_TreeShapes(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T, dir string) (wantFiles, wantDirs int)
+	}{
+		{
+			// Forces sem saturation and inline fallback.
+			name: "wide_shallow",
+			build: func(t *testing.T, dir string) (int, int) {
+				const n = 100
+				for i := 0; i < n; i++ {
+					sub := filepath.Join(dir, fmt.Sprintf("s%d", i))
+					mkdir(t, sub)
+					writeFile(t, filepath.Join(sub, "f"))
+				}
+				return n, n + 1
+			},
+		},
+		{
+			// Drives the inline recursion path.
+			name: "deep_narrow",
+			build: func(t *testing.T, dir string) (int, int) {
+				const n = 100
+				p := dir
+				for i := 0; i < n; i++ {
+					p = filepath.Join(p, "d")
+					mkdir(t, p)
+				}
+				writeFile(t, filepath.Join(p, "leaf"))
+				return 1, n + 1
+			},
+		},
+		{
+			name: "mixed",
+			build: func(t *testing.T, dir string) (int, int) {
+				const a, b, f = 20, 5, 5
+				for i := 0; i < a; i++ {
+					ad := filepath.Join(dir, fmt.Sprintf("a%d", i))
+					mkdir(t, ad)
+					for j := 0; j < b; j++ {
+						bd := filepath.Join(ad, fmt.Sprintf("b%d", j))
+						mkdir(t, bd)
+						for k := 0; k < f; k++ {
+							writeFile(t, filepath.Join(bd, fmt.Sprintf("f%d", k)))
+						}
+					}
+				}
+				return a * b * f, 1 + a + a*b
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			wantFiles, wantDirs := tt.build(t, dir)
+
+			fsys, err := DirFS(dir)
+			if err != nil {
+				t.Fatalf("DirFS(%s): %v", dir, err)
+			}
+			defer fsys.Close()
+
+			// Drive walkContents directly to read counters.
+			g, ctx := errgroup.WithContext(context.Background())
+			g.SetLimit(min(128, max(1, 2*4)))
+
+			var files, dirs atomic.Uint64
+			if err := walkContents(ctx, g, fsys, os.Getuid(), os.Getgid(), &files, &dirs); err != nil {
+				t.Fatalf("walkContents: %v", err)
+			}
+			if err := g.Wait(); err != nil {
+				t.Fatalf("g.Wait: %v", err)
+			}
+
+			if got := files.Load(); got != uint64(wantFiles) {
+				t.Errorf("files = %d, want %d", got, wantFiles)
+			}
+			if got := dirs.Load(); got != uint64(wantDirs) {
+				t.Errorf("dirs = %d, want %d", got, wantDirs)
+			}
+		})
+	}
+}
+
+// TestRecursiveChown_Symlinks checks that symlinks (to files or dirs) are
+// chowned as non-dir entries and never recursed into.
+func TestRecursiveChown_Symlinks(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "real_file"))
+	if err := os.Symlink("real_file", filepath.Join(dir, "link_to_file")); err != nil {
+		t.Fatal(err)
+	}
+
+	mkdir(t, filepath.Join(dir, "subdir"))
+	writeFile(t, filepath.Join(dir, "subdir", "f"))
+	if err := os.Symlink("subdir", filepath.Join(dir, "link_to_dir")); err != nil {
+		t.Fatal(err)
+	}
+
+	fsys, err := DirFS(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fsys.Close()
+
+	g, ctx := errgroup.WithContext(context.Background())
+	g.SetLimit(4)
+	var files, dirs atomic.Uint64
+	if err := walkContents(ctx, g, fsys, os.Getuid(), os.Getgid(), &files, &dirs); err != nil {
+		t.Fatalf("walkContents: %v", err)
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("g.Wait: %v", err)
+	}
+
+	// dirs: root + subdir. link_to_dir must not be recursed.
+	if got, want := dirs.Load(), uint64(2); got != want {
+		t.Errorf("dirs = %d, want %d", got, want)
+	}
+	// files: real_file + link_to_file + link_to_dir + subdir/f.
+	if got, want := files.Load(), uint64(4); got != want {
+		t.Errorf("files = %d, want %d", got, want)
+	}
+}
+
+// TestRecursiveChown_ActualLchown exercises real Lchown by chowning to
+// nobody under root. The no-op tests above take the fast-path skip.
+func TestRecursiveChown_ActualLchown(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to chown to a different uid/gid")
+	}
+
+	const nobodyUID, nobodyGID = 65534, 65534
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "f1"))
+	mkdir(t, filepath.Join(dir, "sub"))
+	writeFile(t, filepath.Join(dir, "sub", "f2"))
+	if err := os.Symlink("f1", filepath.Join(dir, "link_to_f1")); err != nil {
+		t.Fatal(err)
+	}
+
+	fsys, err := DirFS(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fsys.Close()
+
+	if err := fsys.RecursiveChown(nobodyUID, nobodyGID); err != nil {
+		t.Fatalf("RecursiveChown: %v", err)
+	}
+
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("stat for %s is not *syscall.Stat_t", path)
+		}
+		if st.Uid != nobodyUID {
+			t.Errorf("%s uid = %d, want %d", path, st.Uid, nobodyUID)
+		}
+		if st.Gid != nobodyGID {
+			t.Errorf("%s gid = %d, want %d", path, st.Gid, nobodyGID)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("verification walk: %v", err)
+	}
+}
+
+// TestRecursiveChown_PublicAPI smoke-tests the public API. Lchown is not
+// exercised (same-uid fast-path); TestRecursiveChown_ActualLchown covers it.
+func TestRecursiveChown_PublicAPI(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 10; i++ {
+		sub := filepath.Join(dir, fmt.Sprintf("s%d", i))
+		mkdir(t, sub)
+		writeFile(t, filepath.Join(sub, "f"))
+	}
+
+	fsys, err := DirFS(dir)
+	if err != nil {
+		t.Fatalf("DirFS: %v", err)
+	}
+	defer fsys.Close()
+
+	if err := fsys.RecursiveChown(os.Getuid(), os.Getgid()); err != nil {
+		t.Fatalf("RecursiveChown: %v", err)
+	}
+}
+
+// TestRecursiveChown_TOCTOUConcurrent: attacker swaps subdirs for
+// symlinks to a honeypot outside the tree while RecursiveChown runs.
+// Honeypot ownership must stay unchanged.
+func TestRecursiveChown_TOCTOUConcurrent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to chown to a different uid/gid")
+	}
+
+	base := t.TempDir()
+	const n = 50
+	for i := 0; i < n; i++ {
+		sub := filepath.Join(base, fmt.Sprintf("s%d", i))
+		mkdir(t, sub)
+		for j := 0; j < 5; j++ {
+			writeFile(t, filepath.Join(sub, fmt.Sprintf("f%d", j)))
+		}
+	}
+
+	honeypot := t.TempDir()
+	witness := filepath.Join(honeypot, "witness")
+	if err := os.WriteFile(witness, []byte("untouched"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fsys, err := DirFS(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fsys.Close()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for i := 0; i < n; i++ {
+				sub := filepath.Join(base, fmt.Sprintf("s%d", i))
+				bak := sub + ".bak"
+				if os.Rename(sub, bak) == nil {
+					_ = os.Symlink(honeypot, sub)
+					runtime.Gosched() // widen the swap window
+					_ = os.Remove(sub)
+					_ = os.Rename(bak, sub)
+				}
+			}
+		}
+	}()
+
+	const nobodyUID, nobodyGID = 65534, 65534
+	// Log (don't fail) on race-induced errors. A regression where the
+	// walk never reaches anything would silently pass the honeypot check.
+	if err := fsys.RecursiveChown(nobodyUID, nobodyGID); err != nil {
+		t.Logf("RecursiveChown returned (likely from race): %v", err)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// Honeypot dir is the broader detector — sub.Lchown(".") fires before
+	// ReadDir, so a leak hits the dir even if the attacker restores fast.
+	for _, p := range []string{honeypot, witness} {
+		info, err := os.Lstat(p)
+		if err != nil {
+			t.Fatalf("Lstat %s: %v", p, err)
+		}
+		st, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			t.Fatalf("%s stat is not *syscall.Stat_t", p)
+		}
+		if st.Uid == nobodyUID {
+			t.Errorf("TOCTOU regression: %s was chowned to nobody", p)
+		}
+	}
+}
+
+func mkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(%s): %v", path, err)
+	}
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
 	}
 }

--- a/internal/fixperms/fixer/fixer.go
+++ b/internal/fixperms/fixer/fixer.go
@@ -1,4 +1,4 @@
-//go:buid linux
+//go:build linux
 
 package fixer
 

--- a/internal/fixperms/fixperms.go
+++ b/internal/fixperms/fixperms.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/buildkite/elastic-ci-stack-for-aws/v6/internal/fixperms/fixer"
+	"golang.org/x/sys/unix"
 )
 
 // Files that are created by Docker containers end up with strange user and
@@ -55,6 +56,21 @@ const (
 )
 
 func main() {
+	// Raise NOFILE to the hard limit; the parallel walk holds
+	// ~parallelism × tree-depth open FDs.
+	var rl unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rl); err != nil {
+		fmt.Fprintf(os.Stderr, "fix-perms: getrlimit(NOFILE) failed: %v\n", err)
+	} else if rl.Max > rl.Cur {
+		orig := rl.Cur
+		rl.Cur = rl.Max
+		if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rl); err != nil {
+			fmt.Fprintf(os.Stderr, "fix-perms: setrlimit(NOFILE, %d) failed: %v\n", rl.Max, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "fix-perms: raised NOFILE soft limit %d -> %d\n", orig, rl.Cur)
+		}
+	}
+
 	msg, code := fixer.Main(os.Args, buildsDir, username)
 	if code != 0 {
 		fmt.Fprintln(os.Stderr, msg)


### PR DESCRIPTION
## Description

Parallelises the recursive chown, adds a diagnostic heartbeat so users can distinguish slow walks from hangs, and adds an "EBS-bound" tip with a `DOCKER_USERNS_REMAP=true` action hint when the walk is stalled on disk I/O.

This will resolve hanging perms fixes on larger codebases from a "it's doing nothing" POV. And aims to identify any issues that may be occurring, such as slow reading, being bound by resources, or by I/O.

This will not necessarily be a groundbreaking fix, but it should definitely help performance with parallelism and makes the tool verbose.

Fixes #1780

## Checklist

- [x] Tests pass locally
- [x] Added tests for new features/fixes
- [x] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
- [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
