### PR TITLE
CIS hardened build

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -417,6 +417,7 @@ steps:
     timeout_in_minutes: 60
     env:
       AMI_PUBLIC: false
+    retry: { automatic: { limit: 3 } }
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     if: build.source != "schedule"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -142,6 +142,10 @@ steps:
             - organization_id
             - pipeline_slug
 
+  # ============================================================
+  # Windows AMD64
+  # ============================================================
+
   - id: "packer-base-windows-amd64"
     name: ":packer: :windows: (base)"
     command: ".buildkite/steps/packer.sh windows amd64 base"
@@ -220,6 +224,10 @@ steps:
       - "test-windows-amd64"
     plugins:
       - *aws_role_plugin
+
+  # ============================================================
+  # Linux AMD64
+  # ============================================================
 
   - id: "packer-base-linux-amd64"
     name: ":packer: :linux: AMD64 (base)"
@@ -301,6 +309,10 @@ steps:
     plugins:
       - *aws_role_plugin
 
+  # ============================================================
+  # Linux ARM64
+  # ============================================================
+
   - id: "packer-base-linux-arm64"
     name: ":packer: :linux: ARM64 (base)"
     command: ".buildkite/steps/packer.sh linux arm64 base"
@@ -380,6 +392,94 @@ steps:
     plugins:
       - *aws_role_plugin
 
+  # ============================================================
+  # Linux AMD64 CIS-hardened variant
+  # ============================================================
+
+  - id: "packer-base-linux-amd64-cis"
+    name: ":packer: :linux: AMD64 CIS (base)"
+    command: ".buildkite/steps/packer.sh linux amd64 base-cis"
+    timeout_in_minutes: 40
+    env:
+      AMI_PUBLIC: false
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if_changed: *if_changed_base_linux
+    depends_on:
+      - "linting"
+      - "fixperms-tests"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "packer-linux-amd64-cis"
+    name: ":packer: :linux: AMD64 CIS"
+    command: .buildkite/steps/packer.sh linux amd64 stack-cis
+    timeout_in_minutes: 60
+    env:
+      AMI_PUBLIC: false
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_stack_linux
+    depends_on:
+      - "packer-base-linux-amd64-cis"
+      - "linting"
+      - "fixperms-tests"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "launch-linux-amd64-cis"
+    name: ":cloudformation: :linux: AMD64 CIS Launch"
+    command:
+      - .buildkite/steps/launch.sh linux amd64 cis
+    retry: { automatic: { limit: 3 } }
+    env:
+      ROOT_VOLUME_SIZE: "15"
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    artifact_paths: "build/aws-stack.yml"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "packer-linux-amd64-cis"
+      - "deploy-service-role-stack"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "test-linux-amd64-cis"
+    name: ":cloudformation: :linux: AMD64 CIS Test"
+    command:
+      - aws --version
+      - jq --version
+      - git --version
+      - sudo goss validate --format documentation
+    timeout_in_minutes: 5
+    retry: { automatic: { limit: 3 } }
+    agents:
+      stack: "buildkite-aws-stack-test-linux-amd64-cis-${BUILDKITE_BUILD_NUMBER}"
+      queue: "testqueue-linux-amd64-cis-${BUILDKITE_BUILD_NUMBER}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "launch-linux-amd64-cis"
+
+  - id: "delete-linux-amd64-cis"
+    name: ":cloudformation: :linux: AMD64 CIS Delete"
+    command: .buildkite/steps/delete.sh linux amd64 cis
+    allow_dependency_failure: true
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "test-linux-amd64-cis"
+    plugins:
+      - *aws_role_plugin
+
+  # ============================================================
+  # Post-test: service role cleanup, copy, publish, cleanup
+  # ============================================================
+
   - id: "delete-service-role-stack"
     name: ":aws-iam: :cloudformation: Delete"
     command: .buildkite/steps/delete-service-role-stack.sh
@@ -391,6 +491,7 @@ steps:
       - "delete-windows-amd64"
       - "delete-linux-amd64"
       - "delete-linux-arm64"
+      - "delete-linux-amd64-cis"
     plugins:
       - *aws_role_plugin
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -431,6 +431,7 @@ steps:
   - id: "launch-linux-amd64-cis"
     name: ":cloudformation: :linux: AMD64 CIS Launch"
     command:
+      - .buildkite/steps/ensure_ami_metadata.py linux amd64 cis
       - .buildkite/steps/launch.sh linux amd64 cis
     retry: { automatic: { limit: 3 } }
     env:
@@ -439,7 +440,7 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
     if: build.source != "schedule"
-    if_changed: *if_changed_stack_linux
+    if_changed: *if_changed_launch_test_delete_linux
     depends_on:
       - "packer-linux-amd64-cis"
       - "deploy-service-role-stack"
@@ -459,7 +460,7 @@ steps:
       stack: "buildkite-aws-stack-test-linux-amd64-cis-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-amd64-cis-${BUILDKITE_BUILD_NUMBER}"
     if: build.source != "schedule"
-    if_changed: *if_changed_stack_linux
+    if_changed: *if_changed_launch_test_delete_linux
     depends_on:
       - "launch-linux-amd64-cis"
 
@@ -470,7 +471,7 @@ steps:
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     if: build.source != "schedule"
-    if_changed: *if_changed_stack_linux
+    if_changed: *if_changed_launch_test_delete_linux
     depends_on:
       - "test-linux-amd64-cis"
     plugins:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -439,7 +439,7 @@ steps:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
     if: build.source != "schedule"
-    if_changed: *if_changed_launch_test_delete_linux
+    if_changed: *if_changed_stack_linux
     depends_on:
       - "packer-linux-amd64-cis"
       - "deploy-service-role-stack"
@@ -459,7 +459,7 @@ steps:
       stack: "buildkite-aws-stack-test-linux-amd64-cis-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-linux-amd64-cis-${BUILDKITE_BUILD_NUMBER}"
     if: build.source != "schedule"
