### PR TITLE
Rework log collector to use AWS CLI directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,9 +282,17 @@ Provide Buildkite with logs from CloudWatch Logs:
 
 ### Collect logs via script
 
-An alternative method to collect the logs is to use the `log-collector` script in the `utils` folder.
-The script will collect CloudWatch logs for the Instance, Lambda function, and AutoScaling activity and package them in a
-zip archive which you can send via email to support@buildkite.com.
+Use [`utils/log-collector`](utils/log-collector) to collect CloudWatch logs from your stack and bundle them into a `.tar.gz` for support.
+
+```bash
+# Lambda + ASG logs
+./utils/log-collector -s my-stack-name
+
+# Also include a specific instance's logs
+./utils/log-collector -s my-stack-name -i i-0123456789abcdef0
+```
+
+The script requires the AWS CLI configured with credentials for the account the stack runs in. Run with `-h` for all options.
 
 You can also visit our [Forum](https://forum.buildkite.community) and post a question in the [Elastic CI Stack for AWS](https://forum.buildkite.community/c/elastic-ci-stack-for-aws/) section!
 

--- a/README.md
+++ b/README.md
@@ -282,17 +282,19 @@ Provide Buildkite with logs from CloudWatch Logs:
 
 ### Collect logs via script
 
-Use [`utils/log-collector`](utils/log-collector) to collect CloudWatch logs from your stack and bundle them into a `.tar.gz` for support.
+[`utils/log-collector`](utils/log-collector) pulls your stack's CloudWatch logs into a tarball you can send to support.
 
 ```bash
-# Lambda + ASG logs
+# Lambda and ASG logs
 ./utils/log-collector -s my-stack-name
 
-# Also include a specific instance's logs
+# Add a specific instance's logs too
 ./utils/log-collector -s my-stack-name -i i-0123456789abcdef0
 ```
 
-The script requires the AWS CLI configured with credentials for the account the stack runs in. Run with `-h` for all options.
+You'll need the AWS CLI set up with credentials for the account the stack runs in. It only reads (CloudFormation, Lambda, CloudWatch Logs and Auto Scaling), so a read-only role is fine. Run it with `-h` for the other flags.
+
+If a source has no logs you'll get a `.EMPTY` file instead of a `.log`, and a failed one leaves a `.ERROR` file. Whatever went wrong is also listed in `COLLECTION-ERRORS.txt`.
 
 You can also visit our [Forum](https://forum.buildkite.community) and post a question in the [Elastic CI Stack for AWS](https://forum.buildkite.community/c/elastic-ci-stack-for-aws/) section!
 

--- a/utils/log-collector
+++ b/utils/log-collector
@@ -268,6 +268,22 @@ package() {
   echo "Finished collecting logs, you can find them at $PWD/$archive"
 }
 
+summarise() {
+  local errors=0 logs
+  if [[ -f "$dir/COLLECTION-ERRORS.txt" ]]; then
+    errors=$(wc -l <"$dir/COLLECTION-ERRORS.txt" | tr -d ' ')
+  fi
+  logs=$(find "$dir" -maxdepth 1 -type f -name '*.log' | wc -l | tr -d ' ')
+
+  if ((errors > 0)); then
+    echo "WARNING: collection completed with $errors error(s). See COLLECTION-ERRORS.txt for more details." 1>&2
+  fi
+  if ((logs == 0 && errors > 0)); then
+    echo "ERROR: every source failed." 1>&2
+    exit 1
+  fi
+}
+
 main() {
   parse_args "$@"
 
@@ -294,6 +310,7 @@ main() {
   collect_asg
 
   package
+  summarise
 }
 
 main "$@"

--- a/utils/log-collector
+++ b/utils/log-collector
@@ -68,7 +68,7 @@ parse_args() {
     exit 1
   fi
 
-  if [[ -n "$instanceId" && ! "$instanceId" =~ ^i-[0-9a-f]+$ ]]; then
+  if [[ -n "$instanceId" && ! "$instanceId" =~ ^i-[0-9a-f]{8}([0-9a-f]{9})?$ ]]; then
     echo "Error: -i must be an EC2 instance ID (got '$instanceId')" 1>&2
     exit 1
   fi

--- a/utils/log-collector
+++ b/utils/log-collector
@@ -163,20 +163,20 @@ list_lambdas() {
 }
 
 find_lambdas() {
-  list_lambdas "$stackName"
+  local stack="$1" nested child
+  list_lambdas "$stack"
 
-  local nested child
   if ! nested=$(aws_cli cloudformation list-stack-resources \
-    --stack-name "$stackName" \
+    --stack-name "$stack" \
     --query "StackResourceSummaries[?ResourceType=='AWS::CloudFormation::Stack' || ResourceType=='AWS::Serverless::Application'].PhysicalResourceId" \
     --output text 2>"$errFile" | tr '\t' '\n'); then
-    record_error "Failed to list nested stacks in $stackName: $(last_error)"
+    record_error "Failed to list nested stacks in $stack: $(last_error)"
     return 0
   fi
 
   while IFS= read -r child; do
     [[ -z "$child" ]] && continue
-    list_lambdas "$child"
+    find_lambdas "$child"
   done <<<"$nested"
 }
 
@@ -218,7 +218,7 @@ collect_lambda() {
 
 collect_lambdas() {
   local functions fn
-  functions=$(find_lambdas | tr '\t' '\n' | sort -u) || true
+  functions=$(find_lambdas "$stackName" | tr '\t' '\n' | sort -u) || true
 
   if [[ -z "$functions" ]]; then
     record_error "No Lambda functions found in stack $stackName"

--- a/utils/log-collector
+++ b/utils/log-collector
@@ -14,99 +14,286 @@
 
 set -euo pipefail
 
+stackName=""
+instanceId=""
+outputFormat="text"
+region=""
+days=1
+
+now=""
+dir=""
+startTime=""
+errFile=""
+
 usage() {
   cat <<EOF
-Usage: $0 -s <stack-name> -i <instance-id>
-Collect Buildkite Elastic CI stack logs from AWS CloudWatch
--s      Stack name, can be found at https://console.aws.amazon.com/cloudformation/home
--i      Instance ID, the AWS instance ID for the instance you want to collect logs for
--o      Output format for logs (optional flag), supported values are text (default value), json, table
+Usage: $0 -s <stack-name> [-i <instance-id>] [-o <output-format>] [-r <region>] [-d <days>]
+Collect Buildkite Elastic CI Stack logs from AWS CloudWatch.
+
+  -s   Stack name (required).
+  -i   Instance ID (optional). When set, also collects that instance's CloudWatch logs.
+  -o   Output format: text (default), json, or table.
+  -r   AWS region (optional). Defaults to your AWS CLI/IAM Role config.
+  -d   Days of logs to collect (1-365). Defaults to 1 day.
+  -h   Show help.
 EOF
 }
 
-while getopts 'hs:i:o:' opt; do
-  case ${opt} in
-  s)
-    stackName=$OPTARG
-    ;;
-  i)
-    instanceId=$OPTARG
-    ;;
-  o)
-    outputFormat=$OPTARG
-    ;;
-  h)
+parse_args() {
+  while getopts ':hs:i:o:r:d:' opt; do
+    case ${opt} in
+    s) stackName=$OPTARG ;;
+    i) instanceId=$OPTARG ;;
+    o) outputFormat=$OPTARG ;;
+    r) region=$OPTARG ;;
+    d) days=$OPTARG ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" 1>&2
+      exit 1
+      ;;
+    :)
+      echo "Invalid option: -$OPTARG requires an argument" 1>&2
+      exit 1
+      ;;
+    esac
+  done
+
+  if [[ -z "$stackName" ]]; then
+    echo "Error: -s <stack-name> is required" 1>&2
     usage
