### PR TITLE
fix: harden instance storage mounting and support NVME instance storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,11 +393,13 @@ ifdef SERVICE_ROLE
 endif
 
 template_arg=--template-body file://$(PWD)/build/aws-stack.yml
+stack_deps=build/aws-stack.yml
 ifdef TEMPLATE_URL
 	template_arg=--template-url $(TEMPLATE_URL)
+	stack_deps=
 endif
 
-create-stack: build/aws-stack.yml env-STACK_NAME
+create-stack: $(stack_deps) env-STACK_NAME
 	aws cloudformation create-stack \
 		--output text \
 		--stack-name $(STACK_NAME) \
@@ -406,7 +408,7 @@ create-stack: build/aws-stack.yml env-STACK_NAME
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
 		--parameters file://$(PWD)/config.json $(role_arn)
 
-update-stack: build/aws-stack.yml env-STACK_NAME
+update-stack: $(stack_deps) env-STACK_NAME
 	aws cloudformation update-stack \
 		--output text \
 		--stack-name $(STACK_NAME) \

--- a/Makefile
+++ b/Makefile
@@ -389,7 +389,12 @@ config.json:
 
 SERVICE_ROLE=
 ifdef SERVICE_ROLE
-	role_arn="--role-arn=$(SERVICE_ROLE)"
+	role_arn=--role-arn=$(SERVICE_ROLE)
+endif
+
+template_arg=--template-body file://$(PWD)/build/aws-stack.yml
+ifdef TEMPLATE_URL
+	template_arg=--template-url $(TEMPLATE_URL)
 endif
 
 create-stack: build/aws-stack.yml env-STACK_NAME
@@ -397,19 +402,17 @@ create-stack: build/aws-stack.yml env-STACK_NAME
 		--output text \
 		--stack-name $(STACK_NAME) \
 		--disable-rollback \
-		--template-body "file://$(PWD)/build/aws-stack.yml" \
+		$(template_arg) \
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-		--parameters "$$(cat config.json)" \
-		"$(role_arn)"
+		--parameters file://$(PWD)/config.json $(role_arn)
 
 update-stack: build/aws-stack.yml env-STACK_NAME
 	aws cloudformation update-stack \
 		--output text \
 		--stack-name $(STACK_NAME) \
-		--template-body "file://$(PWD)/build/aws-stack.yml" \
+		$(template_arg) \
 		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-		--parameters "$$(cat config.json)" \
-		"$(role_arn)"
+		--parameters file://$(PWD)/config.json $(role_arn)
 
 # -----------------------------------------
 # Other

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ To test a Linux instance type with local NVMe instance storage, such as `c8id.xl
 ]
 ```
 