-    if_changed: *if_changed_launch_test_delete_linux
+    if_changed: *if_changed_stack_linux
     depends_on:
       - "launch-linux-amd64-cis"
 
@@ -470,7 +470,7 @@ steps:
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     if: build.source != "schedule"
-    if_changed: *if_changed_launch_test_delete_linux
+    if_changed: *if_changed_stack_linux
     depends_on:
       - "test-linux-amd64-cis"
     plugins:

--- a/.buildkite/steps/cleanup.sh
+++ b/.buildkite/steps/cleanup.sh
@@ -51,7 +51,7 @@ aws cloudformation describe-stacks \
   --output text \
   --query "$(printf 'Stacks[?CreationTime<`%s`].[StackName]' "$cutoff_date")" \
   | xargs -n1 \
-  | grep -E 'buildkite-aws-stack-test-(linux|windows)-(amd64|arm64)-[[:digit:]]+' \
+  | grep -E 'buildkite-aws-stack-test-(linux|windows)-(amd64|arm64)-([[:alpha:]]+-)?[[:digit:]]+' \
   | xargs -n1 -t -I% aws cloudformation delete-stack --stack-name "%"
 
 echo "--- Deleting old cloudformation stacks for test stack service roles"

--- a/.buildkite/steps/delete.sh
+++ b/.buildkite/steps/delete.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 
 os="${1:-linux}"
 arch="${2:-amd64}"
-stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
+variant="${3:-}"
+if [[ -n "$variant" ]]; then
+  stack_name="buildkite-aws-stack-test-${os}-${arch}-${variant}-${BUILDKITE_BUILD_NUMBER}"
+else
+  stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
+fi
 
 secrets_bucket=$(aws cloudformation describe-stacks \
   --stack-name "${stack_name}" \

--- a/.buildkite/steps/ensure_ami_metadata.py
+++ b/.buildkite/steps/ensure_ami_metadata.py
@@ -3,8 +3,15 @@
 Ensure AMI metadata is set for Stack AMI builds.
 
 This script checks if the packer build step set AMI metadata. If not,
-it fetches the AMI ID from the main branch CloudFormation template,
-which happens when the build was skipped due to if_changed conditions.
+it fetches the AMI ID from a fallback source. For standard builds, the
+fallback is the main branch CloudFormation template on S3. For CIS builds,
+the fallback is the latest CIS stack AMI output file on S3 (since CIS AMIs
+are private and not published in the CloudFormation template).
+
+This allows launch/test/delete steps to use a broader if_changed scope
+than the packer build step: when only launch scripts or templates change,
+the packer step is skipped but the launch/test/delete chain still runs
+against the most recently built AMI.
 """
 
 import os
@@ -97,15 +104,82 @@ def fetch_ami_from_template(os_type: str, arch: str, region: str) -> str:
     )
 
 
-def ensure_ami_metadata(os_type: str, arch: str) -> None:
+def fetch_ami_from_s3(os_type: str, arch: str, region: str, variant: str) -> str:
     """
-    Ensure AMI metadata is set, fetching from template if necessary.
+    Fetch AMI ID from the latest packer output file on S3.
+
+    Used for variants (like CIS) that are not published in the
+    CloudFormation template.
 
     Args:
         os_type: Operating system (linux or windows)
         arch: Architecture (amd64 or arm64)
+        region: AWS region
+        variant: Build variant (e.g. "cis")
+
+    Returns:
+        AMI ID string
+
+    Raises:
+        RuntimeError: If AMI cannot be found
     """
-    metadata_key = f"{os_type}_{arch}_image_id"
+    bucket = os.environ.get("BUILDKITE_AWS_STACK_BUCKET")
+    if not bucket:
+        raise RuntimeError("BUILDKITE_AWS_STACK_BUCKET environment variable not set")
+
+    s3_key = f"packer-{os_type}-{arch}-{variant}-latest.output"
+    s3_path = f"s3://{bucket}/{s3_key}"
+    local_path = f"/tmp/{s3_key}"
+
+    print(f"--- Fetching AMI ID from S3 for {os_type}/{arch}/{variant}")
+
+    try:
+        subprocess.run(
+            ["aws", "s3", "cp", s3_path, local_path],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"Failed to download {s3_path}: {e.stderr}. "
+            f"Has a {variant} build completed on main branch?"
+        ) from e
+
+    try:
+        with open(local_path) as f:
+            content = f.read()
+    finally:
+        os.remove(local_path)
+
+    pattern = rf"{re.escape(region)}: (ami-[a-z0-9]+)"
+    match = re.search(pattern, content)
+    if match:
+        ami_id = match.group(1)
+        print(f"Found AMI ID: {ami_id}")
+        return ami_id
+
+    raise RuntimeError(
+        f"Could not find AMI ID for region {region} in {s3_key}"
+    )
+
+
+def ensure_ami_metadata(os_type: str, arch: str, variant: Optional[str] = None) -> None:
+    """
+    Ensure AMI metadata is set, fetching from a fallback if necessary.
+
+    For standard builds, falls back to the published CloudFormation template.
+    For variant builds (e.g. CIS), falls back to the latest S3 output file.
+
+    Args:
+        os_type: Operating system (linux or windows)
+        arch: Architecture (amd64 or arm64)
+        variant: Optional build variant (e.g. "cis")
+    """
+    if variant:
+        metadata_key = f"{os_type}_{arch}_{variant}_image_id"
+    else:
+        metadata_key = f"{os_type}_{arch}_image_id"
 
     existing_ami = get_metadata(metadata_key)
     if existing_ami:
@@ -116,8 +190,12 @@ def ensure_ami_metadata(os_type: str, arch: str) -> None:
     if not region:
         raise RuntimeError("AWS_REGION environment variable not set")
 
-    print("AMI metadata not found, fetching from main branch template...")
-    ami_id = fetch_ami_from_template(os_type, arch, region)
+    print("AMI metadata not found, fetching from fallback source...")
+
+    if variant:
+        ami_id = fetch_ami_from_s3(os_type, arch, region, variant)
+    else:
+        ami_id = fetch_ami_from_template(os_type, arch, region)
 
     set_metadata(metadata_key, ami_id)
     print(f"Set AMI metadata: {metadata_key}={ami_id}")
@@ -125,14 +203,16 @@ def ensure_ami_metadata(os_type: str, arch: str) -> None:
 
 def main() -> int:
     """Main entry point."""
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <os> <arch>", file=sys.stderr)
-        print("  os:   linux or windows", file=sys.stderr)
-        print("  arch: amd64 or arm64", file=sys.stderr)
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print(f"Usage: {sys.argv[0]} <os> <arch> [variant]", file=sys.stderr)
+        print("  os:      linux or windows", file=sys.stderr)
+        print("  arch:    amd64 or arm64", file=sys.stderr)
+        print("  variant: optional build variant (e.g. cis)", file=sys.stderr)
         return 1
 
     os_type = sys.argv[1]
     arch = sys.argv[2]
+    variant = sys.argv[3] if len(sys.argv) == 4 else None
 
     if os_type not in ("linux", "windows"):
         print(
@@ -148,7 +228,7 @@ def main() -> int:
         return 1
 
     try:
-        ensure_ami_metadata(os_type, arch)
+        ensure_ami_metadata(os_type, arch, variant)
         return 0
     except Exception as e:
         print(f"ERROR: {e}", file=sys.stderr)

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -3,8 +3,14 @@ set -euo pipefail
 
 os="${1:-linux}"
 arch="${2:-amd64}"
-stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
-stack_queue_name="testqueue-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
+variant="${3:-}"
+if [[ -n "$variant" ]]; then
+  stack_name="buildkite-aws-stack-test-${os}-${arch}-${variant}-${BUILDKITE_BUILD_NUMBER}"
+  stack_queue_name="testqueue-${os}-${arch}-${variant}-${BUILDKITE_BUILD_NUMBER}"
+else
+  stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
+  stack_queue_name="testqueue-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
+fi
 
 # download parfait binary
 wget -N https://github.com/lox/parfait/releases/download/v1.1.3/parfait_linux_amd64
@@ -16,14 +22,18 @@ subnets=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$vpc_id" --quer
 subnet_ids=$(awk '{print $1}' <<<"$subnets" | tr ' ' ',' | tr '\n' ',' | sed 's/,$//')
 az_ids=$(awk '{print $2}' <<<"$subnets" | tr ' ' ',' | tr '\n' ',' | sed 's/,$//')
 
-image_id=$(buildkite-agent meta-data get "${os}_${arch}_image_id")
-echo "Using AMI $image_id for $os/$arch"
+if [[ -n "$variant" ]]; then
+  image_id=$(buildkite-agent meta-data get "${os}_${arch}_${variant}_image_id")
+else
+  image_id=$(buildkite-agent meta-data get "${os}_${arch}_image_id")
+fi
+echo "Using AMI $image_id for $os/$arch${variant:+ ($variant)}"
 
 service_role="$(buildkite-agent meta-data get service-role-arn)"
 echo "Using service role ${service_role}"
 
 instance_type="t3.small"
-instance_disk="10"
+instance_disk="${ROOT_VOLUME_SIZE:-10}"
 
 if [[ "$os" == "windows" ]]; then
   instance_type="m5.large"
@@ -127,7 +137,7 @@ make "mappings-for-${os}-${arch}-image" build/aws-stack.yml "IMAGE_ID=$image_id"
 
 echo "--- Uploading test template to S3"
 s3_bucket="buildkite-agent-elastic-stack-test-templates"
-s3_key="templates/build-${BUILDKITE_BUILD_NUMBER}/${os}-${arch}/${BUILDKITE_COMMIT}.aws-stack.yml"
+s3_key="templates/build-${BUILDKITE_BUILD_NUMBER}/${os}-${arch}${variant:+-$variant}/${BUILDKITE_COMMIT}.aws-stack.yml"
 
 # s3 cp requires old path style, cloudformation requires new http style. sigh.
 upload_location="s3://${s3_bucket}/${s3_key}"

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -8,25 +8,41 @@ fi
 
 os="${1:-linux}"
 arch="${2:-amd64}"
-variant="${3:-stack}" # "stack" (default) or "base"
+variant="${3:-stack}" # "stack" (default), "base", "base-cis", or "stack-cis"
 
 mkdir -p "build/"
 
 # Generate timestamped output filenames
 timestamp=$(date -u +"%Y%m%d-%H%M%S")
-if [[ "${variant}" == "base" ]]; then
+if [[ "${variant}" == "base-cis" ]]; then
+  packer_file="packer-base-${os}-${arch}-cis-${timestamp}.output"
+  local_output="packer-base-${os}-${arch}-cis.output"
+  make "packer-base-${os}-${arch}-cis.output"
+elif [[ "${variant}" == "base" ]]; then
   packer_file="packer-base-${os}-${arch}-${timestamp}.output"
   local_output="packer-base-${os}-${arch}.output"
   make "packer-base-${os}-${arch}.output"
 else
+  # Determine metadata key and file naming based on variant
+  if [[ "${variant}" == "stack-cis" ]]; then
+    meta_key="${os}-base-cis-${arch}-ami"
+    latest_base_file="packer-base-${os}-${arch}-cis-latest.output"
+    packer_file="packer-${os}-${arch}-cis-${timestamp}.output"
+    local_output="packer-${os}-${arch}-cis.output"
+  else
+    meta_key="${os}-base-${arch}-ami"
+    latest_base_file="packer-base-${os}-${arch}-latest.output"
+    packer_file="packer-${os}-${arch}-${timestamp}.output"
+    local_output="packer-${os}-${arch}.output"
+  fi
+
   # Get base AMI ID from metadata (set by base build step) or S3 fallback
-  base_ami_id="$(buildkite-agent meta-data get "${os}-base-${arch}-ami" || true)"
+  base_ami_id="$(buildkite-agent meta-data get "${meta_key}" || true)"
 
   if [[ -z "$base_ami_id" ]]; then
     echo "Base AMI ID not found in metadata, checking S3 for latest base image..."
 
     # Try to fetch the latest base AMI output from S3
-    latest_base_file="packer-base-${os}-${arch}-latest.output"
     if aws s3 cp "s3://${BUILDKITE_AWS_STACK_BUCKET}/${latest_base_file}" "/tmp/${latest_base_file}" 2>/dev/null; then
       base_ami_id=$(grep -Eo "${AWS_REGION}: (ami-.+)$" "/tmp/${latest_base_file}" | awk '{print $2}')
       echo "Found base AMI ID from S3: $base_ami_id"
@@ -39,9 +55,17 @@ else
     exit 1
   fi
 
-  packer_file="packer-${os}-${arch}-${timestamp}.output"
-  local_output="packer-${os}-${arch}.output"
-  make "packer-${os}-${arch}.output" BASE_AMI_ID="$base_ami_id"
+  # Both stack and stack-cis use the same Makefile target — only the BASE_AMI_ID differs
+  if [[ "${variant}" == "stack-cis" ]]; then
+    make "packer-${os}-${arch}.output" BASE_AMI_ID="$base_ami_id" IS_CIS=true
+  else
+    make "packer-${os}-${arch}.output" BASE_AMI_ID="$base_ami_id"
+  fi
+
+  # Rename output if this is a CIS build (the Makefile always produces packer-${os}-${arch}.output)
+  if [[ "${variant}" == "stack-cis" && "packer-${os}-${arch}.output" != "${local_output}" ]]; then
+    mv "packer-${os}-${arch}.output" "${local_output}"
+  fi
 fi
 
 # Upload to S3 with timestamped filename
@@ -54,14 +78,25 @@ if [[ "${variant}" == "base" && "${BUILDKITE_BRANCH:-}" == "main" ]]; then
   echo "Updated latest base AMI pointer for ${os}/${arch}"
 fi
 
+# For CIS base images on main branch, also upload as "latest"
+if [[ "${variant}" == "base-cis" && "${BUILDKITE_BRANCH:-}" == "main" ]]; then
+  latest_file="packer-base-${os}-${arch}-cis-latest.output"
+  aws s3 cp "${local_output}" "s3://${BUILDKITE_AWS_STACK_BUCKET}/${latest_file}"
+  echo "Updated latest CIS base AMI pointer for ${os}/${arch}"
+fi
+
 mv "${local_output}" "${packer_file}"
 
 # Get the image id from the packer build output for later steps
 image_id=$(grep -Eo "${AWS_REGION}: (ami-.+)$" "$packer_file" | awk '{print $2}')
 echo "AMI for ${AWS_REGION} is $image_id"
 
-if [[ "${variant}" == "base" ]]; then
+if [[ "${variant}" == "base-cis" ]]; then
+  buildkite-agent meta-data set "${os}-base-cis-${arch}-ami" "$image_id"
+elif [[ "${variant}" == "base" ]]; then
   buildkite-agent meta-data set "${os}-base-${arch}-ami" "$image_id"
+elif [[ "${variant}" == "stack-cis" ]]; then
+  buildkite-agent meta-data set "${os}_${arch}_cis_image_id" "$image_id"
 else
   buildkite-agent meta-data set "${os}_${arch}_image_id" "$image_id"
 fi

--- a/.buildkite/steps/packer.sh
+++ b/.buildkite/steps/packer.sh
@@ -85,6 +85,13 @@ if [[ "${variant}" == "base-cis" && "${BUILDKITE_BRANCH:-}" == "main" ]]; then
   echo "Updated latest CIS base AMI pointer for ${os}/${arch}"
 fi
 
+# For CIS stack images on main branch, also upload as "latest"
+if [[ "${variant}" == "stack-cis" && "${BUILDKITE_BRANCH:-}" == "main" ]]; then
+  latest_file="packer-${os}-${arch}-cis-latest.output"
+  aws s3 cp "${local_output}" "s3://${BUILDKITE_AWS_STACK_BUCKET}/${latest_file}"
+  echo "Updated latest CIS stack AMI pointer for ${os}/${arch}"
+fi
+
 mv "${local_output}" "${packer_file}"
 
 # Get the image id from the packer build output for later steps

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linux packer image
-packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 packer-base-linux-amd64.output
+packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 $(if $(strip $(BASE_AMI_ID)),,packer-base-linux-amd64.output)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -163,7 +163,7 @@ print-agent-versions:
 	@echo Windows: $(CURRENT_AGENT_VERSION_WINDOWS)
 
 # Build linuxarm64 packer image
-packer-linux-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 packer-base-linux-arm64.output
+packer-linux-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 $(if $(strip $(BASE_AMI_ID)),,packer-base-linux-arm64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
@@ -193,7 +193,7 @@ build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build windows packer image
-packer-windows-amd64.output: $(PACKER_WINDOWS_STACK_FILES) packer-base-windows-amd64.output
+packer-windows-amd64.output: $(PACKER_WINDOWS_STACK_FILES) $(if $(strip $(BASE_AMI_ID)),,packer-base-windows-amd64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_WINDOWS)
 	docker run \
 		-e AWS_DEFAULT_REGION  \

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,13 @@ packer-base-linux-amd64.output: $(PACKER_LINUX_BASE_FILES)
 			-var 'ami_users=$(AMI_USERS_LIST)' \
 			base.pkr.hcl | tee $@
 
-# CIS-hardened source AMI IDs
+# CIS-hardened source AMI IDs (us-east-1 only)
+# Unlike the standard AL2023 base, which uses a dynamic Packer amazon-ami data
+# source lookup that works in any region, CIS AMIs are referenced by ID because
+# they come from the CIS Marketplace publisher (owner 679593333241). AMI IDs are
+# region-specific, so these only work in us-east-1 where our CI runs. To support
+# other regions, replace these with a Packer data source filtering by owner and
+# name pattern (requires an active Marketplace subscription in that region).
 CIS_SOURCE_AMI_AMD64 ?= ami-0ade66ab1b3aaa37a
 CIS_SOURCE_AMI_ARM64 ?= ami-039ef18047739861b
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ PACKER_WINDOWS_STACK_FILES = $(exec find packer/windows/stack)
 # Allow passing an existing golden base AMI into packer via `BASE_AMI_ID` env var
 override BASE_AMI_ID ?=
 
+# Set to true when building a stack image on top of a CIS-hardened base
+IS_CIS ?= false
+
 base_ami_from_output = $(shell \
   if [ -f $(1) ]; then \
     $(SED) -nE 's/^.*AMI: (ami-[a-z0-9]+).*$$/\1/p' $(1) | tail -n 1; \
@@ -144,6 +147,7 @@ packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd
 			-var 'ami_public=$(AMI_PUBLIC)' \
 			-var 'ami_users=$(AMI_USERS_LIST)' \
 			-var 'base_ami_id=$(if $(BASE_AMI_ID),$(BASE_AMI_ID),$(BASE_AMI_ID_LINUX_AMD64))' \
+			-var 'is_cis=$(IS_CIS)' \
 			buildkite-ami.pkr.hcl | tee $@
 
 build/linux-arm64-ami.txt: packer-linux-arm64.output env-AWS_REGION
@@ -238,6 +242,34 @@ packer-base-linux-amd64.output: $(PACKER_LINUX_BASE_FILES)
 			-var 'is_released=$(IS_RELEASED)' \
 			-var 'ami_public=$(AMI_PUBLIC)' \
 			-var 'ami_users=$(AMI_USERS_LIST)' \
+			base.pkr.hcl | tee $@
+
+# CIS-hardened source AMI IDs
+CIS_SOURCE_AMI_AMD64 ?= ami-0ade66ab1b3aaa37a
+CIS_SOURCE_AMI_ARM64 ?= ami-039ef18047739861b
+
+# Build base AMI for linux amd64 (CIS-hardened)
+packer-base-linux-amd64-cis.output: $(PACKER_LINUX_BASE_FILES)
+	docker run \
+		-e AWS_DEFAULT_REGION  \
+		-e AWS_PROFILE \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e PACKER_LOG \
+		-v ${HOME}/.aws:/root/.aws \
+		-v "$(PWD):/src" \
+		--rm \
+		-w /src/packer/linux/base \
+		hashicorp/packer:full-$(PACKER_VERSION) build -timestamp-ui \
+			-var 'region=$(AWS_REGION)' \
+			-var 'arch=x86_64' \
+			-var 'instance_type=$(AMD64_INSTANCE_TYPE)' \
+			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
+			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
+			-var 'cis_source_ami=$(CIS_SOURCE_AMI_AMD64)' \
 			base.pkr.hcl | tee $@
 
 # Build base AMI for linux arm64

--- a/goss.yaml
+++ b/goss.yaml
@@ -92,7 +92,10 @@ user:
     groups:
     - sshd
     home: /usr/share/empty.sshd
-    shell: /sbin/nologin
+    shell:
+      or:
+      - /sbin/nologin
+      - /usr/sbin/nologin
 
 group:
   buildkite-agent:

--- a/packer/linux/base/base.pkr.hcl
+++ b/packer/linux/base/base.pkr.hcl
@@ -44,6 +44,12 @@ variable "ami_users" {
   default     = []
 }
 
+variable "cis_source_ami" {
+  type        = string
+  description = "When set, use this CIS-hardened AMI as the source instead of the standard AL2023 AMI lookup."
+  default     = ""
+}
+
 # Latest minimal Amazon Linux 2023 image for the given arch
 data "amazon-ami" "al2023" {
   filters = {
@@ -56,14 +62,23 @@ data "amazon-ami" "al2023" {
   region      = var.region
 }
 
+locals {
+  is_cis     = var.cis_source_ami != ""
+  source_ami = local.is_cis ? var.cis_source_ami : data.amazon-ami.al2023.id
+  ami_prefix = local.is_cis ? "buildkite-base-cis-linux" : "buildkite-base-linux"
+  ami_desc   = local.is_cis ? "Buildkite Golden Base (CIS AL2023 w/ docker)" : "Buildkite Golden Base (Amazon Linux 2023 w/ docker)"
+  os_version = local.is_cis ? "CIS Amazon Linux 2023" : "Amazon Linux 2023"
+  component  = local.is_cis ? "buildkite-base-cis" : "buildkite-base"
+}
+
 source "amazon-ebs" "buildkite-base-ami" {
-  ami_description                           = "Buildkite Golden Base (Amazon Linux 2023 w/ docker)"
+  ami_description                           = local.ami_desc
   ami_groups                                = var.ami_public ? ["all"] : []
   ami_users                                 = var.ami_public ? [] : var.ami_users
-  ami_name                                  = "buildkite-base-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
+  ami_name                                  = "${local.ami_prefix}-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region
-  source_ami                                = data.amazon-ami.al2023.id
+  source_ami                                = local.source_ami
   ssh_username                              = "ec2-user"
   ssh_clear_authorized_keys                 = true
   temporary_security_group_source_public_ip = true
@@ -71,7 +86,7 @@ source "amazon-ebs" "buildkite-base-ami" {
   launch_block_device_mappings {
     volume_type           = "gp3"
     device_name           = "/dev/xvda"
-    volume_size           = 10
+    volume_size           = local.is_cis ? 15 : 10
     delete_on_termination = true
   }
 
@@ -82,12 +97,12 @@ source "amazon-ebs" "buildkite-base-ami" {
   imds_support = "v2.0"
 
   tags = {
-    Name        = "buildkite-base-linux-${var.arch}"
-    OSVersion   = "Amazon Linux 2023"
+    Name        = "${local.ami_prefix}-${var.arch}"
+    OSVersion   = local.os_version
     BuildNumber = var.build_number
     IsReleased  = var.is_released
-    SourceAMIID = data.amazon-ami.al2023.id
-    Component   = "buildkite-base"
+    SourceAMIID = local.source_ami
+    Component   = local.component
   }
 }
 
@@ -111,26 +126,31 @@ build {
 
   # Essential utilities & updates
   provisioner "shell" {
-    script = "scripts/install-utils.sh"
+    script        = "scripts/install-utils.sh"
+    remote_folder = "/var/tmp"
   }
 
   # Docker engine
   provisioner "shell" {
-    script = "scripts/install-docker.sh"
+    script        = "scripts/install-docker.sh"
+    remote_folder = "/var/tmp"
   }
 
   # CloudWatch agent
   provisioner "shell" {
-    script = "scripts/install-cloudwatch-agent.sh"
+    script        = "scripts/install-cloudwatch-agent.sh"
+    remote_folder = "/var/tmp"
   }
 
   # Session Manager plugin
   provisioner "shell" {
-    script = "scripts/install-session-manager-plugin.sh"
+    script        = "scripts/install-session-manager-plugin.sh"
+    remote_folder = "/var/tmp"
   }
 
   # Clean up
   provisioner "shell" {
-    script = "../shared/scripts/cleanup.sh"
+    script        = "../shared/scripts/cleanup.sh"
+    remote_folder = "/var/tmp"
   }
 }

--- a/packer/linux/base/scripts/install-docker.sh
+++ b/packer/linux/base/scripts/install-docker.sh
@@ -20,7 +20,7 @@ sudo cp /tmp/conf/docker/daemon.json /etc/docker/daemon.json
 echo "Adding docker systemd timers..."
 sudo cp /tmp/conf/docker/scripts/* /usr/local/bin
 sudo cp /tmp/conf/docker/systemd/docker-* /etc/systemd/system
-sudo chmod +x /usr/local/bin/docker-*
+sudo chmod 755 /usr/local/bin/docker-*
 
 echo "Installing docker buildx..."
 DOCKER_CLI_DIR=/usr/libexec/docker/cli-plugins
@@ -33,17 +33,18 @@ aarch64) BUILDX_ARCH="arm64" ;;
 esac
 
 sudo curl --location --fail --silent --output "${DOCKER_CLI_DIR}/docker-buildx" "https://github.com/docker/buildx/releases/download/v${DOCKER_BUILDX_VERSION}/buildx-v${DOCKER_BUILDX_VERSION}.linux-${BUILDX_ARCH}"
-sudo chmod +x "${DOCKER_CLI_DIR}/docker-buildx"
-docker buildx version
+sudo chmod 755 "${DOCKER_CLI_DIR}/docker-buildx"
 
 sudo curl --location --fail --silent --output "${DOCKER_CLI_DIR}/docker-compose" "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_V2_VERSION}/docker-compose-linux-${DOCKER_COMPOSE_V2_ARCH}"
-sudo chmod +x "${DOCKER_CLI_DIR}/docker-compose"
+sudo chmod 755 "${DOCKER_CLI_DIR}/docker-compose"
+
+docker buildx version
 docker compose version
 
 echo "Making docker compose v2 compatible w/ docker-compose v1..."
 sudo ln -s "${DOCKER_CLI_DIR}/docker-compose" /usr/bin/docker-compose
 sudo cp /tmp/conf/bin/docker-compose /usr/local/bin/docker-compose
-sudo chmod +x /usr/local/bin/docker-compose
+sudo chmod 755 /usr/local/bin/docker-compose
 docker-compose version
 
 sudo mkdir -p /usr/local/lib

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -59,7 +59,7 @@ sudo systemctl enable --now amazon-ssm-agent
 sudo systemctl enable --now rsyslog
 
 echo "Installing AWS CLI v2 ${AWS_CLI_LINUX_VERSION}..."
-pushd "$(mktemp -d)"
+pushd "$(mktemp -d -p /var/tmp)"
 case $(uname -m) in
 x86_64)
   curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_LINUX_VERSION}.zip" -o "awscliv2.zip"
@@ -77,7 +77,7 @@ sudo ./aws/install
 popd
 
 echo "Installing git lfs ${GIT_LFS_VERSION}..."
-pushd "$(mktemp -d)"
+pushd "$(mktemp -d -p /var/tmp)"
 curl -sSL https://github.com/git-lfs/git-lfs/releases/download/v"${GIT_LFS_VERSION}"/git-lfs-linux-"${ARCH}"-v"${GIT_LFS_VERSION}".tar.gz | tar xz
 sudo git-lfs-"${GIT_LFS_VERSION}"/install.sh
 popd

--- a/packer/linux/stack/buildkite-ami.pkr.hcl
+++ b/packer/linux/stack/buildkite-ami.pkr.hcl
@@ -66,11 +66,24 @@ variable "base_ami_id" {
   default = ""
 }
 
+variable "is_cis" {
+  type        = bool
+  description = "Whether we are building on a CIS-hardened base AMI. Adjusts volume size and naming."
+  default     = false
+}
+
+locals {
+  ami_prefix = var.is_cis ? "buildkite-stack-cis-linux" : "buildkite-stack-linux"
+  ami_desc   = var.is_cis ? "Buildkite Elastic Stack (CIS AL2023 w/ docker)" : "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
+  os_version = var.is_cis ? "CIS Amazon Linux 2023" : "Amazon Linux 2023"
+  component  = var.is_cis ? "elastic-ci-stack-cis" : "elastic-ci-stack"
+}
+
 source "amazon-ebs" "elastic-ci-stack-ami" {
-  ami_description                           = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
+  ami_description                           = local.ami_desc
   ami_groups                                = var.ami_public ? ["all"] : []
   ami_users                                 = var.ami_public ? [] : var.ami_users
-  ami_name                                  = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
+  ami_name                                  = "${local.ami_prefix}-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region
   source_ami                                = var.base_ami_id
@@ -88,7 +101,7 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   launch_block_device_mappings {
     volume_type           = "gp3"
     device_name           = "/dev/xvda"
-    volume_size           = 10
+    volume_size           = var.is_cis ? 15 : 10
     delete_on_termination = true
   }
 
@@ -97,12 +110,13 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   }
 
   tags = {
-    Name         = "elastic-ci-stack-linux-${var.arch}"
-    OSVersion    = "Amazon Linux 2023"
+    Name         = "${local.component}-linux-${var.arch}"
+    OSVersion    = local.os_version
     BuildNumber  = var.build_number
     AgentVersion = var.agent_version
     IsReleased   = var.is_released
     SourceAMIID  = var.base_ami_id
+    Component    = local.component
   }
 }
 
@@ -135,18 +149,22 @@ build {
   }
 
   provisioner "shell" {
-    script = "scripts/configure-cloudwatch-agent.sh"
+    script        = "scripts/configure-cloudwatch-agent.sh"
+    remote_folder = "/var/tmp"
   }
 
   provisioner "shell" {
-    script = "scripts/install-buildkite-agent.sh"
+    script        = "scripts/install-buildkite-agent.sh"
+    remote_folder = "/var/tmp"
   }
 
   provisioner "shell" {
-    script = "scripts/install-buildkite-utils.sh"
+    script        = "scripts/install-buildkite-utils.sh"
+    remote_folder = "/var/tmp"
   }
 
   provisioner "shell" {
-    script = "../shared/scripts/cleanup.sh"
+    script        = "../shared/scripts/cleanup.sh"
+    remote_folder = "/var/tmp"
   }
 }

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -250,7 +250,7 @@ edge)
   echo Downloading buildkite-agent edge...
   curl -Lsf -o /usr/bin/buildkite-agent-edge \
     "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-${ARCH}"
-  chmod +x /usr/bin/buildkite-agent-edge
+  chmod 0755 /usr/bin/buildkite-agent-edge
   buildkite-agent-edge --version
   ;;
 oldstable)

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -257,7 +257,7 @@ oldstable)
   echo Downloading buildkite-agent oldstable...
   curl -Lsf -o /usr/bin/buildkite-agent-oldstable \
     "https://download.buildkite.com/agent/oldstable/latest/buildkite-agent-linux-${ARCH}"
-  chmod +x /usr/bin/buildkite-agent-oldstable
+  chmod 0755 /usr/bin/buildkite-agent-oldstable
   buildkite-agent-oldstable --version
   ;;
 *)

--- a/packer/linux/stack/conf/buildkite-agent/systemd/buildkite-agent.service
+++ b/packer/linux/stack/conf/buildkite-agent/systemd/buildkite-agent.service
@@ -11,6 +11,7 @@ User=buildkite-agent
 Environment="HOME=/var/lib/buildkite-agent"
 Environment="PATH=/usr/local/bin:/usr/bin"
 Environment="USER=buildkite-agent"
+Environment="TMPDIR=/var/tmp"
 # The =- (rather than just = ) in the line below means that systemd won't complain if it can't find the file
 EnvironmentFile=-/var/lib/buildkite-agent/env
 ExecStart=/usr/bin/buildkite-agent start

--- a/packer/linux/stack/scripts/install-buildkite-agent.sh
+++ b/packer/linux/stack/scripts/install-buildkite-agent.sh
@@ -10,7 +10,14 @@ aarch64) ARCH=arm64 ;;
 esac
 
 echo "Creating buildkite-agent user and group..."
-sudo useradd --base-dir /var/lib --uid 2000 buildkite-agent
+sudo groupadd --gid 2000 buildkite-agent 2>/dev/null || {
+  rc=$?
+  if [[ $rc -ne 9 ]]; then
+    echo "groupadd failed with unexpected exit code $rc" >&2
+    exit 1
+  fi
+}
+sudo useradd --base-dir /var/lib --uid 2000 --gid 2000 buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
 sudo mkdir -p /var/lib/buildkite-agent/.aws
@@ -20,17 +27,18 @@ sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
 echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
   "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"
-sudo chmod +x /usr/bin/buildkite-agent-stable
+sudo chmod 755 /usr/bin/buildkite-agent-stable
 buildkite-agent-stable --version
 
 echo "Downloading buildkite-agent beta..."
 sudo curl -Lsf -o /usr/bin/buildkite-agent-beta \
   "https://download.buildkite.com/agent/unstable/latest/buildkite-agent-linux-${ARCH}"
-sudo chmod +x /usr/bin/buildkite-agent-beta
+sudo chmod 755 /usr/bin/buildkite-agent-beta
 buildkite-agent-beta --version
 
 echo "Adding scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/* /usr/bin
+sudo chmod 755 /usr/bin/stop-agent-gracefully /usr/bin/terminate-instance
 
 echo "Adding sudoers config..."
 sudo cp /tmp/conf/buildkite-agent/sudoers.conf /etc/sudoers.d/buildkite-agent
@@ -38,11 +46,12 @@ sudo chmod 440 /etc/sudoers.d/buildkite-agent
 
 echo "Creating hooks dir..."
 sudo mkdir -p /etc/buildkite-agent/hooks
+sudo chmod 755 /etc/buildkite-agent
 sudo chown -R buildkite-agent: /etc/buildkite-agent/hooks
 
 echo "Copying custom hooks..."
-sudo cp -a /tmp/conf/buildkite-agent/hooks/* /etc/buildkite-agent/hooks
-sudo chmod +x /etc/buildkite-agent/hooks/*
+sudo cp -a /tmp/conf/buildkite-agent/hooks/* /etc/buildkite-agent/hooks/
+sudo find /etc/buildkite-agent/hooks -type f -exec chmod 755 {} +
 sudo chown -R buildkite-agent: /etc/buildkite-agent/hooks
 
 echo "Creating builds dir..."
@@ -68,7 +77,9 @@ sudo cp /tmp/conf/buildkite-agent/systemd/cloud-init.service.d/10-power-off-on-f
 
 echo "Adding termination scripts..."
 sudo cp /tmp/conf/buildkite-agent/scripts/stop-agent-gracefully /usr/local/bin/stop-agent-gracefully
+sudo chmod 755 /usr/local/bin/stop-agent-gracefully
 sudo cp /tmp/conf/buildkite-agent/scripts/terminate-instance /usr/local/bin/terminate-instance
+sudo chmod 755 /usr/local/bin/terminate-instance
 
 echo "Copying built-in plugins..."
 sudo mkdir -p /usr/local/buildkite-aws-stack/plugins

--- a/packer/linux/stack/scripts/install-buildkite-utils.sh
+++ b/packer/linux/stack/scripts/install-buildkite-utils.sh
@@ -12,31 +12,31 @@ aarch64) ARCH=arm64 ;;
 esac
 
 echo "Installing bk elastic stack bin files..."
-sudo chmod +x /tmp/conf/bin/bk-*
+sudo chmod 755 /tmp/conf/bin/bk-*
 sudo mv /tmp/conf/bin/bk-* /usr/local/bin
 
 echo "Installing fix-buildkite-agent-builds-permissions..."
-sudo chmod +x "/tmp/build/fix-perms-linux-${ARCH}"
+sudo chmod 755 "/tmp/build/fix-perms-linux-${ARCH}"
 sudo mv "/tmp/build/fix-perms-linux-${ARCH}" /usr/bin/fix-buildkite-agent-builds-permissions
 
 # goss is built by the build/goss-* Makefile targets and uploaded via the
 # build/ provisioner; dgoss is a shell script fetched from the same commit.
 echo "Installing goss ${GOSS_VERSION} (built from ${GOSS_COMMIT}) for system validation..."
-sudo chmod +x "/tmp/build/goss-linux-${ARCH}"
+sudo chmod 755 "/tmp/build/goss-linux-${ARCH}"
 sudo mv "/tmp/build/goss-linux-${ARCH}" /usr/local/bin/goss
 sudo curl -Lsf -o /usr/local/bin/dgoss \
   "https://raw.githubusercontent.com/goss-org/goss/${GOSS_COMMIT}/extras/dgoss/dgoss"
-sudo chmod +rx /usr/local/bin/dgoss
+sudo chmod 755 /usr/local/bin/dgoss
 
 echo "Downloading s3-secrets-helper ${S3_SECRETS_HELPER_VERSION}..."
 sudo curl -Lsf -o /usr/local/bin/s3secrets-helper \
   "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-linux-${ARCH}"
-sudo chmod +x /usr/local/bin/s3secrets-helper
+sudo chmod 755 /usr/local/bin/s3secrets-helper
 
 echo "Installing lifecycled ${LIFECYCLED_VERSION}..."
 sudo touch /etc/lifecycled
 sudo curl -Lf -o /usr/bin/lifecycled \
   "https://github.com/buildkite/lifecycled/releases/download/${LIFECYCLED_VERSION}/lifecycled-linux-${ARCH}"
-sudo chmod +x /usr/bin/lifecycled
+sudo chmod 755 /usr/bin/lifecycled
 sudo curl -Lf -o /etc/systemd/system/lifecycled.service \
   "https://raw.githubusercontent.com/buildkite/lifecycled/${LIFECYCLED_VERSION}/init/systemd/lifecycled.unit"


### PR DESCRIPTION
## CIS Level 1 hardened AMI compatibility

### Goal

Make the standard Elastic CI Stack AMI compatible with CIS Level 1 hardening applied on top. Customers using EC2 Image Builder (or similar) to apply CIS benchmarks to our published AMI should have it work out of the box, with no configuration on their end.

This is an extension of #1832.

Ref. SUP-7508

### What we didn't want to do

- **Publish a separate CIS AMI.** That would mean marketplace licensing concerns, per-hour costs, and maintaining two image variants. Instead, all fixes are backward-compatible — the standard AMI becomes CIS-compatible.
- **Require customer-side workarounds.** The customer who reported this had already found the `TMPDIR` fix via systemd drop-in. We wanted that (and everything else) handled automatically.

### How

Two classes of CIS incompatibility were found and fixed:

**`/tmp` noexec (CIS Rule 1.1.2.3):** The agent writes hook wrapper scripts to `$TMPDIR` (defaults to `/tmp`) and executes them. CIS mounts `/tmp` noexec, causing `Permission denied`. Fixed by setting `TMPDIR=/var/tmp` in the agent's systemd service file, and redirecting all Packer provisioner scripts and `mktemp` calls to `/var/tmp`.

**Restrictive umask (CIS Rule 5.5.5):** CIS tightens umask to `027`, so files created by root during bootstrap are unreadable by the `buildkite-agent` user. Fixed by:
- `chown buildkite-agent:` on `cfn-env` and `env` files written at boot
- `chmod 755` instead of `chmod +x` throughout (the latter is umask-relative and produces `750` under `027`)
- Explicit `chmod 755` on directories that need to be traversable
- Explicit `groupadd` before `useradd` (CIS may disable automatic group creation)

A CIS build variant was added to the CI pipeline to validate these fixes on every build. It uses a CIS AL2023 marketplace AMI as the base, builds the stack on top, launches a CloudFormation stack, and runs the full goss test suite.

### Review notes

Buildsworth flagged a few items we intentionally left as-is:

- **File provisioners still use `/tmp`** — these files are read/copied, never executed. `noexec` doesn't affect reads. Moving 25+ references for zero benefit isn't worthwhile.
- **`copy-ami` doesn't depend on `test-linux-amd64-cis`** — intentional. CIS AMIs are private validation builds, not published.
- **`cfn-env` logged before `chown`** — the file explicitly doesn't contain secrets (existing code comment confirms this).How does that look? I'd suggest squashing before opening the PR — the commit history has a lot of debug/iteration commits (diagnostics, temporary pipeline stripping, hardcoded AMIs, reverts). Want me to squash it down, or would you prefer to keep the history?