-    exit 0
-    ;;
-  \?)
-    echo "Invalid Option: -$OPTARG" 1>&2
+    exit 1
+  fi
+
+  if [[ -n "$instanceId" && ! "$instanceId" =~ ^i-[0-9a-f]+$ ]]; then
+    echo "Error: -i must be an EC2 instance ID (got '$instanceId')" 1>&2
+    exit 1
+  fi
+
+  if ! [[ "$days" =~ ^[1-9][0-9]{0,3}$ ]] || ((days > 365)); then
+    echo "Error: -d must be a whole number of days from 1 to 365 (got '$days')" 1>&2
+    exit 1
+  fi
+
+  case "$outputFormat" in
+  text | json | table) ;;
+  *)
+    echo "Error: -o must be one of text, json, table (got '$outputFormat')" 1>&2
     exit 1
     ;;
-  :)
-    echo "Invalid option: $OPTARG requires an arguemnt" 1>&2
-    ;;
   esac
-done
-shift $((OPTIND - 1))
+}
 
-now=$(date +"%F")
-outputFormat="${outputFormat:=text}"
+aws_cli() {
+  if [[ -n "$region" ]]; then
+    aws --region "$region" "$@"
+  else
+    aws "$@"
+  fi
+}
 
-# Create a temporary directory to store our logs
-dir=$(mktemp -d buildkite-logs-"$now"-XXXX)
+record_error() {
+  echo "ERROR: $1" 1>&2
+  echo "$1" >>"$dir/COLLECTION-ERRORS.txt"
+}
 