-When enabled on Linux, available NVMe instance storage is mounted at `/mnt/ephemeral`, and the Buildkite builds path is bind-mounted from `/mnt/ephemeral/builds` to `/var/lib/buildkite-agent/builds`.
+When enabled on Linux, available NVMe instance storage is mounted at `/mnt/ephemeral`, and the Buildkite builds path is bind-mounted from `/mnt/ephemeral/builds` to `/var/lib/buildkite-agent/builds`. When git-mirrors are also enabled, the git-mirrors path is bind-mounted from `/mnt/ephemeral/git-mirrors` to `/var/lib/buildkite-agent/git-mirrors`.
 
 **Security Note:** Making AMIs public (`AMI_PUBLIC=true`) can expose any secrets accidentally baked into the image. The default private setting helps prevent accidental exposure of sensitive information.
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ make packer-base-linux-amd64.output packer-linux-amd64.output \
      packer-base-linux-arm64.output packer-linux-arm64.output
 ```
 
+To test a Linux instance type with local NVMe instance storage, such as `c8id.xlarge`, set both `InstanceTypes` and `EnableInstanceStorage` in `config.json`:
+
+```json
+[
+  {
+    "ParameterKey": "BuildkiteAgentToken",
+    "ParameterValue": "<insert-your-token>"
+  },
+  {
+    "ParameterKey": "InstanceTypes",
+    "ParameterValue": "c8id.xlarge"
+  },
+  {
+    "ParameterKey": "EnableInstanceStorage",
+    "ParameterValue": "true"
+  }
+]
+```
+
+When enabled on Linux, available NVMe instance storage is mounted at `/mnt/ephemeral`, and the Buildkite builds path is bind-mounted from `/mnt/ephemeral/builds` to `/var/lib/buildkite-agent/builds`.
+
 **Security Note:** Making AMIs public (`AMI_PUBLIC=true`) can expose any secrets accidentally baked into the image. The default private setting helps prevent accidental exposure of sensitive information.
 
 ## Support Policy

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -305,7 +305,7 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
     echo Mounting git-mirrors to instance storage...
 
     EPHEMERAL_GIT_MIRRORS_PATH="/mnt/ephemeral/git-mirrors"
-    echo "Creating ephemeral git-mirrors direcotry at $EPHEMERAL_GIT_MIRRORS_PATH"
+    echo "Creating ephemeral git-mirrors directory at $EPHEMERAL_GIT_MIRRORS_PATH"
     mkdir -p "${EPHEMERAL_GIT_MIRRORS_PATH}"
 
     if findmnt --mountpoint "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}" >/dev/null; then

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -308,11 +308,19 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
     echo "Creating ephemeral git-mirrors direcotry at $EPHEMERAL_GIT_MIRRORS_PATH"
     mkdir -p "${EPHEMERAL_GIT_MIRRORS_PATH}"
 
-    echo Bind mounting ephemeral git-mirror directory to git-mirrors path...
-    mount -o bind "${EPHEMERAL_GIT_MIRRORS_PATH}" "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
+    if findmnt --mountpoint "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}" >/dev/null; then
+      echo "$BUILDKITE_AGENT_GIT_MIRRORS_PATH is already mounted. Skipping bind mount."
+    else
+      echo Bind mounting ephemeral git-mirror directory to git-mirrors path...
+      mount -o bind "${EPHEMERAL_GIT_MIRRORS_PATH}" "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}"
+    fi
 
-    echo Writing bind mount to fstab...
-    echo "${EPHEMERAL_GIT_MIRRORS_PATH} ${BUILDKITE_AGENT_GIT_MIRRORS_PATH} none defaults,bind 0 0" >>/etc/fstab
+    if grep -q -E "[[:space:]]${BUILDKITE_AGENT_GIT_MIRRORS_PATH}[[:space:]]" /etc/fstab; then
+      echo "$BUILDKITE_AGENT_GIT_MIRRORS_PATH already exists in /etc/fstab. Skipping fstab update."
+    else
+      echo Writing bind mount to fstab...
+      echo "${EPHEMERAL_GIT_MIRRORS_PATH} ${BUILDKITE_AGENT_GIT_MIRRORS_PATH} none defaults,bind 0 0" >>/etc/fstab
+    fi
 
     echo fstab is now:
     cat /etc/fstab
@@ -336,8 +344,17 @@ if [[ "${BUILDKITE_ENABLE_INSTANCE_STORAGE:-false}" == "true" ]]; then
   EPHEMERAL_BUILD_PATH="/mnt/ephemeral/builds"
   mkdir -p "${EPHEMERAL_BUILD_PATH}"
 
-  mount -o bind "${EPHEMERAL_BUILD_PATH}" "${BUILDKITE_AGENT_BUILD_PATH}"
-  echo "${EPHEMERAL_BUILD_PATH} ${BUILDKITE_AGENT_BUILD_PATH} none defaults,bind 0 0" >>/etc/fstab
+  if findmnt --mountpoint "${BUILDKITE_AGENT_BUILD_PATH}" >/dev/null; then
+    echo "$BUILDKITE_AGENT_BUILD_PATH is already mounted. Skipping bind mount."
+  else
+    mount -o bind "${EPHEMERAL_BUILD_PATH}" "${BUILDKITE_AGENT_BUILD_PATH}"
+  fi
+
+  if grep -q -E "[[:space:]]${BUILDKITE_AGENT_BUILD_PATH}[[:space:]]" /etc/fstab; then
+    echo "$BUILDKITE_AGENT_BUILD_PATH already exists in /etc/fstab. Skipping fstab update."
+  else
+    echo "${EPHEMERAL_BUILD_PATH} ${BUILDKITE_AGENT_BUILD_PATH} none defaults,bind 0 0" >>/etc/fstab
+  fi
 
   echo fstab is now:
   cat /etc/fstab

--- a/packer/linux/stack/conf/bin/bk-mount-instance-storage.sh
+++ b/packer/linux/stack/conf/bin/bk-mount-instance-storage.sh
@@ -55,6 +55,17 @@ fi
 
 echo Mounting instance storage...
 
+devicemount=/mnt/ephemeral
+fs_type="ext4"
+mount_options="defaults,noatime"
+
+mkdir -p "$devicemount"
+
+if findmnt --mountpoint "$devicemount" >/dev/null; then
+  echo "$devicemount is already mounted. Skipping instance storage setup."
+  exit 0
+fi
+
 #shellcheck disable=SC2207
 devices=($(nvme list | grep "Amazon EC2 NVMe Instance Storage" | cut -f1 -d' ' || true))
 if [[ -z "${devices[*]}" ]]; then
@@ -96,29 +107,36 @@ else
   exit 1
 fi
 
-echo "Formatting $logicalname as ext4..."
-# Make an ext4 file system, [-F]orce creation, don’t TRIM at fs creation time (-E nodiscard)
-mkfs.ext4 -F -E nodiscard "$logicalname" >/dev/null
+existing_fs_type="$(blkid -o value -s TYPE "$logicalname" || true)"
+if [[ "$existing_fs_type" == "$fs_type" ]]; then
+  echo "$logicalname is already formatted as $fs_type. Skipping format."
+elif [[ -n "$existing_fs_type" ]]; then
+  echo "$logicalname already has filesystem type $existing_fs_type, expected $fs_type."
+  echo "Refusing to format an existing filesystem."
+  exit 1
+else
+  echo "Formatting $logicalname as ext4..."
+  # Make an ext4 file system, [-F]orce creation, don’t TRIM at fs creation time (-E nodiscard)
+  mkfs.ext4 -F -E nodiscard "$logicalname" >/dev/null
+fi
 
-devicemount=/mnt/ephemeral
 echo "Mounting $logicalname to $devicemount..."
-fs_type="ext4"
-mount_options="defaults,noatime"
 
-mkdir -p "$devicemount"
 mount -t "$fs_type" -o "$mount_options" "$logicalname" "$devicemount"
 
 if [[ ! -f /etc/fstab.backup ]]; then
   echo Backing up /etc/fstab to /etc/fstab.backup...
   cp -P /etc/fstab /etc/fstab.backup
+fi
 
-  fstab_line="$logicalname $devicemount    ${fs_type}  ${mount_options}  0 0"
+fstab_line="$logicalname $devicemount    ${fs_type}  ${mount_options}  0 0"
+if grep -q -E "[[:space:]]${devicemount}[[:space:]]" /etc/fstab; then
+  echo "$devicemount already exists in /etc/fstab. Not modifying /etc/fstab:"
+  cat /etc/fstab
+else
   echo "Appending $fstab_line to /etc/fstab..."
   echo "$fstab_line" >>/etc/fstab
 
-  echo Appened to /etc/fstab:
-  cat /etc/fstab
-else
-  echo /etc/fstab.backup already exists. Not modifying /etc/fstab:
+  echo Appended to /etc/fstab:
   cat /etc/fstab
 fi


### PR DESCRIPTION
## Description

Enables reliable use of EC2 instance-store NVMe storage, such as c8id.xlarge, for Buildkite build workspaces.

- Harden Linux NVMe instance-storage mounting for reruns/reboots.
- Bind Buildkite builds and git mirrors to instance storage idempotently.
- Update local stack helpers to support S3-backed CloudFormation templates.
- Document how to test `c8id.xlarge` with `EnableInstanceStorage=true`.

## Details

This keeps the existing public stack interface unchanged:

- `InstanceTypes=c8id.xlarge`
- `EnableInstanceStorage=true`

The instance storage setup now:

- skips setup when `/mnt/ephemeral` is already mounted
- avoids reformatting an existing `ext4` filesystem
- refuses to format unexpected existing filesystems
- avoids duplicate `/etc/fstab` entries
- avoids repeated bind mounts for `/var/lib/buildkite-agent/builds` and git mirrors

The Makefile deploy helpers now support:

```bash
make create-stack STACK_NAME=... TEMPLATE_URL=...
make update-stack STACK_NAME=... TEMPLATE_URL=...
```

This avoids CloudFormation’s 51,200 byte inline `--template-body` limit for the generated stack template.

## Checklist

- [x] Tests pass locally
- [x] Added tests for new features/fixes
- [x] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
