### PR TITLE
Track Git for Windows version with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,19 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "^packer/windows/base/scripts/versions\\.ps1$"
+      ],
+      "matchStrings": [
+        "\\$GIT_VERSION = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "git-for-windows/git",
+      "extractVersionTemplate": "^v?(?<version>\\d+\\.\\d+\\.\\d+)",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$"
       ],
       "matchStrings": [
@@ -185,6 +198,7 @@
     {
       "matchPackageNames": [
         "git-lfs/git-lfs",
+        "git-for-windows/git",
         "goss-org/goss",
         "docker/compose",
         "docker/buildx",


### PR DESCRIPTION
## Description

Adds a Renovate custom manager so the Git for Windows version (`$GIT_VERSION` in `packer/windows/base/scripts/versions.ps1`) receives automatic update PRs. It is currently pinned at 2.39.1 with nothing to bump it.

This is a follow-up to #1797, which stopped Renovate from mis-tracking `$GIT_VERSION` as `git-lfs` but left Git for Windows untracked. The new manager sources from `git-for-windows/git` GitHub releases and uses `extractVersion` to strip the `.windows.N` packaging suffix down to plain semver (for example `v2.54.0.windows.1` becomes `2.54.0`). The existing global `ignoreUnstable` and `respectLatest` rules keep it on the latest stable release, so release candidates are skipped.

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
