### PR TITLE
Build goss from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ GO_VERSION ?= 1.26.1
 
 FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
 
+# goss is pinned to a commit (see versions.sh) until the upstream fix is
+# released. Read the pin from versions.sh.
+GOSS_VERSIONS_FILE = packer/linux/base/scripts/versions.sh
+GOSS_COMMIT = $(shell . $(GOSS_VERSIONS_FILE) && echo $$GOSS_COMMIT)
+GOSS_VERSION = $(shell . $(GOSS_VERSIONS_FILE) && echo $$GOSS_VERSION)
+
 AWS_REGION ?= us-east-1
 
 ARM64_INSTANCE_TYPE ?= m7g.xlarge
@@ -117,7 +123,7 @@ build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linux packer image
-packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 packer-base-linux-amd64.output
+packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 packer-base-linux-amd64.output
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -153,7 +159,7 @@ print-agent-versions:
 	@echo Windows: $(CURRENT_AGENT_VERSION_WINDOWS)
 
 # Build linuxarm64 packer image
-packer-linux-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 packer-base-linux-arm64.output
+packer-linux-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 packer-base-linux-arm64.output
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
@@ -304,6 +310,38 @@ build/fix-perms-linux-arm64: $(FIXPERMS_FILES)
 		--rm \
 		golang:$(GO_VERSION) \
 			go build -v -buildvcs=false -o "build/fix-perms-linux-arm64" ./internal/fixperms
+
+# Build goss in the golang container so no Go toolchain ends up in the AMI.
+# Same flags as goss's release-build.sh. Rebuilds when the pin changes.
+build/goss-linux-amd64: $(GOSS_VERSIONS_FILE)
+	mkdir -p build
+	docker run \
+		-e CGO_ENABLED=0 \
+		-e GOOS=linux \
+		-e GOARCH=amd64 \
+		-v "$(PWD)/build:/out" \
+		--rm \
+		golang:$(GO_VERSION) \
+			bash -c 'set -euo pipefail; \
+				git clone --quiet https://github.com/goss-org/goss /goss; \
+				git -C /goss checkout --quiet $(GOSS_COMMIT); \
+				cd /goss; \
+				go build -trimpath -ldflags "-X github.com/goss-org/goss/util.Version=$(GOSS_VERSION) -s -w" -o /out/goss-linux-amd64 ./cmd/goss'
+
+build/goss-linux-arm64: $(GOSS_VERSIONS_FILE)
+	mkdir -p build
+	docker run \
+		-e CGO_ENABLED=0 \
+		-e GOOS=linux \
+		-e GOARCH=arm64 \
+		-v "$(PWD)/build:/out" \
+		--rm \
+		golang:$(GO_VERSION) \
+			bash -c 'set -euo pipefail; \
+				git clone --quiet https://github.com/goss-org/goss /goss; \
+				git -C /goss checkout --quiet $(GOSS_COMMIT); \
+				cd /goss; \
+				go build -trimpath -ldflags "-X github.com/goss-org/goss/util.Version=$(GOSS_VERSION) -s -w" -o /out/goss-linux-arm64 ./cmd/goss'
 
 # -----------------------------------------
 # Cloudformation helpers

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -82,12 +82,8 @@ curl -sSL https://github.com/git-lfs/git-lfs/releases/download/v"${GIT_LFS_VERSI
 sudo git-lfs-"${GIT_LFS_VERSION}"/install.sh
 popd
 
