### PR TITLE
Fix CIS umask compatibility: chown cfn-env and env files

### DIFF
--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -436,6 +436,7 @@ if [[ "${BUILDKITE_ENV_FILE_URL}" != "" ]]; then
   echo "Fetching env file from ${BUILDKITE_ENV_FILE_URL}..."
   /usr/local/bin/bk-fetch.sh "${BUILDKITE_ENV_FILE_URL}" /var/lib/buildkite-agent/env
   chown buildkite-agent: /var/lib/buildkite-agent/env
+  chmod 0640 /var/lib/buildkite-agent/env
 else
   echo No env file to fetch.
 fi

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -241,6 +241,7 @@ EOF
 # We warned about not putting secrets in this file
 echo Wrote to /var/lib/buildkite-agent/cfn-env:
 cat /var/lib/buildkite-agent/cfn-env
+chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
 echo
 
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]]; then
@@ -433,6 +434,7 @@ fi
 if [[ "${BUILDKITE_ENV_FILE_URL}" != "" ]]; then
   echo "Fetching env file from ${BUILDKITE_ENV_FILE_URL}..."
   /usr/local/bin/bk-fetch.sh "${BUILDKITE_ENV_FILE_URL}" /var/lib/buildkite-agent/env
+  chown buildkite-agent: /var/lib/buildkite-agent/env
 else
   echo No env file to fetch.
 fi

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -241,7 +241,8 @@ EOF
 # We warned about not putting secrets in this file
 echo Wrote to /var/lib/buildkite-agent/cfn-env:
 cat /var/lib/buildkite-agent/cfn-env
-chown buildkite-agent: /var/lib/buildkite-agent/cfn-env
+chown root:buildkite-agent /var/lib/buildkite-agent/cfn-env
+chmod 0640 /var/lib/buildkite-agent/cfn-env
 echo
 
 if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]]; then


### PR DESCRIPTION
When CIS Level 1 hardening sets umask to 027 (CIS Rule 5.5.5), files written by root during cfn-init become unreadable by the buildkite-agent user. Add chown calls for cfn-env and env files, consistent with the existing pattern for buildkite-agent.cfg.

Fixes compatibility with CIS-hardened AMIs where restrictive umask causes agent startup failures.

Reference: SUP-7508