-echo "Collecting logs for instance $instanceId"
+mark_empty() {
+  echo "$2" >"$dir/$1.EMPTY"
+  rm -f "$dir/$1"
+}
 
-# Collect the logs for the instance
-for name in buildkite-agent system lifecycled docker-daemon; do
-  aws logs get-log-events \
-    --log-group-name "/buildkite/$name" \
-    --log-stream-name "$instanceId" \
-    --output "$outputFormat" \
-    >>"$dir/$name-$instanceId.log"
-done
+mark_failed() {
+  echo "$2" >"$dir/$1.ERROR"
+  rm -f "$dir/$1"
+}
 
-# CloudWatch stores the creationTime as milliseconds since epoch UTC.
-# Since macOS doesn't support calculating the time since epoch in milliseconds, we don't have perfect accuracy on this, but it should be as close to 24 hours as possible
-# We'll check to see if we're running on a macOS-based OS and adjust appropriately, otherwise use the standard date command
+is_empty() {
+  [[ ! -s "$1" ]] && return 0
+  [[ "$(wc -c <"$1" | tr -d ' ')" -le 8 && "$(tr -d '[:space:]' <"$1")" == "[]" ]]
+}
 
-# Currently only collects the last 24h of logs, but it might be good to be able to specify a different value for this.
+last_error() {
+  tr -s '[:space:]' ' ' <"$errFile" 2>/dev/null | sed 's/^ //; s/ $//' || true
+}
 
-# check if we're running on a macOS based system, otherwise use the GNU-based date syntax
-if [[ $OSTYPE == 'darwin'* ]]; then
-  logAge=$(date -v-1d "+%s000")
-else
-  logAge=$(date --date="1day" "+%s000")
-fi
+compute_start_time() {
+  if date --version >/dev/null 2>&1; then
+    date --date="${days} days ago" "+%s000"
+  else
+    date -v-"${days}"d "+%s000"
+  fi
+}
 
