### PR TITLE
Add oldstable as a BuildkiteAgentRelease option

### DIFF
--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -245,15 +245,25 @@ chown root:buildkite-agent /var/lib/buildkite-agent/cfn-env
 chmod 0640 /var/lib/buildkite-agent/cfn-env
 echo
 
-if [[ "${BUILDKITE_AGENT_RELEASE}" == "edge" ]]; then
+case "${BUILDKITE_AGENT_RELEASE}" in
+edge)
   echo Downloading buildkite-agent edge...
   curl -Lsf -o /usr/bin/buildkite-agent-edge \
     "https://download.buildkite.com/agent/experimental/latest/buildkite-agent-linux-${ARCH}"
   chmod +x /usr/bin/buildkite-agent-edge
   buildkite-agent-edge --version
-else
-  echo Not using buildkite-agent edge.
-fi
+  ;;
+oldstable)
+  echo Downloading buildkite-agent oldstable...
+  curl -Lsf -o /usr/bin/buildkite-agent-oldstable \
+    "https://download.buildkite.com/agent/oldstable/latest/buildkite-agent-linux-${ARCH}"
+  chmod +x /usr/bin/buildkite-agent-oldstable
+  buildkite-agent-oldstable --version
+  ;;
+*)
+  echo Not using buildkite-agent edge or oldstable.
+  ;;
+esac
 
 if [[ "${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" != "" ]]; then
   echo "buildkite-agent ALL=NOPASSWD: ${BUILDKITE_ADDITIONAL_SUDO_PERMISSIONS}" \

--- a/packer/windows/stack/conf/bin/bk-install-elastic-stack.ps1
+++ b/packer/windows/stack/conf/bin/bk-install-elastic-stack.ps1
@@ -106,6 +106,13 @@ If ($Env:BUILDKITE_AGENT_RELEASE -eq "edge") {
   If ($lastexitcode -ne 0) { Exit $lastexitcode }
 }
 
+If ($Env:BUILDKITE_AGENT_RELEASE -eq "oldstable") {
+  Write-Output "Downloading buildkite-agent oldstable..."
+  Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-oldstable.exe -Uri "https://download.buildkite.com/agent/oldstable/latest/buildkite-agent-windows-amd64.exe"
+  buildkite-agent-oldstable.exe --version
+  If ($lastexitcode -ne 0) { Exit $lastexitcode }
+}
+
 # Check if the source agent executable exists before copying
 $sourceAgentPath = "C:\buildkite-agent\bin\buildkite-agent-${Env:BUILDKITE_AGENT_RELEASE}.exe"
 if (-not (Test-Path -Path $sourceAgentPath -PathType Leaf)) {

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -200,11 +200,12 @@ Parameters:
   BuildkiteAgentRelease:
     Description: >
         Buildkite agent release channel to install.
-        'stable' = production-ready (recommended), 'beta' = pre-release with latest features, 'edge' = bleeding-edge development builds.
+        'stable' = production-ready (recommended), 'oldstable' = most recent release from the major version branch prior to stable, 'beta' = pre-release with latest features, 'edge' = bleeding-edge development builds.
         Use 'stable' unless specific new features are required.
     Type: String
     AllowedValues:
       - stable
+      - oldstable
       - beta
       - edge
     Default: "stable"


### PR DESCRIPTION
## Description

Add `oldstable` as a new option for `BuildkiteAgentRelease` parameter. 

`oldstable` matches the `oldstable` release channel of the agent, which currently mirrors `stable`. When v4 becomes stable, v3 will remain available in `oldstable`.

## Checklist

- [ ] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [ ] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [x] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
