### PR TITLE
generate-changelog: fix changelog for multi version bump

### DIFF
--- a/.buildkite/scripts/generate-changelog.sh
+++ b/.buildkite/scripts/generate-changelog.sh
@@ -20,12 +20,40 @@ CHANGELOG_BODY=$(ghch --format=markdown --from="$PREVIOUS_TAG" --next-version="$
 AGENT_INSTALL_SCRIPT_LINUX="packer/linux/stack/scripts/install-buildkite-agent.sh"
 AGENT_INSTALL_SCRIPT_WINDOWS="packer/windows/stack/scripts/install-buildkite-agent.ps1"
 
+extract_agent_version() {
+  # Reads the pinned agent version from a given git ref's Linux install script.
+  git show "$1:${AGENT_INSTALL_SCRIPT_LINUX}" 2>/dev/null | grep "AGENT_VERSION=" | cut -d'=' -f2 | tr -d '"'
+}
+
 if git diff --name-only "$PREVIOUS_TAG..HEAD" -- "$AGENT_INSTALL_SCRIPT_LINUX" "$AGENT_INSTALL_SCRIPT_WINDOWS" | grep -q "."; then
   echo "--- Buildkite Agent version has changed. Fetching agent release notes."
-  AGENT_VERSION=$(grep "AGENT_VERSION=" "$AGENT_INSTALL_SCRIPT_LINUX" | cut -d'=' -f2 | tr -d '"')
-  AGENT_RELEASE_NOTES=$(gh release view "v${AGENT_VERSION}" --repo "buildkite/agent" --json body -q .body)
-  AGENT_CHANGELOG_DETAILS="<details>\n  <summary><h3>Agent Changelog</h3></summary>\n\n${AGENT_RELEASE_NOTES}\n</details>"
-  CHANGELOG_BODY+="\n\n${AGENT_CHANGELOG_DETAILS}"
+  PREVIOUS_AGENT_VERSION=$(extract_agent_version "$PREVIOUS_TAG")
+  CURRENT_AGENT_VERSION=$(extract_agent_version HEAD)
+
+  # The stack can jump across multiple agent releases between two stack releases
+  # (e.g. v3.128.0 -> v3.129.0 -> v3.130.0). Enumerate every agent release in the
+  # range (PREVIOUS_AGENT_VERSION, CURRENT_AGENT_VERSION] so no hop is skipped.
+  AGENT_VERSIONS=$(gh release list --repo "buildkite/agent" --limit 200 --json tagName -q '.[].tagName' \
+    | sed 's/^v//' \
+    | sort -V \
+    | awk -v prev="$PREVIOUS_AGENT_VERSION" -v cur="$CURRENT_AGENT_VERSION" '
+        $0 == prev { seen = 1; next }
+        seen { print }
+        $0 == cur { exit }')
+
+  # Fall back to just the current version if enumeration produced nothing.
+  if [[ -z "$AGENT_VERSIONS" ]]; then
+    AGENT_VERSIONS="$CURRENT_AGENT_VERSION"
+  fi
+
+  # Emit newest hop first to match chronological changelog order in reverse
+  AGENT_CHANGELOG_SECTION=""
+  for AGENT_VERSION in $(echo "$AGENT_VERSIONS" | sort -rV); do
+    echo "--- Fetching agent release notes for v${AGENT_VERSION}"
+    AGENT_RELEASE_NOTES=$(gh release view "v${AGENT_VERSION}" --repo "buildkite/agent" --json body -q .body)
+    AGENT_CHANGELOG_SECTION+="<details>\n  <summary><h3>Agent Changelog (v${AGENT_VERSION})</h3></summary>\n\n${AGENT_RELEASE_NOTES}\n</details>\n"
+  done
+  CHANGELOG_BODY+="\n\n${AGENT_CHANGELOG_SECTION}"
 fi
 
 # 4. Update CHANGELOG.md, preserving the header


### PR DESCRIPTION
## Description

When generating changelog for a release that jumps from agent, e.g. v3.128.0 to v3.130.0, the script would only include changes from the newest release, rather than all the releases in-between. This change iterates over versions and appends them to the changelog entry for given release.

<!-- Please include a summary of the change and the issue it fixes. -->

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