-# Collect some information about the Lambda function and associated log groups
-lambdaFunction=$(aws cloudformation describe-stack-resources --stack-name "$stackName" --logical-resource-id Autoscaling --query "StackResources[*].PhysicalResourceId" --output text | sed -nr 's/.*stack\/(.*)\/.*/\1/p')
-lambdaLogGroup=$(aws cloudformation describe-stack-resources --stack-name "$lambdaFunction" --logical-resource-id LogGroup --query "StackResources[*].PhysicalResourceId" --output text)
-logStreams=$(aws logs describe-log-streams --log-group-name "$lambdaLogGroup" --order-by LastEventTime --query "logStreams[?creationTime > \`$logAge\`] | [*].logStreamName" --output text | tr -s '[:space:]' '\n')
+collect_instance() {
+  echo "Collecting logs for instance $instanceId..."
+  local name safe file err
+  for name in buildkite-agent system lifecycled docker-daemon cloud-init cloud-init/output cfn-init elastic-stack auth; do
+    safe="${name//\//-}"
+    file="$dir/$safe-$instanceId.log"
+    if ! aws_cli logs filter-log-events \
+      --log-group-name "/buildkite/$name" \
+      --log-stream-names "$instanceId" \
+      --start-time "$startTime" \
+      --query "events[].[timestamp,message]" \
+      --output "$outputFormat" >"$file" 2>"$errFile"; then
+      err=$(last_error)
+      record_error "Failed to read /buildkite/$name for $instanceId: $err"
+      mark_failed "$safe-$instanceId.log" "Collection failed for /buildkite/$name: $err"
+      continue
+    fi
+    if is_empty "$file"; then
+      mark_empty "$safe-$instanceId.log" "No log events in /buildkite/$name for $instanceId within the last $days day(s)"
+    fi
+  done
+}
 
