### PR TITLE
Fix git-lfs update with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,12 +52,10 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^packer/linux/base/scripts/versions\\.sh$",
-        "^packer/windows/base/scripts/versions\\.ps1$"
+        "^packer/linux/base/scripts/versions\\.sh$"
       ],
       "matchStrings": [
-        "export GIT_LFS_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
-        "\\$GIT_VERSION = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+        "export GIT_LFS_VERSION=\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "git-lfs/git-lfs",


### PR DESCRIPTION

## Description

<!-- Please include a summary of the change and the issue it fixes. -->

git-lfs is bundled with the Git package installed via Chocolatey, so having it defined in `versions.ps1` is what trips Renovate now.

Context: https://linear.app/buildkite/issue/SUP-7259/

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