-# See https://github.com/goss-org/goss/releases for release versions
-echo "Installing goss $GOSS_VERSION for system validation..."
-sudo curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss-linux-${ARCH}" -o /usr/local/bin/goss
-sudo chmod +rx /usr/local/bin/goss
-sudo curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/dgoss" -o /usr/local/bin/dgoss
-sudo chmod +rx /usr/local/bin/dgoss
+# goss is built from source and installed in the stack image (see
+# install-buildkite-utils.sh), because we pin it to an unreleased commit.
 
 echo "Adding authorized keys systemd units..."
 sudo cp /tmp/conf/ssh/systemd/* /etc/systemd/system

--- a/packer/linux/base/scripts/versions.sh
+++ b/packer/linux/base/scripts/versions.sh
@@ -16,7 +16,8 @@ export GIT_LFS_VERSION="3.7.1"
 # GOSS_VERSION derives its short hash from GOSS_COMMIT, so a Renovate digest
 # bump updates both. Bump the base version (v0.4.9) when goss next tags a release.
 export GOSS_COMMIT="c4634acb0ff00fff08438b2396deb72e6b2b9d83"
-export GOSS_VERSION="v0.4.9-dev-$(printf '%.7s' "$GOSS_COMMIT")"
+GOSS_VERSION="v0.4.9-dev-$(printf '%.7s' "$GOSS_COMMIT")"
+export GOSS_VERSION
 
 # Container Tools
 export DOCKER_COMPOSE_V2_VERSION="5.1.4"

--- a/packer/linux/base/scripts/versions.sh
+++ b/packer/linux/base/scripts/versions.sh
@@ -13,8 +13,10 @@ export GIT_LFS_VERSION="3.7.1"
 # because the dependency-bump fix (https://github.com/goss-org/goss/pull/1064)
 # for the Go CVEs is not in any release yet (latest is v0.4.9). Revert to a
 # release download once a version above v0.4.9 ships with the fix.
+# GOSS_VERSION derives its short hash from GOSS_COMMIT, so a Renovate digest
+# bump updates both. Bump the base version (v0.4.9) when goss next tags a release.
 export GOSS_COMMIT="c4634acb0ff00fff08438b2396deb72e6b2b9d83"
-export GOSS_VERSION="v0.4.9-dev-c4634ac"
+export GOSS_VERSION="v0.4.9-dev-$(printf '%.7s' "$GOSS_COMMIT")"
 
 # Container Tools
 export DOCKER_COMPOSE_V2_VERSION="5.1.4"

--- a/packer/linux/base/scripts/versions.sh
+++ b/packer/linux/base/scripts/versions.sh
@@ -8,7 +8,13 @@ export SESSION_MANAGER_PLUGIN_VERSION="1.2.814.0"
 
 # Development Tools
 export GIT_LFS_VERSION="3.7.1"
-export GOSS_VERSION="v0.4.9"
+
+# goss is built from source (build/goss-* in the Makefile), pinned to a commit
+# because the dependency-bump fix (https://github.com/goss-org/goss/pull/1064)
+# for the Go CVEs is not in any release yet (latest is v0.4.9). Revert to a
+# release download once a version above v0.4.9 ships with the fix.
+export GOSS_COMMIT="c4634acb0ff00fff08438b2396deb72e6b2b9d83"
+export GOSS_VERSION="v0.4.9-dev-c4634ac"
 
 # Container Tools
 export DOCKER_COMPOSE_V2_VERSION="5.1.4"

--- a/packer/linux/stack/scripts/install-buildkite-utils.sh
+++ b/packer/linux/stack/scripts/install-buildkite-utils.sh
@@ -19,6 +19,15 @@ echo "Installing fix-buildkite-agent-builds-permissions..."
 sudo chmod +x "/tmp/build/fix-perms-linux-${ARCH}"
 sudo mv "/tmp/build/fix-perms-linux-${ARCH}" /usr/bin/fix-buildkite-agent-builds-permissions
 
+# goss is built by the build/goss-* Makefile targets and uploaded via the
+# build/ provisioner; dgoss is a shell script fetched from the same commit.
+echo "Installing goss ${GOSS_VERSION} (built from ${GOSS_COMMIT}) for system validation..."
+sudo chmod +x "/tmp/build/goss-linux-${ARCH}"
+sudo mv "/tmp/build/goss-linux-${ARCH}" /usr/local/bin/goss
+sudo curl -Lsf -o /usr/local/bin/dgoss \
+  "https://raw.githubusercontent.com/goss-org/goss/${GOSS_COMMIT}/extras/dgoss/dgoss"
+sudo chmod +rx /usr/local/bin/dgoss
+
 echo "Downloading s3-secrets-helper ${S3_SECRETS_HELPER_VERSION}..."
 sudo curl -Lsf -o /usr/local/bin/s3secrets-helper \
   "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-linux-${ARCH}"

--- a/renovate.json
+++ b/renovate.json
@@ -80,11 +80,13 @@
         "^packer/linux/base/scripts/versions\\.sh$"
       ],
       "matchStrings": [
-        "export GOSS_VERSION=\"v(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+        "export GOSS_COMMIT=\"(?<currentDigest>[a-f0-9]+)\""
       ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "goss-org/goss",
-      "versioningTemplate": "semver"
+      "currentValueTemplate": "master",
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "goss",
+      "packageNameTemplate": "https://github.com/goss-org/goss",
+      "versioningTemplate": "git"
     },
     {
       "customType": "regex",
@@ -199,7 +201,7 @@
       "matchPackageNames": [
         "git-lfs/git-lfs",
         "git-for-windows/git",
-        "goss-org/goss",
+        "goss",
         "docker/compose",
         "docker/buildx",
         "buildkite/lifecycled",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->

This PR migrates from upstream provided binaries over to ones built from source.
Reason: Go patches landed in https://github.com/goss-org/goss/pull/1064, but there was no release yet. Once a new release lands, this PR can be safely reverted.

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