-# Iterate through all of the log streams we collected from the lambda log group
-echo "Collecting Lambda logs for $lambdaFunction"
+list_lambdas() {
+  local stack="$1" out
+  if out=$(aws_cli cloudformation list-stack-resources \
+    --stack-name "$stack" \
+    --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" \
+    --output text 2>"$errFile"); then
+    echo "$out"
+  else
+    record_error "Failed to list Lambda functions in $stack: $(last_error)"
+  fi
+}
 
-for i in $logStreams; do
-  fileName=$(echo "$i" | sed -r 's/\//-/g')
-  aws logs get-log-events --log-group-name "$lambdaLogGroup" \
-    --log-stream-name "$i" \
-    --output "$outputFormat" \
-    >>"${dir}/lambda-${fileName}.log"
-done
+find_lambdas() {
+  list_lambdas "$stackName"
 
-# Collect ASG activity for the scaling group
-autoScalingGroup=$(aws cloudformation describe-stack-resources --stack-name "$stackName" --logical-resource-id AgentAutoScaleGroup --query "StackResources[*].PhysicalResourceId" --output text)
-echo "Collecting ASG activity for $autoScalingGroup"
-aws autoscaling describe-scaling-activities --auto-scaling-group-name "$autoScalingGroup" >>"${dir}/asg-activities-${stackName}.log"
+  local nested child
+  if ! nested=$(aws_cli cloudformation list-stack-resources \
+    --stack-name "$stackName" \
+    --query "StackResourceSummaries[?ResourceType=='AWS::CloudFormation::Stack' || ResourceType=='AWS::Serverless::Application'].PhysicalResourceId" \
+    --output text 2>"$errFile" | tr '\t' '\n'); then
+    record_error "Failed to list nested stacks in $stackName: $(last_error)"
+    return 0
+  fi
 
-# Make an archive with the logs
-tar -czvf buildkite-logs-"$now".tar.gz "$dir"/*.log
+  while IFS= read -r child; do
+    [[ -z "$child" ]] && continue
+    list_lambdas "$child"
+  done <<<"$nested"
+}
 
-# Clean up the unneeded files
-rm -r "$dir"
+find_log_group() {
+  local fn="$1" lg
+  if ! lg=$(aws_cli lambda get-function-configuration \
+    --function-name "$fn" \
+    --query "LoggingConfig.LogGroup" \
+    --output text 2>"$errFile"); then
+    record_error "Failed to resolve log group for $fn at /aws/lambda/$fn: $(last_error)"
+    lg=""
+  fi
+  if [[ -z "$lg" || "$lg" == "None" ]]; then
+    lg="/aws/lambda/$fn"
+  fi
+  echo "$lg"
+}
 
-echo "Finished collecting logs, you can find them here: $PWD/buildkite-logs-${now}.tar.gz"
+collect_lambda() {
+  local fn="$1" safe logGroup file err
+  safe="${fn//\//-}"
+  logGroup=$(find_log_group "$fn")
+  file="${dir}/lambda-${safe}.log"
+  echo "Collecting logs for Lambda $fn..."
+  if ! aws_cli logs filter-log-events \
+    --log-group-name "$logGroup" \
+    --start-time "$startTime" \
+    --query "events[].[timestamp,message]" \
+    --output "$outputFormat" >"$file" 2>"$errFile"; then
+    err=$(last_error)
+    record_error "Failed to read $logGroup for $fn: $err"
+    mark_failed "lambda-${safe}.log" "Collection failed for $logGroup: $err"
+    return 0
+  fi
+  if is_empty "$file"; then
+    mark_empty "lambda-${safe}.log" "No log events in $logGroup within the last $days day(s)"
+  fi
+}
 
-exit 0
+collect_lambdas() {
+  local functions fn
+  functions=$(find_lambdas | tr '\t' '\n' | sort -u)
+
+  if [[ -z "$functions" ]]; then
+    record_error "No Lambda functions found in stack $stackName"
+    mark_empty "lambda.log" "No Lambda functions found in stack $stackName"
+    return 0
+  fi
+
+  while IFS= read -r fn; do
+    [[ -z "$fn" ]] && continue
+    collect_lambda "$fn"
+  done <<<"$functions"
+}
+
+collect_asg() {
+  local asg file err
+  if ! asg=$(aws_cli cloudformation describe-stack-resources \
+    --stack-name "$stackName" \
+    --logical-resource-id AgentAutoScaleGroup \
+    --query "StackResources[*].PhysicalResourceId" \
+    --output text 2>"$errFile") || [[ -z "$asg" ]]; then
+    err=$(last_error)
+    record_error "Failed to resolve AgentAutoScaleGroup in $stackName: $err"
+    mark_failed "asg-scaling.log" "Collection failed resolving AgentAutoScaleGroup in $stackName: $err"
+    return 0
+  fi
+
+  echo "Collecting scaling activity for $asg..."
+  file="${dir}/asg-scaling.log"
+  if ! aws_cli autoscaling describe-scaling-activities \
+    --auto-scaling-group-name "$asg" \
+    --query "Activities" \
+    --output "$outputFormat" >"$file" 2>"$errFile"; then
+    err=$(last_error)
+    record_error "Failed to collect scaling activity for $asg: $err"
+    mark_failed "asg-scaling.log" "Collection failed for $asg: $err"
+    return 0
+  fi
+  if is_empty "$file"; then
+    mark_empty "asg-scaling.log" "No scaling activity found for $asg"
+  fi
+}
+
+package() {
+  local archive
+  archive="$(basename "$dir").tar.gz"
+  tar -czf "$archive" "$dir"
+  echo "Finished collecting logs, you can find them at $PWD/$archive"
+}
+
+main() {
+  parse_args "$@"
+
+  now=$(date +"%F-%H%M%S")
+  dir=$(mktemp -d buildkite-logs-"$now"-XXXX)
+  trap 'rm -rf "$dir" "$errFile"' EXIT
+  errFile=$(mktemp)
+  startTime=$(compute_start_time)
+
+  local stackError
+  if ! stackError=$(aws_cli cloudformation describe-stacks --stack-name "$stackName" 2>&1 >/dev/null); then
+    echo "Error: could not describe CloudFormation stack '$stackName'" 1>&2
+    echo "$stackError" 1>&2
+    exit 1
+  fi
+
+  if [[ -n "$instanceId" ]]; then
+    collect_instance
+  else
+    echo "No instance ID supplied, skipping per-instance logs"
+  fi
+
+  collect_lambdas
+  collect_asg
+
+  package
+}
+
+main "$@"

--- a/utils/log-collector
+++ b/utils/log-collector
@@ -218,7 +218,7 @@ collect_lambda() {
 
 collect_lambdas() {
   local functions fn
-  functions=$(find_lambdas | tr '\t' '\n' | sort -u)
+  functions=$(find_lambdas | tr '\t' '\n' | sort -u) || true
 
   if [[ -z "$functions" ]]; then
     record_error "No Lambda functions found in stack $stackName"

--- a/utils/log-collector
+++ b/utils/log-collector
@@ -119,6 +119,10 @@ last_error() {
   tr -s '[:space:]' ' ' <"$errFile" 2>/dev/null | sed 's/^ //; s/ $//' || true
 }
 
+missing_log_group() {
+  [[ "$1" == *ResourceNotFoundException* ]]
+}
+
 compute_start_time() {
   if date --version >/dev/null 2>&1; then
     date --date="${days} days ago" "+%s000"
@@ -130,7 +134,7 @@ compute_start_time() {
 collect_instance() {
   echo "Collecting logs for instance $instanceId..."
   local name safe file err
-  for name in buildkite-agent system lifecycled docker-daemon cloud-init cloud-init/output cfn-init elastic-stack auth; do
+  for name in buildkite-agent system lifecycled docker-daemon cloud-init cloud-init/output cfn-init elastic-stack auth EC2Launch/UserdataExecution; do
     safe="${name//\//-}"
     file="$dir/$safe-$instanceId.log"
     if ! aws_cli logs filter-log-events \
@@ -140,8 +144,12 @@ collect_instance() {
       --query "events[].[timestamp,message]" \
       --output "$outputFormat" >"$file" 2>"$errFile"; then
       err=$(last_error)
-      record_error "Failed to read /buildkite/$name for $instanceId: $err"
-      mark_failed "$safe-$instanceId.log" "Collection failed for /buildkite/$name: $err"
+      if missing_log_group "$err"; then
+        mark_empty "$safe-$instanceId.log" "Log group /buildkite/$name does not exist for $instanceId"
+      else
+        record_error "Failed to read /buildkite/$name for $instanceId: $err"
+        mark_failed "$safe-$instanceId.log" "Collection failed for /buildkite/$name: $err"
+      fi
       continue
     fi
     if is_empty "$file"; then
@@ -207,8 +215,12 @@ collect_lambda() {
     --query "events[].[timestamp,message]" \
     --output "$outputFormat" >"$file" 2>"$errFile"; then
     err=$(last_error)
-    record_error "Failed to read $logGroup for $fn: $err"
-    mark_failed "lambda-${safe}.log" "Collection failed for $logGroup: $err"
+    if missing_log_group "$err"; then
+      mark_empty "lambda-${safe}.log" "Log group $logGroup does not exist for $fn"
+    else
+      record_error "Failed to read $logGroup for $fn: $err"
+      mark_failed "lambda-${safe}.log" "Collection failed for $logGroup: $err"
+    fi
     return 0
   fi
   if is_empty "$file"; then


### PR DESCRIPTION
Now collects logs for instances, and lambdas. Extended options.

## Description

- Updates the log collector as it was fragile and required JQ, depending on hardcoded log group names. Also only collected 4 instance log groups, silently swallowed AWS errors and left temp files behind.
- This discovers all lambda functions associated with a stack and any nested stacks. It resolves each function's log group and then collects them.
- Can now optionally collect instance logs and all of their associated log groups.
- Allows for region now
- Allows for a number of days worth of logs to be collected

## Checklist

- [x] Tests pass locally
- [x] Added tests for new features/fixes
- [x] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
