### PR TITLE
Add Ubuntu 24.04 as a selectable Linux base OS

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,6 +23,7 @@ x-if-changed-patterns:
       - "Makefile"
       - "internal/**"
       - "goss.yaml"
+      - "goss.ubuntu2404.yaml"
     exclude:
       - "**/*.md"
       - "**/README*"
@@ -48,6 +49,7 @@ x-if-changed-patterns:
       - "Makefile"
       - "internal/**"
       - "goss.yaml"
+      - "goss.ubuntu2404.yaml"
     exclude:
       - "**/*.md"
       - "**/README*"
@@ -77,6 +79,7 @@ x-if-changed-patterns:
       - "Makefile"
       - "internal/**"
       - "goss.yaml"
+      - "goss.ubuntu2404.yaml"
     exclude:
       - "**/*.md"
       - "**/README*"
@@ -380,6 +383,165 @@ steps:
     plugins:
       - *aws_role_plugin
 
+  - id: "packer-base-ubuntu2404-amd64"
+    name: ":packer: :ubuntu: AMD64 (base)"
+    command: ".buildkite/steps/packer.sh ubuntu2404 amd64 base"
+    timeout_in_minutes: 40
+    env:
+      AMI_PUBLIC: false
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if_changed: *if_changed_base_linux
+    depends_on:
+      - "linting"
+      - "fixperms-tests"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "packer-ubuntu2404-amd64"
+    name: ":packer: :ubuntu: AMD64"
+    command: .buildkite/steps/packer.sh ubuntu2404 amd64
+    timeout_in_minutes: 60
+    env:
+      AMI_PUBLIC: true
+    retry: { automatic: { limit: 3 } }
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_stack_linux
+    depends_on:
+      - "packer-base-ubuntu2404-amd64"
+      - "linting"
+      - "fixperms-tests"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "launch-ubuntu2404-amd64"
+    name: ":cloudformation: :ubuntu: AMD64 Launch"
+    command:
+      - .buildkite/steps/ensure_ami_metadata.py ubuntu2404 amd64
+      - .buildkite/steps/launch.sh ubuntu2404 amd64
+    retry: { automatic: { limit: 3 } }
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    artifact_paths: "build/aws-stack.yml"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "packer-ubuntu2404-amd64"
+      - "deploy-service-role-stack"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "test-ubuntu2404-amd64"
+    name: ":cloudformation: :ubuntu: AMD64 Test"
+    command:
+      - aws --version
+      - jq --version
+      - git --version
+      - sudo goss -g goss.ubuntu2404.yaml validate --format documentation
+    timeout_in_minutes: 5
+    retry: { automatic: { limit: 3 } }
+    agents:
+      stack: "buildkite-aws-stack-test-ubuntu2404-amd64-${BUILDKITE_BUILD_NUMBER}"
+      queue: "testqueue-ubuntu2404-amd64-${BUILDKITE_BUILD_NUMBER}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "launch-ubuntu2404-amd64"
+
+  - id: "delete-ubuntu2404-amd64"
+    name: ":cloudformation: :ubuntu: AMD64 Delete"
+    command: .buildkite/steps/delete.sh ubuntu2404 amd64
+    allow_dependency_failure: true
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "test-ubuntu2404-amd64"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "packer-base-ubuntu2404-arm64"
+    name: ":packer: :ubuntu: ARM64 (base)"
+    command: ".buildkite/steps/packer.sh ubuntu2404 arm64 base"
+    timeout_in_minutes: 40
+    env:
+      AMI_PUBLIC: false
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if_changed: *if_changed_base_linux
+    depends_on:
+      - "linting"
+      - "fixperms-tests"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "packer-ubuntu2404-arm64"
+    name: ":packer: :ubuntu: ARM64"
+    command: .buildkite/steps/packer.sh ubuntu2404 arm64
+    timeout_in_minutes: 60
+    env:
+      AMI_PUBLIC: true
+    retry: { automatic: { limit: 3 } }
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_stack_linux
+    depends_on:
+      - "packer-base-ubuntu2404-arm64"
+      - "linting"
+      - "fixperms-tests"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "launch-ubuntu2404-arm64"
+    name: ":cloudformation: :ubuntu: ARM64 Launch"
+    command:
+      - .buildkite/steps/ensure_ami_metadata.py ubuntu2404 arm64
+      - .buildkite/steps/launch.sh ubuntu2404 arm64
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    artifact_paths: "build/aws-stack.yml"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "packer-ubuntu2404-arm64"
+      - "deploy-service-role-stack"
+    plugins:
+      - *aws_role_plugin
+
+  - id: "test-ubuntu2404-arm64"
+    name: ":cloudformation: :ubuntu: ARM64 Test"
+    command:
+      - aws --version
+      - jq --version
+      - git --version
+      - sudo goss -g goss.ubuntu2404.yaml validate --format documentation
+    retry: { automatic: { limit: 3 } }
+    timeout_in_minutes: 5
+    agents:
+      stack: "buildkite-aws-stack-test-ubuntu2404-arm64-${BUILDKITE_BUILD_NUMBER}"
+      queue: "testqueue-ubuntu2404-arm64-${BUILDKITE_BUILD_NUMBER}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "launch-ubuntu2404-arm64"
+
+  - id: "delete-ubuntu2404-arm64"
+    name: ":cloudformation: :ubuntu: ARM64 Delete"
+    command: .buildkite/steps/delete.sh ubuntu2404 arm64
+    allow_dependency_failure: true
+    agents:
+      queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+    if: build.source != "schedule"
+    if_changed: *if_changed_launch_test_delete_linux
+    depends_on:
+      - "test-ubuntu2404-arm64"
+    plugins:
+      - *aws_role_plugin
+
   - id: "delete-service-role-stack"
     name: ":aws-iam: :cloudformation: Delete"
     command: .buildkite/steps/delete-service-role-stack.sh
@@ -391,6 +553,8 @@ steps:
       - "delete-windows-amd64"
       - "delete-linux-amd64"
       - "delete-linux-arm64"
+      - "delete-ubuntu2404-amd64"
+      - "delete-ubuntu2404-arm64"
     plugins:
       - *aws_role_plugin
 
@@ -400,6 +564,8 @@ steps:
       - .buildkite/steps/ensure_ami_metadata.py linux amd64
       - .buildkite/steps/ensure_ami_metadata.py linux arm64
       - .buildkite/steps/ensure_ami_metadata.py windows amd64
+      - .buildkite/steps/ensure_ami_metadata.py ubuntu2404 amd64
+      - .buildkite/steps/ensure_ami_metadata.py ubuntu2404 arm64
       - .buildkite/steps/copy.sh
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
@@ -410,6 +576,8 @@ steps:
       - "test-linux-amd64"
       - "test-linux-arm64"
       - "test-windows-amd64"
+      - "test-ubuntu2404-amd64"
+      - "test-ubuntu2404-arm64"
     plugins:
       - *aws_role_plugin
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -395,6 +395,9 @@ steps:
     plugins:
       - *aws_role_plugin
 
+  # ============================================================
+  # Ubuntu 24.04 AMD64
+  # ============================================================
   - id: "packer-base-ubuntu2404-amd64"
     name: ":packer: :ubuntu: AMD64 (base)"
     command: ".buildkite/steps/packer.sh ubuntu2404 amd64 base"
@@ -456,8 +459,8 @@ steps:
       - jq --version
       - git --version
       - sudo goss -g goss.ubuntu2404.yaml validate --format documentation
-    timeout_in_minutes: 5
     retry: { automatic: { limit: 3 } }
+    timeout_in_minutes: 5
     agents:
       stack: "buildkite-aws-stack-test-ubuntu2404-amd64-${BUILDKITE_BUILD_NUMBER}"
       queue: "testqueue-ubuntu2404-amd64-${BUILDKITE_BUILD_NUMBER}"
@@ -479,6 +482,9 @@ steps:
     plugins:
       - *aws_role_plugin
 
+  # ============================================================
+  # Ubuntu 24.04 ARM64
+  # ============================================================
   - id: "packer-base-ubuntu2404-arm64"
     name: ":packer: :ubuntu: ARM64 (base)"
     command: ".buildkite/steps/packer.sh ubuntu2404 arm64 base"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -434,6 +434,10 @@ steps:
       - .buildkite/steps/ensure_ami_metadata.py ubuntu2404 amd64
       - .buildkite/steps/launch.sh ubuntu2404 amd64
     retry: { automatic: { limit: 3 } }
+    # Ubuntu's image is larger than AL2023: the 10GB test default leaves under the
+    # 5GiB docker-low-disk-gc cutoff free, which marks the fresh instance unhealthy.
+    env:
+      ROOT_VOLUME_SIZE: "20"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"
@@ -513,6 +517,10 @@ steps:
     command:
       - .buildkite/steps/ensure_ami_metadata.py ubuntu2404 arm64
       - .buildkite/steps/launch.sh ubuntu2404 arm64
+    # Ubuntu's image is larger than AL2023: the 10GB test default leaves under the
+    # 5GiB docker-low-disk-gc cutoff free, which marks the fresh instance unhealthy.
+    env:
+      ROOT_VOLUME_SIZE: "20"
     agents:
       queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
     artifact_paths: "build/aws-stack.yml"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -116,6 +116,11 @@ steps:
         agents:
           queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
 
+      - name: ":mag: goss sync"
+        command: .buildkite/steps/goss-sync-check.sh
+        agents:
+          queue: "${BUILDKITE_AGENT_META_DATA_QUEUE}"
+
   - id: "fixperms-tests"
     name: ":go: fixperms tests"
     agents:

--- a/.buildkite/scripts/check-goss-sync.py
+++ b/.buildkite/scripts/check-goss-sync.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Fail if goss.yaml gains a check that goss.ubuntu2404.yaml doesn't mirror.
+#
+# goss.ubuntu2404.yaml documents its intentional divergences from goss.yaml
+# in its header comment; those are the exceptions below. Anything else in
+# goss.yaml is expected to have a same-keyed entry in goss.ubuntu2404.yaml.
+import sys
+
+import yaml
+
+EXCEPTIONS = {
+    "file": {"/home/ec2-user/.ssh/authorized_keys"},
+    "service": {"amazon-ssm-agent", "sshd"},
+    "group": {"sshd"},
+    "process": {"sshd"},
+    "command": {'getent group docker | cut -d: -f3 | grep -E "^99[0-5]$"'},
+}
+
+with open("goss.yaml") as f:
+    base = yaml.safe_load(f)
+with open("goss.ubuntu2404.yaml") as f:
+    ubuntu = yaml.safe_load(f)
+
+missing = []
+for section, checks in base.items():
+    excepted = EXCEPTIONS.get(section, set())
+    ubuntu_keys = set((ubuntu.get(section) or {}).keys())
+    for key in checks:
+        if key in excepted:
+            continue
+        if key not in ubuntu_keys:
+            missing.append(f"{section}: {key!r}")
+
+if missing:
+    print("goss.ubuntu2404.yaml is missing checks present in goss.yaml:")
+    for m in missing:
+        print(f"  - {m}")
+    print()
+    print("Either add the check to goss.ubuntu2404.yaml, or if it's an intentional")
+    print("AL2023-only divergence, document it in goss.ubuntu2404.yaml's header")
+    print("comment and add it to EXCEPTIONS in .buildkite/scripts/check-goss-sync.py.")
+    sys.exit(1)
+
+print("goss.yaml and goss.ubuntu2404.yaml are in sync.")

--- a/.buildkite/steps/cleanup.sh
+++ b/.buildkite/steps/cleanup.sh
@@ -51,7 +51,7 @@ aws cloudformation describe-stacks \
   --output text \
   --query "$(printf 'Stacks[?CreationTime<`%s`].[StackName]' "$cutoff_date")" \
   | xargs -n1 \
-  | grep -E 'buildkite-aws-stack-test-(linux|windows)-(amd64|arm64)-([[:alpha:]]+-)?[[:digit:]]+' \
+  | grep -E 'buildkite-aws-stack-test-(linux|windows|ubuntu2404)-(amd64|arm64)-([[:alpha:]]+-)?[[:digit:]]+' \
   | xargs -n1 -t -I% aws cloudformation delete-stack --stack-name "%"
 
 echo "--- Deleting old cloudformation stacks for test stack service roles"

--- a/.buildkite/steps/copy.sh
+++ b/.buildkite/steps/copy.sh
@@ -109,6 +109,8 @@ IMAGES=(
 linux_amd64_source_image_id="${1:-}"
 linux_arm64_source_image_id="${1:-}"
 windows_amd64_source_image_id="${2:-}"
+ubuntu2404_amd64_source_image_id="${3:-}"
+ubuntu2404_arm64_source_image_id="${3:-}"
 
 source_region="${AWS_REGION}"
 mapping_file="build/mappings.yml"
@@ -118,6 +120,8 @@ if [ $# -eq 0 ]; then
   linux_amd64_source_image_id=$(buildkite-agent meta-data get "linux_amd64_image_id")
   linux_arm64_source_image_id=$(buildkite-agent meta-data get "linux_arm64_image_id")
   windows_amd64_source_image_id=$(buildkite-agent meta-data get "windows_amd64_image_id")
+  ubuntu2404_amd64_source_image_id=$(buildkite-agent meta-data get "ubuntu2404_amd64_image_id")
+  ubuntu2404_arm64_source_image_id=$(buildkite-agent meta-data get "ubuntu2404_arm64_image_id")
 fi
 
 # If we're not on the main branch or a tag build skip the copy
@@ -127,7 +131,7 @@ if [[ $BUILDKITE_BRANCH != main && $BUILDKITE_TAG != "$BUILDKITE_BRANCH" && ${CO
   cat <<EOF >"$mapping_file"
 Mappings:
   AWSRegion2AMI:
-    ${AWS_REGION} : { linuxamd64: $linux_amd64_source_image_id, linuxarm64: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id }
+    ${AWS_REGION} : { linuxamd64: $linux_amd64_source_image_id, linuxarm64: $linux_arm64_source_image_id, windows: $windows_amd64_source_image_id, ubuntu2404amd64: $ubuntu2404_amd64_source_image_id, ubuntu2404arm64: $ubuntu2404_arm64_source_image_id }
 EOF
   exit 0
 fi
@@ -137,6 +141,8 @@ if [[ $BUILDKITE_BRANCH == main || $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TA
   tag-ami "$linux_amd64_source_image_id" "$source_region" IsReleased true
   tag-ami "$linux_arm64_source_image_id" "$source_region" IsReleased true
   tag-ami "$windows_amd64_source_image_id" "$source_region" IsReleased true
+  tag-ami "$ubuntu2404_amd64_source_image_id" "$source_region" IsReleased true
+  tag-ami "$ubuntu2404_arm64_source_image_id" "$source_region" IsReleased true
 fi
 
 echo "--- Tagging elastic ci stack release version"
@@ -149,14 +155,18 @@ if [[ $BUILDKITE_TAG == "$BUILDKITE_BRANCH" || ${TAG_VERSION:-false} == true ]];
   tag-ami "$linux_amd64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
   tag-ami "$linux_arm64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
   tag-ami "$windows_amd64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
+  tag-ami "$ubuntu2404_amd64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
+  tag-ami "$ubuntu2404_arm64_source_image_id" "$source_region" "Version:${BUILDKITE_TAG}" true
 fi
 
 echo "--- Checking if there is a previously copy in the cache bucket"
-s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s.yml" \
+s3_mappings_cache=$(printf "s3://%s/mappings-%s-%s-%s-%s-%s-%s.yml" \
   "${BUILDKITE_AWS_STACK_BUCKET}" \
   "${linux_amd64_source_image_id}" \
   "${linux_arm64_source_image_id}" \
   "${windows_amd64_source_image_id}" \
+  "${ubuntu2404_amd64_source_image_id}" \
+  "${ubuntu2404_arm64_source_image_id}" \
   "${BUILDKITE_BRANCH}")
 
 if aws s3 cp "${s3_mappings_cache}" "$mapping_file"; then
@@ -170,6 +180,8 @@ echo "--- Copying images to other regions"
 linux_amd64_source_image_name=$(get_image_name "$linux_amd64_source_image_id" "$source_region")
 linux_arm64_source_image_name=$(get_image_name "$linux_arm64_source_image_id" "$source_region")
 windows_amd64_source_image_name=$(get_image_name "$windows_amd64_source_image_id" "$source_region")
+ubuntu2404_amd64_source_image_name=$(get_image_name "$ubuntu2404_amd64_source_image_id" "$source_region")
+ubuntu2404_arm64_source_image_name=$(get_image_name "$ubuntu2404_arm64_source_image_id" "$source_region")
 
 # Copy to all other regions
 for region in "${ALL_REGIONS[@]}"; do
@@ -182,8 +194,14 @@ for region in "${ALL_REGIONS[@]}"; do
 
     echo "--- :windows: Copying Windows AMD64 $windows_amd64_source_image_id to $region" >&2
     IMAGES+=("$(copy_ami_to_region "$windows_amd64_source_image_id" "$source_region" "$region" "${windows_amd64_source_image_name}-${region}")")
+
+    echo "--- :ubuntu: Copying Ubuntu AMD64 $ubuntu2404_amd64_source_image_id to $region" >&2
+    IMAGES+=("$(copy_ami_to_region "$ubuntu2404_amd64_source_image_id" "$source_region" "$region" "${ubuntu2404_amd64_source_image_name}-${region}")")
+
+    echo "--- :ubuntu: Copying Ubuntu ARM64 $ubuntu2404_arm64_source_image_id to $region" >&2
+    IMAGES+=("$(copy_ami_to_region "$ubuntu2404_arm64_source_image_id" "$source_region" "$region" "${ubuntu2404_arm64_source_image_name}-${region}")")
   else
-    IMAGES+=("$linux_amd64_source_image_id" "$linux_arm64_source_image_id" "$windows_amd64_source_image_id")
+    IMAGES+=("$linux_amd64_source_image_id" "$linux_arm64_source_image_id" "$windows_amd64_source_image_id" "$ubuntu2404_amd64_source_image_id" "$ubuntu2404_arm64_source_image_id")
   fi
 done
 
@@ -199,6 +217,8 @@ for region in "${ALL_REGIONS[@]}"; do
   linux_amd64_image_id="${IMAGES[0]}"
   linux_arm64_image_id="${IMAGES[1]}"
   windows_amd64_image_id="${IMAGES[2]}"
+  ubuntu2404_amd64_image_id="${IMAGES[3]}"
+  ubuntu2404_arm64_image_id="${IMAGES[4]}"
 
   wait_for_ami_to_be_available "$linux_amd64_image_id" "$region" >&2
 
@@ -224,11 +244,27 @@ for region in "${ALL_REGIONS[@]}"; do
     make_ami_public "$windows_amd64_image_id" "$region"
   fi
 
+  wait_for_ami_to_be_available "$ubuntu2404_amd64_image_id" "$region" >&2
+
+  # Make the ubuntu AMI public if it's not the source image
+  if [[ $ubuntu2404_amd64_image_id != "$ubuntu2404_amd64_source_image_id" ]]; then
+    echo ":ubuntu: Making Ubuntu AMD64 ${ubuntu2404_amd64_image_id} public" >&2
+    make_ami_public "$ubuntu2404_amd64_image_id" "$region"
+  fi
+
+  wait_for_ami_to_be_available "$ubuntu2404_arm64_image_id" "$region" >&2
+
+  # Make the ubuntu ARM AMI public if it's not the source image
+  if [[ $ubuntu2404_arm64_image_id != "$ubuntu2404_arm64_source_image_id" ]]; then
+    echo ":ubuntu: Making Ubuntu ARM64 ${ubuntu2404_arm64_image_id} public" >&2
+    make_ami_public "$ubuntu2404_arm64_image_id" "$region"
+  fi
+
   # Write yaml to file
-  echo "    $region : { linuxamd64: $linux_amd64_image_id, linuxarm64: $linux_arm64_image_id, windows: $windows_amd64_image_id }" >>"$mapping_file"
+  echo "    $region : { linuxamd64: $linux_amd64_image_id, linuxarm64: $linux_arm64_image_id, windows: $windows_amd64_image_id, ubuntu2404amd64: $ubuntu2404_amd64_image_id, ubuntu2404arm64: $ubuntu2404_arm64_image_id }" >>"$mapping_file"
 
   # Shift off the processed images
-  IMAGES=("${IMAGES[@]:3}")
+  IMAGES=("${IMAGES[@]:5}")
 done
 
 echo "--- Uploading mapping to s3 cache"

--- a/.buildkite/steps/ensure_ami_metadata.py
+++ b/.buildkite/steps/ensure_ami_metadata.py
@@ -77,12 +77,14 @@ def fetch_ami_from_template(os_type: str, arch: str, region: str) -> str:
 
     if os_type == "windows":
         key_name = "windows"
+    elif os_type == "ubuntu2404":
+        key_name = "ubuntu2404arm64" if arch == "arm64" else "ubuntu2404amd64"
     elif arch == "arm64":
         key_name = "linuxarm64"
     else:
         key_name = "linuxamd64"
 
-    # Template format: "    us-east-1: { linuxamd64: ami-xxx, linuxarm64: ami-yyy, windows: ami-zzz }"
+    # Template format: "    us-east-1: { linuxamd64: ami-xxx, linuxarm64: ami-yyy, windows: ami-zzz, ubuntu2404amd64: ami-aaa, ubuntu2404arm64: ami-bbb }"
     pattern = rf"^\s+{re.escape(region)}\s*:.*{key_name}:\s*(ami-[a-z0-9]+)"
 
     for line in template_content.split("\n"):
@@ -127,16 +129,16 @@ def main() -> int:
     """Main entry point."""
     if len(sys.argv) != 3:
         print(f"Usage: {sys.argv[0]} <os> <arch>", file=sys.stderr)
-        print("  os:   linux or windows", file=sys.stderr)
+        print("  os:   linux, windows or ubuntu2404", file=sys.stderr)
         print("  arch: amd64 or arm64", file=sys.stderr)
         return 1
 
     os_type = sys.argv[1]
     arch = sys.argv[2]
 
-    if os_type not in ("linux", "windows"):
+    if os_type not in ("linux", "windows", "ubuntu2404"):
         print(
-            f"ERROR: Invalid OS '{os_type}', must be 'linux' or 'windows'",
+            f"ERROR: Invalid OS '{os_type}', must be 'linux', 'windows' or 'ubuntu2404'",
             file=sys.stderr,
         )
         return 1

--- a/.buildkite/steps/goss-sync-check.sh
+++ b/.buildkite/steps/goss-sync-check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "--- Installing PyYAML"
+python3.12 -m pip install -q pyyaml
+
+echo "--- Checking goss.yaml / goss.ubuntu2404.yaml sync"
+python3.12 .buildkite/scripts/check-goss-sync.py

--- a/.buildkite/steps/launch.sh
+++ b/.buildkite/steps/launch.sh
@@ -6,6 +6,17 @@ arch="${2:-amd64}"
 stack_name="buildkite-aws-stack-test-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
 stack_queue_name="testqueue-${os}-${arch}-${BUILDKITE_BUILD_NUMBER}"
 
+# The "os" argument may select a Linux distro (e.g. ubuntu2404); map it to the
+# CloudFormation InstanceOperatingSystem + LinuxDistribution parameters.
+instance_os="$os"
+linux_distribution="amazonlinux2023"
+case "$os" in
+ubuntu2404)
+  instance_os="linux"
+  linux_distribution="ubuntu2404"
+  ;;
+esac
+
 # download parfait binary
 wget -N https://github.com/lox/parfait/releases/download/v1.1.3/parfait_linux_amd64
 mv parfait_linux_amd64 parfait
@@ -61,7 +72,11 @@ cat <<EOF >config.json
   },
   {
     "ParameterKey": "InstanceOperatingSystem",
-    "ParameterValue": "${os}"
+    "ParameterValue": "${instance_os}"
+  },
+  {
+    "ParameterKey": "LinuxDistribution",
+    "ParameterValue": "${linux_distribution}"
   },
   {
     "ParameterKey": "VpcId",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 * Public API: add `NestedVirtualizationEnabled` stack parameter for `c8i`, `m8i`, `r8i`, and their flex variants
+* Public API: add `LinuxDistribution` stack parameter to select the Linux base OS (`amazonlinux2023` default, or `ubuntu2404`)
 
 ## [v6.66.2](https://github.com/buildkite/elastic-ci-stack-for-aws/tree/v6.66.2) (2026-06-05)
 [Full Changelog](https://github.com/buildkite/elastic-ci-stack-for-aws/compare/v6.66.1...v6.66.2)

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ VERSION = $(shell git describe --tags --candidates=1)
 SHELL = /bin/bash -o pipefail
 
 PACKER_VERSION ?= 1.11.2
-PACKER_LINUX_BASE_FILES = $(exec find packer/linux/base)
-PACKER_LINUX_STACK_FILES = $(exec find packer/linux/stack)
-PACKER_WINDOWS_BASE_FILES = $(exec find packer/windows/base)
-PACKER_WINDOWS_STACK_FILES = $(exec find packer/windows/stack)
+PACKER_LINUX_BASE_FILES = $(shell find packer/linux/base packer/linux/shared)
+PACKER_LINUX_STACK_FILES = $(shell find packer/linux/stack packer/linux/shared)
+PACKER_WINDOWS_BASE_FILES = $(shell find packer/windows/base)
+PACKER_WINDOWS_STACK_FILES = $(shell find packer/windows/stack)
 
 # Allow passing an existing golden base AMI into packer via `BASE_AMI_ID` env var
 override BASE_AMI_ID ?=
@@ -29,7 +29,7 @@ BASE_AMI_ID_WINDOWS_AMD64 ?= $(call base_ami_from_output,packer-base-windows-amd
 
 GO_VERSION ?= 1.26.1
 
-FIXPERMS_FILES = go.mod go.sum $(exec find internal/fixperms)
+FIXPERMS_FILES = go.mod go.sum $(shell find internal/fixperms)
 
 # goss is pinned to a commit (see versions.sh) until the upstream fix is
 # released. Read the pin from versions.sh.

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ base_ami_from_output = $(shell \
 
 BASE_AMI_ID_LINUX_AMD64 ?= $(call base_ami_from_output,packer-base-linux-amd64.output)
 BASE_AMI_ID_LINUX_ARM64 ?= $(call base_ami_from_output,packer-base-linux-arm64.output)
+BASE_AMI_ID_UBUNTU2404_AMD64 ?= $(call base_ami_from_output,packer-base-ubuntu2404-amd64.output)
+BASE_AMI_ID_UBUNTU2404_ARM64 ?= $(call base_ami_from_output,packer-base-ubuntu2404-arm64.output)
 BASE_AMI_ID_WINDOWS_AMD64 ?= $(call base_ami_from_output,packer-base-windows-amd64.output)
 
 GO_VERSION ?= 1.26.1
@@ -77,19 +79,31 @@ build: packer build/mappings.yml build/aws-stack.yml
 # Build a mapping file for a single region and image id pair
 mappings-for-linux-amd64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: %s, linuxarm64: '', windows: '' }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: %s, linuxarm64: '', windows: '', ubuntu2404amd64: '', ubuntu2404arm64: '' }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Build a mapping file for a single region and image id pair
 mappings-for-linux-arm64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: %s, windows: '' }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: %s, windows: '', ubuntu2404amd64: '', ubuntu2404arm64: '' }\n" \
+		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
+
+# Build an ubuntu2404 mapping file for a single region and image id pair
+mappings-for-ubuntu2404-amd64-image: env-AWS_REGION env-IMAGE_ID
+	mkdir -p build/
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: '', windows: '', ubuntu2404amd64: %s, ubuntu2404arm64: '' }\n" \
+		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
+
+# Build an ubuntu2404 mapping file for a single region and image id pair
+mappings-for-ubuntu2404-arm64-image: env-AWS_REGION env-IMAGE_ID
+	mkdir -p build/
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: '', windows: '', ubuntu2404amd64: '', ubuntu2404arm64: %s }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Build a windows mapping file for a single region and image id pair
 mappings-for-windows-amd64-image: env-AWS_REGION env-IMAGE_ID
 	mkdir -p build/
-	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: '', windows: %s }\n" \
+	printf "Mappings:\n  AWSRegion2AMI:\n    %s: { linuxamd64: '', linuxarm64: '', windows: %s, ubuntu2404amd64: '', ubuntu2404arm64: '' }\n" \
 		"$(AWS_REGION)" $(IMAGE_ID) > build/mappings.yml
 
 # Takes the mappings files and copies them into a generated stack template
@@ -108,15 +122,15 @@ build/aws-stack.yml:
 
 
 # Full images depend on base images when available
-packer: packer-base-linux-amd64.output packer-base-linux-arm64.output packer-base-windows-amd64.output packer-linux-amd64.output packer-linux-arm64.output packer-windows-amd64.output
+packer: packer-base-linux-amd64.output packer-base-linux-arm64.output packer-base-ubuntu2404-amd64.output packer-base-ubuntu2404-arm64.output packer-base-windows-amd64.output packer-linux-amd64.output packer-linux-arm64.output packer-ubuntu2404-amd64.output packer-ubuntu2404-arm64.output packer-windows-amd64.output
 
 packer-fmt:
 	docker run --rm -v "$(PWD):/src" -w /src "hashicorp/packer:full-$(PACKER_VERSION)" fmt -check -recursive packer/
 
-build/mappings.yml: build/linux-amd64-ami.txt build/linux-arm64-ami.txt build/windows-amd64-ami.txt
+build/mappings.yml: build/linux-amd64-ami.txt build/linux-arm64-ami.txt build/windows-amd64-ami.txt build/ubuntu2404-amd64-ami.txt build/ubuntu2404-arm64-ami.txt
 	mkdir -p build
-	printf "Mappings:\n  AWSRegion2AMI:\n    %q : { linuxamd64: %q, linuxarm64: %q, windows: %q }\n" \
-		"$(AWS_REGION)" $$(cat build/linux-amd64-ami.txt) $$(cat build/linux-arm64-ami.txt) $$(cat build/windows-amd64-ami.txt) > $@
+	printf "Mappings:\n  AWSRegion2AMI:\n    %q : { linuxamd64: %q, linuxarm64: %q, windows: %q, ubuntu2404amd64: %q, ubuntu2404arm64: %q }\n" \
+		"$(AWS_REGION)" $$(cat build/linux-amd64-ami.txt) $$(cat build/linux-arm64-ami.txt) $$(cat build/windows-amd64-ami.txt) $$(cat build/ubuntu2404-amd64-ami.txt) $$(cat build/ubuntu2404-arm64-ami.txt) > $@
 
 build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
 	mkdir -p build
@@ -188,6 +202,68 @@ build/windows-amd64-ami.txt: packer-windows-amd64.output env-AWS_REGION
 	mkdir -p build
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
+build/ubuntu2404-amd64-ami.txt: packer-ubuntu2404-amd64.output env-AWS_REGION
+	mkdir -p build
+	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
+
+# Build ubuntu2404 amd64 packer image (reuses packer/linux/stack via os_distro)
+packer-ubuntu2404-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 packer-base-ubuntu2404-amd64.output
+	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
+	docker run \
+		-e AWS_DEFAULT_REGION  \
+		-e AWS_PROFILE \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e PACKER_LOG \
+		-v ${HOME}/.aws:/root/.aws \
+		-v "$(PWD):/src" \
+		--rm \
+		-w /src/packer/linux/stack \
+		hashicorp/packer:full-$(PACKER_VERSION) build -timestamp-ui \
+			-var 'region=$(AWS_REGION)' \
+			-var 'arch=x86_64' \
+			-var 'os_distro=ubuntu2404' \
+			-var 'instance_type=$(AMD64_INSTANCE_TYPE)' \
+			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
+			-var 'is_released=$(IS_RELEASED)' \
+			-var 'agent_version=$(CURRENT_AGENT_VERSION_LINUX)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
+			-var 'base_ami_id=$(if $(BASE_AMI_ID),$(BASE_AMI_ID),$(BASE_AMI_ID_UBUNTU2404_AMD64))' \
+			buildkite-ami.pkr.hcl | tee $@
+
+build/ubuntu2404-arm64-ami.txt: packer-ubuntu2404-arm64.output env-AWS_REGION
+	mkdir -p build
+	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
+
+# Build ubuntu2404 arm64 packer image (reuses packer/linux/stack via os_distro)
+packer-ubuntu2404-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 packer-base-ubuntu2404-arm64.output
+	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
+	docker run \
+		-e AWS_DEFAULT_REGION  \
+		-e AWS_PROFILE \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e PACKER_LOG \
+		-v ${HOME}/.aws:/root/.aws \
+		-v "$(PWD):/src" \
+		--rm \
+		-w /src/packer/linux/stack \
+		hashicorp/packer:full-$(PACKER_VERSION) build -timestamp-ui \
+			-var 'region=$(AWS_REGION)' \
+			-var 'arch=arm64' \
+			-var 'os_distro=ubuntu2404' \
+			-var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
+			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
+			-var 'is_released=$(IS_RELEASED)' \
+			-var 'agent_version=$(CURRENT_AGENT_VERSION_LINUX)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
+			-var 'base_ami_id=$(if $(BASE_AMI_ID),$(BASE_AMI_ID),$(BASE_AMI_ID_UBUNTU2404_ARM64))' \
+			buildkite-ami.pkr.hcl | tee $@
+
 # Build windows packer image
 packer-windows-amd64.output: $(PACKER_WINDOWS_STACK_FILES) packer-base-windows-amd64.output
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_WINDOWS)
@@ -256,6 +332,54 @@ packer-base-linux-arm64.output: $(PACKER_LINUX_BASE_FILES)
 		hashicorp/packer:full-$(PACKER_VERSION) build -timestamp-ui \
 			-var 'region=$(AWS_REGION)' \
 			-var 'arch=arm64' \
+			-var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
+			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
+			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
+			base.pkr.hcl | tee $@
+
+# Build base AMI for ubuntu2404 amd64 (reuses packer/linux/base via os_distro)
+packer-base-ubuntu2404-amd64.output: $(PACKER_LINUX_BASE_FILES)
+	docker run \
+		-e AWS_DEFAULT_REGION  \
+		-e AWS_PROFILE \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e PACKER_LOG \
+		-v ${HOME}/.aws:/root/.aws \
+		-v "$(PWD):/src" \
+		--rm \
+		-w /src/packer/linux/base \
+		hashicorp/packer:full-$(PACKER_VERSION) build -timestamp-ui \
+			-var 'region=$(AWS_REGION)' \
+			-var 'arch=x86_64' \
+			-var 'os_distro=ubuntu2404' \
+			-var 'instance_type=$(AMD64_INSTANCE_TYPE)' \
+			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
+			-var 'is_released=$(IS_RELEASED)' \
+			-var 'ami_public=$(AMI_PUBLIC)' \
+			-var 'ami_users=$(AMI_USERS_LIST)' \
+			base.pkr.hcl | tee $@
+
+# Build base AMI for ubuntu2404 arm64 (reuses packer/linux/base via os_distro)
+packer-base-ubuntu2404-arm64.output: $(PACKER_LINUX_BASE_FILES)
+	docker run \
+		-e AWS_DEFAULT_REGION  \
+		-e AWS_PROFILE \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_SESSION_TOKEN \
+		-e PACKER_LOG \
+		-v ${HOME}/.aws:/root/.aws \
+		-v "$(PWD):/src" \
+		--rm \
+		-w /src/packer/linux/base \
+		hashicorp/packer:full-$(PACKER_VERSION) build -timestamp-ui \
+			-var 'region=$(AWS_REGION)' \
+			-var 'arch=arm64' \
+			-var 'os_distro=ubuntu2404' \
 			-var 'instance_type=$(ARM64_INSTANCE_TYPE)' \
 			-var 'build_number=$(BUILDKITE_BUILD_NUMBER)' \
 			-var 'is_released=$(IS_RELEASED)' \

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ build/ubuntu2404-amd64-ami.txt: packer-ubuntu2404-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build ubuntu2404 amd64 packer image (reuses packer/linux/stack via os_distro)
-packer-ubuntu2404-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 packer-base-ubuntu2404-amd64.output
+packer-ubuntu2404-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 $(if $(strip $(BASE_AMI_ID)),,packer-base-ubuntu2404-amd64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
@@ -242,7 +242,7 @@ build/ubuntu2404-arm64-ami.txt: packer-ubuntu2404-arm64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build ubuntu2404 arm64 packer image (reuses packer/linux/stack via os_distro)
-packer-ubuntu2404-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 packer-base-ubuntu2404-arm64.output
+packer-ubuntu2404-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 $(if $(strip $(BASE_AMI_ID)),,packer-base-ubuntu2404-arm64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \

--- a/README.md
+++ b/README.md
@@ -202,9 +202,11 @@ This will create AMIs for the following platforms in your account's `us-east-1` 
 
 - Linux (64-bit x86)
 - Linux (64-bit Arm)
+- Ubuntu (64-bit x86)
+- Ubuntu (64-bit Arm)
 - Windows (64-bit x86)
 
-If you only need Linux AMIs, invoke the specific targets to skip the Windows build:
+If you only need a subset, invoke the specific targets to skip the rest:
 
 ```bash
 # Linux amd64 (x86_64)
@@ -216,6 +218,12 @@ make packer-base-linux-arm64.output packer-linux-arm64.output
 # Both Linux architectures
 make packer-base-linux-amd64.output packer-linux-amd64.output \
      packer-base-linux-arm64.output packer-linux-arm64.output
+
+# Ubuntu amd64 (x86_64)
+make packer-base-ubuntu2404-amd64.output packer-ubuntu2404-amd64.output
+
+# Ubuntu arm64
+make packer-base-ubuntu2404-arm64.output packer-ubuntu2404-arm64.output
 ```
 
 **Security Note:** Making AMIs public (`AMI_PUBLIC=true`) can expose any secrets accidentally baked into the image. The default private setting helps prevent accidental exposure of sensitive information.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,12 @@ Buildkite builds and deploys the following AMIs to all our supported regions:
 
 - Amazon Linux 2023 (64-bit x86)
 - Amazon Linux 2023 (64-bit Arm)
+- Ubuntu 24.04 LTS (64-bit x86)
+- Ubuntu 24.04 LTS (64-bit Arm)
 - Windows Server 2022 (64-bit x86)
+
+Amazon Linux 2023 is the default for Linux instances. To run Ubuntu 24.04 LTS
+instead, set the `LinuxDistribution` parameter to `ubuntu2404`.
 
 ### Buildkite Agent
 

--- a/goss.ubuntu2404.yaml
+++ b/goss.ubuntu2404.yaml
@@ -138,6 +138,9 @@ command:
   git-lfs --version:
     exit-status: 0
 
+  session-manager-plugin --version:
+    exit-status: 0
+
   command -v lsof:
     exit-status: 0
 

--- a/goss.ubuntu2404.yaml
+++ b/goss.ubuntu2404.yaml
@@ -2,7 +2,8 @@
 # Keep in sync with goss.yaml. Intentional differences from the AL2023 file:
 #   - login user home is /home/ubuntu (not /home/ec2-user)
 #   - amazon-ssm-agent runs as a snap (snap.amazon-ssm-agent.amazon-ssm-agent)
-#   - the sshd privsep user/group are not the RHEL uid/gid 74
+#   - OpenSSH is socket-activated (ssh.socket): no persistent sshd process, no
+#     sshd.service and no sshd group; only the sshd privsep user exists
 #   - the docker group gid is not constrained to the AL2023 990-995 range
 file:
   /etc/buildkite-agent/buildkite-agent.cfg:
@@ -72,10 +73,6 @@ service:
     enabled: true
     running: true
 
-  sshd:
-    enabled: true
-    running: true
-
   buildkite-agent:
     enabled: true
     running: true
@@ -102,9 +99,6 @@ group:
   docker:
     exists: true
 
-  sshd:
-    exists: true
-
 process:
   buildkite-agent:
     running: true
@@ -112,10 +106,16 @@ process:
   lifecycled:
     running: true
 
-  sshd:
-    running: true
-
 command:
+  # Ubuntu 24.04 ships OpenSSH as a socket-activated unit (ssh.socket); there is
+  # no persistent sshd process and no sshd.service like on Amazon Linux. Assert
+  # the socket is enabled at boot and active (the port 22 checks cover reach).
+  systemctl is-enabled ssh.socket:
+    exit-status: 0
+
+  systemctl is-active ssh.socket:
+    exit-status: 0
+
   aws --version:
     exit-status: 0
 

--- a/goss.ubuntu2404.yaml
+++ b/goss.ubuntu2404.yaml
@@ -116,6 +116,13 @@ command:
   systemctl is-active ssh.socket:
     exit-status: 0
 
+  # /tmp is a tmpfs by default: tmp.mount is enabled at build time (mirroring
+  # AL2023), and MountTmpfsAtTmp defaults to true.
+  findmnt --noheadings --output FSTYPE /tmp:
+    exit-status: 0
+    stdout:
+    - tmpfs
+
   aws --version:
     exit-status: 0
 

--- a/goss.ubuntu2404.yaml
+++ b/goss.ubuntu2404.yaml
@@ -1,0 +1,214 @@
+# Ubuntu 24.04 variant of goss.yaml, used by the ubuntu2404 test steps.
+# Keep in sync with goss.yaml. Intentional differences from the AL2023 file:
+#   - login user home is /home/ubuntu (not /home/ec2-user)
+#   - amazon-ssm-agent runs as a snap (snap.amazon-ssm-agent.amazon-ssm-agent)
+#   - the sshd privsep user/group are not the RHEL uid/gid 74
+#   - the docker group gid is not constrained to the AL2023 990-995 range
+file:
+  /etc/buildkite-agent/buildkite-agent.cfg:
+    exists: true
+
+  /etc/buildkite-agent/hooks:
+    filetype: directory
+    exists: true
+    owner: buildkite-agent
+    group: buildkite-agent
+
+  /etc/systemd/system/refresh_authorized_keys.service:
+    exists: true
+
+  /etc/systemd/system/refresh_authorized_keys.timer:
+    exists: true
+
+  /home/ubuntu/.ssh/authorized_keys:
+    exists: true
+    contains: ["!packer"]
+
+  /root/.ssh/authorized_keys:
+    exists: true
+    contains: ["!packer"]
+
+  /var/lib/buildkite-agent/builds:
+    filetype: directory
+    exists: true
+    owner: buildkite-agent
+    group: buildkite-agent
+
+  /var/lib/buildkite-agent/plugins:
+    filetype: directory
+    exists: true
+    owner: buildkite-agent
+    group: buildkite-agent
+
+  /usr/local/bin/stop-agent-gracefully:
+    exists: true
+    mode: "0755"
+
+port:
+  tcp:22:
+    listening: true
+    ip:
+    - 0.0.0.0
+
+  tcp6:22:
+    listening: true
+    ip:
+    - "::"
+
+service:
+  amazon-cloudwatch-agent:
+    enabled: true
+    running: true
+
+  snap.amazon-ssm-agent.amazon-ssm-agent:
+    enabled: true
+    running: true
+
+  docker:
+    enabled: true
+    running: true
+
+  lifecycled:
+    enabled: true
+    running: true
+
+  sshd:
+    enabled: true
+    running: true
+
+  buildkite-agent:
+    enabled: true
+    running: true
+
+user:
+  buildkite-agent:
+    exists: true
+    uid: 2000
+    gid: 2000
+    groups:
+    - buildkite-agent
+    - docker
+    home: /var/lib/buildkite-agent
+    shell: /bin/bash
+
+  sshd:
+    exists: true
+
+group:
+  buildkite-agent:
+    exists: true
+    gid: 2000
+
+  docker:
+    exists: true
+
+  sshd:
+    exists: true
+
+process:
+  buildkite-agent:
+    running: true
+
+  lifecycled:
+    running: true
+
+  sshd:
+    running: true
+
+command:
+  aws --version:
+    exit-status: 0
+
+  curl --version:
+    exit-status: 0
+
+  dig -h:
+    exit-status: 0
+
+  git --version:
+    exit-status: 0
+
+  git-lfs --version:
+    exit-status: 0
+
+  command -v lsof:
+    exit-status: 0
+
+  make --version:
+    exit-status: 0
+
+  wget --version:
+    exit-status: 0
+
+  # Check refresh authorized keys gear is present, but disabled.
+  # disabled: The unit file is not enabled, but contains an [Install] section with installation instructions.
+  systemctl is-enabled refresh_authorized_keys.timer:
+    exit-status: 1
+    stdout:
+    - /disabled/
+
+  systemctl is-enabled proc-sys-fs-binfmt_misc.mount:
+    exit-status: 0
+
+  systemctl is-enabled docker-binfmt.service:
+    exit-status: 0
+
+  systemctl is-enabled docker-gc.timer:
+    exit-status: 0
+
+  /usr/local/bin/docker-gc:
+    exit-status: 0
+
+  systemctl is-enabled docker-low-disk-gc.timer:
+    exit-status: 0
+
+  /usr/local/bin/docker-low-disk-gc:
+    exit-status: 0
+
+  # test that we can build a docker image
+  docker buildx build -f tests/Dockerfile --progress=plain -t buildkite-postgres:latest tests:
+    exit-status: 0
+    timeout: 60000
+
+  # Check docker userns is enabled
+  # Note that goss will evaluate the outer layer of templating, and docker will evaluate the second
+  # Running `goss validate --format documentation` will print this with the first layer of templating evaluated
+  '{{ `docker info --format=",{{range .SecurityOptions}}{{.}},{{end}}"` }}':
+    exit-status: 0
+    timeout: 30000
+    stdout:
+    - /,name=userns,/
+
+  # Check docker plugins are installed
+  # Note that goss will evaluate the first layer of templating, and docker will evaluate the second
+  # Running `goss validate --format documentation` will print this with the first layer of templating evaluated
+  '{{ `docker info --format=",{{range .ClientInfo.Plugins}}{{.Name}},{{end}}"` }}':
+    exit-status: 0
+    timeout: 30000
+    stdout:
+    - /,buildx,/
+    - /,compose,/
+
+  # Check that docker containers can run
+  docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker:latest version:
+    exit-status: 0
+    timeout: 60000
+
+  # Check that userns allows writing as buildkite-agent
+  sh -c 'docker run --rm -v "$PWD:/pwd" alpine:latest touch /pwd/test && stat -c %U:%G test' && rm test:
+    exit-status: 0
+    timeout: 30000
+    stdout:
+    - buildkite-agent:docker
+
+  docker run --rm --platform linux/arm64 -t arm64v8/ubuntu uname -m:
+    exit-status: 0
+    timeout: 30000
+    stdout:
+    - aarch64
+
+  docker run --rm --platform linux/amd64 -t amd64/ubuntu uname -m:
+    exit-status: 0
+    timeout: 30000
+    stdout:
+    - x86_64

--- a/packer/linux/base/base.pkr.hcl
+++ b/packer/linux/base/base.pkr.hcl
@@ -12,6 +12,12 @@ variable "arch" {
   default = "x86_64"
 }
 
+variable "os_distro" {
+  type        = string
+  description = "Base Linux distribution to build on: amazonlinux2023 or ubuntu2404."
+  default     = "amazonlinux2023"
+}
+
 variable "instance_type" {
   type    = string
   default = "m7a.xlarge"
@@ -56,21 +62,54 @@ data "amazon-ami" "al2023" {
   region      = var.region
 }
 
+# Latest Ubuntu 24.04 (Noble) image for the given arch. Ubuntu AMI names use
+# amd64/arm64 whereas var.arch is x86_64/arm64. Owner 099720109477 is Canonical.
+data "amazon-ami" "ubuntu" {
+  filters = {
+    architecture        = var.arch
+    name                = "ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-${var.arch == "x86_64" ? "amd64" : "arm64"}-server-*"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["099720109477"]
+  region      = var.region
+}
+
+locals {
+  os_distro_name = {
+    amazonlinux2023 = "Amazon Linux 2023"
+    ubuntu2404      = "Ubuntu 24.04"
+  }
+  source_ami = {
+    amazonlinux2023 = data.amazon-ami.al2023.id
+    ubuntu2404      = data.amazon-ami.ubuntu.id
+  }
+  ssh_username = {
+    amazonlinux2023 = "ec2-user"
+    ubuntu2404      = "ubuntu"
+  }
+  # Ubuntu root volume is /dev/sda1; AL2023 is /dev/xvda
+  root_device_name = {
+    amazonlinux2023 = "/dev/xvda"
+    ubuntu2404      = "/dev/sda1"
+  }
+}
+
 source "amazon-ebs" "buildkite-base-ami" {
-  ami_description                           = "Buildkite Golden Base (Amazon Linux 2023 w/ docker)"
+  ami_description                           = "Buildkite Golden Base (${local.os_distro_name[var.os_distro]} w/ docker)"
   ami_groups                                = var.ami_public ? ["all"] : []
   ami_users                                 = var.ami_public ? [] : var.ami_users
-  ami_name                                  = "buildkite-base-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
+  ami_name                                  = "buildkite-base-linux-${var.os_distro}-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region
-  source_ami                                = data.amazon-ami.al2023.id
-  ssh_username                              = "ec2-user"
+  source_ami                                = local.source_ami[var.os_distro]
+  ssh_username                              = local.ssh_username[var.os_distro]
   ssh_clear_authorized_keys                 = true
   temporary_security_group_source_public_ip = true
 
   launch_block_device_mappings {
     volume_type           = "gp3"
-    device_name           = "/dev/xvda"
+    device_name           = local.root_device_name[var.os_distro]
     volume_size           = 10
     delete_on_termination = true
   }
@@ -82,11 +121,12 @@ source "amazon-ebs" "buildkite-base-ami" {
   imds_support = "v2.0"
 
   tags = {
-    Name        = "buildkite-base-linux-${var.arch}"
-    OSVersion   = "Amazon Linux 2023"
+    Name        = "buildkite-base-linux-${var.os_distro}-${var.arch}"
+    OSVersion   = local.os_distro_name[var.os_distro]
+    Distro      = var.os_distro
     BuildNumber = var.build_number
     IsReleased  = var.is_released
-    SourceAMIID = data.amazon-ami.al2023.id
+    SourceAMIID = local.source_ami[var.os_distro]
     Component   = "buildkite-base"
   }
 }
@@ -109,28 +149,38 @@ build {
     source      = "scripts/versions.sh"
   }
 
+  provisioner "file" {
+    destination = "/tmp/"
+    source      = "../shared/scripts/distro.sh"
+  }
+
   # Essential utilities & updates
   provisioner "shell" {
-    script = "scripts/install-utils.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/install-utils.sh"
   }
 
   # Docker engine
   provisioner "shell" {
-    script = "scripts/install-docker.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/install-docker.sh"
   }
 
   # CloudWatch agent
   provisioner "shell" {
-    script = "scripts/install-cloudwatch-agent.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/install-cloudwatch-agent.sh"
   }
 
   # Session Manager plugin
   provisioner "shell" {
-    script = "scripts/install-session-manager-plugin.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/install-session-manager-plugin.sh"
   }
 
   # Clean up
   provisioner "shell" {
-    script = "../shared/scripts/cleanup.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "../shared/scripts/cleanup.sh"
   }
 }

--- a/packer/linux/base/scripts/install-cloudwatch-agent.sh
+++ b/packer/linux/base/scripts/install-cloudwatch-agent.sh
@@ -1,7 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck disable=SC1091
+source "/tmp/distro.sh"
+
 echo "Installing cloudwatch agent..."
-sudo dnf install -yq amazon-cloudwatch-agent
+case "${OS_DISTRO}" in
+amazonlinux2023)
+  pkg_install amazon-cloudwatch-agent
+  ;;
+ubuntu2404)
+  # The agent is not in Ubuntu's apt repos; fetch the .deb published by Amazon.
+  case "$(uname -m)" in
+  x86_64) CW_ARCH=amd64 ;;
+  aarch64) CW_ARCH=arm64 ;;
+  *)
+    echo "Unsupported architecture for amazon-cloudwatch-agent" >&2
+    exit 1
+    ;;
+  esac
+  pushd "$(mktemp -d)"
+  curl -sSL "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb" -o amazon-cloudwatch-agent.deb
+  pkg_install_local ./amazon-cloudwatch-agent.deb
+  popd
+  ;;
+esac
 
 echo "CloudWatch agent installed. Configuration will be done in stack layer."

--- a/packer/linux/base/scripts/install-cloudwatch-agent.sh
+++ b/packer/linux/base/scripts/install-cloudwatch-agent.sh
@@ -10,7 +10,8 @@ amazonlinux2023)
   pkg_install amazon-cloudwatch-agent
   ;;
 ubuntu2404)
-  # The agent is not in Ubuntu's apt repos; fetch the .deb published by Amazon.
+  # The agent is not in Ubuntu's apt repos; fetch the .deb published by Amazon
+  # and verify its GPG signature before installing.
   case "$(uname -m)" in
   x86_64) CW_ARCH=amd64 ;;
   aarch64) CW_ARCH=arm64 ;;
@@ -19,10 +20,41 @@ ubuntu2404)
     exit 1
     ;;
   esac
-  pushd "$(mktemp -d)"
-  curl -sSL "https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb" -o amazon-cloudwatch-agent.deb
+
+  # AWS's documented signing key fingerprint for the CloudWatch agent, pinned as
+  # the trust anchor: the key fetched below must match it, so a tampered bucket
+  # cannot substitute a different key. AWS signs every agent version with this
+  # key, so it does not change between releases; a key rotation fails here loudly.
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/verify-CloudWatch-Agent-Package-Signature.html
+  CW_KEY_FINGERPRINT="937616F3450B7D806CBD9725D58167303B789C72"
+  CW_BASE="https://amazoncloudwatch-agent.s3.amazonaws.com"
+
+  workdir="$(mktemp -d)"
+  pushd "$workdir"
+
+  curl -fsSL "${CW_BASE}/assets/amazon-cloudwatch-agent.gpg" -o amazon-cloudwatch-agent.gpg
+  curl -fsSL "${CW_BASE}/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb" -o amazon-cloudwatch-agent.deb
+  curl -fsSL "${CW_BASE}/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb.sig" -o amazon-cloudwatch-agent.deb.sig
+
+  # Import the key into an isolated keyring and confirm its fingerprint before
+  # trusting it to verify the package signature.
+  export GNUPGHOME="${workdir}/gnupg"
+  mkdir -p "$GNUPGHOME"
+  chmod 700 "$GNUPGHOME"
+  gpg --batch --import amazon-cloudwatch-agent.gpg
+  if ! gpg --batch --with-colons --fingerprint \
+    | awk -F: '/^fpr:/ { print $10 }' \
+    | grep -qx "$CW_KEY_FINGERPRINT"; then
+    echo "CloudWatch agent GPG key fingerprint mismatch; refusing to install" >&2
+    exit 1
+  fi
+  gpg --batch --verify amazon-cloudwatch-agent.deb.sig amazon-cloudwatch-agent.deb
+
   pkg_install_local ./amazon-cloudwatch-agent.deb
+
   popd
+  unset GNUPGHOME
+  rm -rf "$workdir"
   ;;
 esac
 

--- a/packer/linux/base/scripts/install-cloudwatch-agent.sh
+++ b/packer/linux/base/scripts/install-cloudwatch-agent.sh
@@ -33,8 +33,6 @@ ubuntu2404)
   pushd "$workdir"
 
   curl -fsSL "${CW_BASE}/assets/amazon-cloudwatch-agent.gpg" -o amazon-cloudwatch-agent.gpg
-  curl -fsSL "${CW_BASE}/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb" -o amazon-cloudwatch-agent.deb
-  curl -fsSL "${CW_BASE}/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb.sig" -o amazon-cloudwatch-agent.deb.sig
 
   # Import the key into an isolated keyring and confirm its fingerprint before
   # trusting it to verify the package signature.
@@ -48,7 +46,24 @@ ubuntu2404)
     echo "CloudWatch agent GPG key fingerprint mismatch; refusing to install" >&2
     exit 1
   fi
-  gpg --batch --verify amazon-cloudwatch-agent.deb.sig amazon-cloudwatch-agent.deb
+
+  # .deb and .deb.sig are fetched from unversioned latest/ paths in separate
+  # requests, so a release rotating between them leaves a mismatched pair.
+  # Re-fetch both together and retry verification a few times to self-heal.
+  cw_verified=false
+  for attempt in 1 2 3; do
+    curl -fsSL "${CW_BASE}/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb" -o amazon-cloudwatch-agent.deb
+    curl -fsSL "${CW_BASE}/ubuntu/${CW_ARCH}/latest/amazon-cloudwatch-agent.deb.sig" -o amazon-cloudwatch-agent.deb.sig
+    if gpg --batch --verify amazon-cloudwatch-agent.deb.sig amazon-cloudwatch-agent.deb; then
+      cw_verified=true
+      break
+    fi
+    echo "CloudWatch agent .deb/.sig verification failed on attempt ${attempt}/3; latest/ may have rotated mid-fetch, retrying..." >&2
+  done
+  if [ "$cw_verified" != true ]; then
+    echo "CloudWatch agent signature verification failed after 3 attempts; refusing to install" >&2
+    exit 1
+  fi
 
   pkg_install_local ./amazon-cloudwatch-agent.deb
 

--- a/packer/linux/base/scripts/install-docker.sh
+++ b/packer/linux/base/scripts/install-docker.sh
@@ -4,14 +4,24 @@ set -euo pipefail
 # Source centralized version definitions
 # shellcheck disable=SC1091
 source "/tmp/versions.sh"
+# shellcheck disable=SC1091
+source "/tmp/distro.sh"
 MACHINE=$(uname -m)
 
 echo Installing docker...
-sudo dnf install -yq docker
+case "${OS_DISTRO}" in
+amazonlinux2023)
+  pkg_install docker
+  ;;
+ubuntu2404)
+  # docker.io is Ubuntu's packaged engine; buildx/compose plugins are added below.
+  pkg_install docker.io
+  ;;
+esac
 sudo systemctl enable --now docker
 
-echo Add ec2-user to docker group.
-sudo usermod -a -G docker ec2-user
+echo "Add ${LOGIN_USER} to docker group."
+sudo usermod -a -G docker "${LOGIN_USER}"
 
 echo Add docker config
 sudo mkdir -p /etc/docker
@@ -61,4 +71,4 @@ echo "show docker-binfmt status..."
 systemctl status docker-binfmt.service
 
 echo "Installing Amazon ECR credential helper..."
-sudo dnf install -y amazon-ecr-credential-helper
+pkg_install amazon-ecr-credential-helper

--- a/packer/linux/base/scripts/install-session-manager-plugin.sh
+++ b/packer/linux/base/scripts/install-session-manager-plugin.sh
@@ -4,6 +4,8 @@ set -eu -o pipefail
 # Source centralized version definitions
 # shellcheck disable=SC1091
 source "/tmp/versions.sh"
+# shellcheck disable=SC1091
+source "/tmp/distro.sh"
 
 MACHINE="$(uname -m)"
 
@@ -15,4 +17,15 @@ esac
 
 echo "Installing session-manager-plugin ${SESSION_MANAGER_PLUGIN_VERSION}..."
 
-sudo dnf install -y "https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}/linux_${ARCH}/session-manager-plugin.rpm"
+BASE_URL="https://s3.amazonaws.com/session-manager-downloads/plugin/${SESSION_MANAGER_PLUGIN_VERSION}"
+case "${OS_DISTRO}" in
+amazonlinux2023)
+  pkg_install_local "${BASE_URL}/linux_${ARCH}/session-manager-plugin.rpm"
+  ;;
+ubuntu2404)
+  pushd "$(mktemp -d)"
+  curl -sSL "${BASE_URL}/ubuntu_${ARCH}/session-manager-plugin.deb" -o session-manager-plugin.deb
+  pkg_install_local ./session-manager-plugin.deb
+  popd
+  ;;
+esac

--- a/packer/linux/base/scripts/install-session-manager-plugin.sh
+++ b/packer/linux/base/scripts/install-session-manager-plugin.sh
@@ -24,7 +24,7 @@ amazonlinux2023)
   ;;
 ubuntu2404)
   pushd "$(mktemp -d)"
-  curl -sSL "${BASE_URL}/ubuntu_${ARCH}/session-manager-plugin.deb" -o session-manager-plugin.deb
+  curl -fsSL "${BASE_URL}/ubuntu_${ARCH}/session-manager-plugin.deb" -o session-manager-plugin.deb
   pkg_install_local ./session-manager-plugin.deb
   popd
   ;;

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -82,10 +82,12 @@ ubuntu2404)
   # cfn-signal (the only CFN helper this stack uses) is not packaged for Ubuntu,
   # so install it from Amazon's tarball. Source its Python dependencies from apt
   # rather than letting pip pull them from PyPI unpinned as root: with --no-deps
-  # pip installs only aws-cfn-bootstrap itself. AWS publishes no signature or
-  # versioned URL for the tarball, so the fetch trusts TLS to the AWS-owned
-  # bucket (its documented install method).
-  pkg_install python3-daemon python3-docutils python3-chevron
+  # pip installs only aws-cfn-bootstrap itself. The third declared dep, chevron,
+  # is omitted: it is imported lazily only by cfn-init's template rendering
+  # (never reached by cfn-signal) and is not packaged for Ubuntu 24.04. AWS
+  # publishes no signature or versioned URL for the tarball, so the fetch trusts
+  # TLS to the AWS-owned bucket (its documented install method).
+  pkg_install python3-daemon python3-docutils
   sudo pip3 install --break-system-packages --no-deps \
     https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
   # cfn-hup's init script (init/ubuntu/cfn-hup) is intentionally not symlinked

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 # Source centralized version definitions
 # shellcheck disable=SC1091
 source "/tmp/versions.sh"
+# shellcheck disable=SC1091
+source "/tmp/distro.sh"
 
 case $(uname -m) in
 x86_64) ARCH=amd64 ;;
@@ -13,49 +15,76 @@ aarch64) ARCH=arm64 ;;
 esac
 
 echo Updating core packages
-sudo dnf update -yq
+pkg_update
 
 echo Installing utils...
-sudo dnf install -yq \
-  amazon-ssm-agent \
-  aws-cfn-bootstrap \
-  ec2-instance-connect \
+# Packages available under the same name on both distros
+pkg_install \
   git \
   jq \
+  lsof \
   mdadm \
   nvme-cli \
   pigz \
-  python \
-  python-pip \
-  python-setuptools \
-  python3.11 \
-  python3.11-pip \
-  python3.12 \
-  python3.12-pip \
-  python3.13 \
-  python3.13-pip \
-  python3.14 \
-  python3.14-pip \
+  rsyslog \
   unzip \
   wget \
   zip
 
-# These are some tools that are no longer installed on AL2023 by default
-# there may be more modern replacements for these, so they may dissapper
-# in a future version of Amazon Linux
-sudo dnf install -yq \
-  bind-utils \
-  lsof \
-  rsyslog
+case "${OS_DISTRO}" in
+amazonlinux2023)
+  pkg_install \
+    amazon-ssm-agent \
+    aws-cfn-bootstrap \
+    ec2-instance-connect \
+    bind-utils \
+    python \
+    python-pip \
+    python-setuptools \
+    python3.11 \
+    python3.11-pip \
+    python3.12 \
+    python3.12-pip \
+    python3.13 \
+    python3.13-pip \
+    python3.14 \
+    python3.14-pip
 
-sudo dnf -yq groupinstall "Development Tools"
+  sudo dnf -yq groupinstall "Development Tools"
 
-# Upgrade GPG to full version to support development tools like asdf
-# See https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1402
-echo "Upgrading GPG from minimum to full version..."
-sudo dnf swap -yq gnupg2-minimal gnupg2-full
+  # Upgrade GPG to full version to support development tools like asdf
+  # See https://github.com/buildkite/elastic-ci-stack-for-aws/issues/1402
+  echo "Upgrading GPG from minimum to full version..."
+  sudo dnf swap -yq gnupg2-minimal gnupg2-full
 
-sudo systemctl enable --now amazon-ssm-agent
+  sudo systemctl enable --now amazon-ssm-agent
+  ;;
+ubuntu2404)
+  # Ubuntu ships Python 3.12 natively. The extra 3.11/3.13/3.14 interpreters
+  # available on AL2023 are not packaged here and are intentionally omitted.
+  pkg_install \
+    dnsutils \
+    build-essential \
+    ec2-instance-connect \
+    gnupg \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    snapd
+
+  # amazon-ssm-agent ships as a snap and is preinstalled on Canonical's AWS AMIs
+  if ! snap list amazon-ssm-agent >/dev/null 2>&1; then
+    sudo snap install amazon-ssm-agent
+  fi
+  sudo systemctl enable --now snap.amazon-ssm-agent.amazon-ssm-agent.service
+
+  # cfn-init/cfn-signal are not packaged for Ubuntu; install from Amazon's tarball
+  sudo pip3 install --break-system-packages \
+    https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+  ;;
+esac
+
 sudo systemctl enable --now rsyslog
 
 echo "Installing AWS CLI v2 ${AWS_CLI_LINUX_VERSION}..."

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -79,9 +79,17 @@ ubuntu2404)
   fi
   sudo systemctl enable --now snap.amazon-ssm-agent.amazon-ssm-agent.service
 
-  # cfn-init/cfn-signal are not packaged for Ubuntu; install from Amazon's tarball
-  sudo pip3 install --break-system-packages \
+  # cfn-signal (the only CFN helper this stack uses) is not packaged for Ubuntu,
+  # so install it from Amazon's tarball. Source its Python dependencies from apt
+  # rather than letting pip pull them from PyPI unpinned as root: with --no-deps
+  # pip installs only aws-cfn-bootstrap itself. AWS publishes no signature or
+  # versioned URL for the tarball, so the fetch trusts TLS to the AWS-owned
+  # bucket (its documented install method).
+  pkg_install python3-daemon python3-docutils python3-chevron
+  sudo pip3 install --break-system-packages --no-deps \
     https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
+  # cfn-hup's init script (init/ubuntu/cfn-hup) is intentionally not symlinked
+  # into /etc/init.d: this stack runs cfn-signal only, never cfn-hup.
   ;;
 esac
 

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -92,6 +92,13 @@ ubuntu2404)
     https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
   # cfn-hup's init script (init/ubuntu/cfn-hup) is intentionally not symlinked
   # into /etc/init.d: this stack runs cfn-signal only, never cfn-hup.
+
+  # AL2023 enables systemd's tmp.mount (tmpfs /tmp) by default; Ubuntu ships it
+  # as a static, disabled unit. Enable it so the default MountTmpfsAtTmp=true
+  # gives a tmpfs /tmp (bk-mount-instance-storage.sh masks it when set false).
+  sudo cp /usr/share/systemd/tmp.mount /etc/systemd/system/tmp.mount
+  sudo systemctl daemon-reload
+  sudo systemctl enable tmp.mount
   ;;
 esac
 

--- a/packer/linux/shared/scripts/cleanup.sh
+++ b/packer/linux/shared/scripts/cleanup.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo dnf clean all
+# shellcheck disable=SC1091
+source "/tmp/distro.sh"
+
+pkg_clean

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -44,7 +44,10 @@ ubuntu2404)
     return 1
   }
 
-  pkg_update() { sudo apt-get update -yq; }
+  pkg_update() {
+    sudo apt-get update -yq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -yq
+  }
   pkg_install() { _apt_install "$@"; }
   # apt resolves dependencies for a local .deb path when prefixed with ./
   pkg_install_local() { _apt_install "$@"; }

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Distro abstraction for Linux packer builds.
+# Sourced by install scripts alongside versions.sh. Reads OS_DISTRO (set by the
+# packer shell provisioners) and exposes package-manager verbs and per-distro
+# facts so the shared install logic stays distro-agnostic.
+
+OS_DISTRO="${OS_DISTRO:-amazonlinux2023}"
+export OS_DISTRO
+
+case "${OS_DISTRO}" in
+amazonlinux2023)
+  LOGIN_USER="ec2-user"
+  # rsyslog/RHEL log locations for the CloudWatch agent config
+  CW_SYSLOG_PATH="/var/log/messages"
+  CW_AUTHLOG_PATH="/var/log/secure"
+
+  pkg_update() { sudo dnf update -yq; }
+  pkg_install() { sudo dnf install -yq "$@"; }
+  pkg_install_local() { sudo dnf install -y "$@"; }
+  pkg_clean() { sudo dnf clean all; }
+  ;;
+ubuntu2404)
+  LOGIN_USER="ubuntu"
+  CW_SYSLOG_PATH="/var/log/syslog"
+  CW_AUTHLOG_PATH="/var/log/auth.log"
+
+  pkg_update() { sudo apt-get update -yq; }
+  pkg_install() { sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq "$@"; }
+  # apt resolves dependencies for a local .deb path when prefixed with ./
+  pkg_install_local() { sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq "$@"; }
+  pkg_clean() { sudo apt-get clean; }
+  ;;
+*)
+  echo "Unsupported OS_DISTRO: ${OS_DISTRO}" >&2
+  exit 1
+  ;;
+esac
+
+export LOGIN_USER CW_SYSLOG_PATH CW_AUTHLOG_PATH

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -24,10 +24,30 @@ ubuntu2404)
   CW_SYSLOG_PATH="/var/log/syslog"
   CW_AUTHLOG_PATH="/var/log/auth.log"
 
+  # apt can 404 on a package version when ports.ubuntu.com rotates a security
+  # update between `apt-get update` and the fetch: the index lists a version the
+  # pool has already purged. A plain URL retry cannot help (the file is gone), so
+  # refresh the index (which then lists the version that exists) and retry.
+  _apt_install() {
+    local attempt
+    for attempt in 1 2 3; do
+      if sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq "$@"; then
+        return 0
+      fi
+      if [ "${attempt}" -lt 3 ]; then
+        echo "apt-get install failed (attempt ${attempt}/3); refreshing index and retrying..." >&2
+        sudo apt-get update -yq || true
+        sleep $((attempt * 5))
+      fi
+    done
+    echo "apt-get install failed after 3 attempts" >&2
+    return 1
+  }
+
   pkg_update() { sudo apt-get update -yq; }
-  pkg_install() { sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq "$@"; }
+  pkg_install() { _apt_install "$@"; }
   # apt resolves dependencies for a local .deb path when prefixed with ./
-  pkg_install_local() { sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq "$@"; }
+  pkg_install_local() { _apt_install "$@"; }
   pkg_clean() { sudo apt-get clean; }
   ;;
 *)

--- a/packer/linux/stack/buildkite-ami.pkr.hcl
+++ b/packer/linux/stack/buildkite-ami.pkr.hcl
@@ -97,7 +97,7 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   instance_type                             = var.instance_type
   region                                    = var.region
   source_ami                                = var.base_ami_id
-  ssh_username                              = local.ssh_username[var.os_distro]
+  ssh_username                              = local.is_cis ? "ec2-user" : local.ssh_username[var.os_distro]
   ssh_clear_authorized_keys                 = true
   temporary_security_group_source_public_ip = true
 

--- a/packer/linux/stack/buildkite-ami.pkr.hcl
+++ b/packer/linux/stack/buildkite-ami.pkr.hcl
@@ -97,7 +97,7 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   instance_type                             = var.instance_type
   region                                    = var.region
   source_ami                                = var.base_ami_id
-  ssh_username                              = local.is_cis ? "ec2-user" : local.ssh_username[var.os_distro]
+  ssh_username                              = var.is_cis ? "ec2-user" : local.ssh_username[var.os_distro]
   ssh_clear_authorized_keys                 = true
   temporary_security_group_source_public_ip = true
 

--- a/packer/linux/stack/buildkite-ami.pkr.hcl
+++ b/packer/linux/stack/buildkite-ami.pkr.hcl
@@ -12,6 +12,12 @@ variable "arch" {
   default = "x86_64"
 }
 
+variable "os_distro" {
+  type        = string
+  description = "Base Linux distribution the base AMI was built on: amazonlinux2023 or ubuntu2404."
+  default     = "amazonlinux2023"
+}
+
 variable "instance_type" {
   type    = string
   default = "m7a.xlarge"
@@ -49,32 +55,37 @@ variable "ami_users" {
   default     = []
 }
 
-data "amazon-ami" "al2023" {
-  filters = {
-    architecture        = var.arch
-    name                = "al2023-ami-minimal-*"
-    virtualization-type = "hvm"
-  }
-  most_recent = true
-  owners      = ["amazon"]
-  region      = var.region
-}
-
 # Optional override for building from a pre-baked “golden base” AMI
 variable "base_ami_id" {
   type    = string
   default = ""
 }
 
+locals {
+  os_distro_name = {
+    amazonlinux2023 = "Amazon Linux 2023"
+    ubuntu2404      = "Ubuntu 24.04"
+  }
+  ssh_username = {
+    amazonlinux2023 = "ec2-user"
+    ubuntu2404      = "ubuntu"
+  }
+  # Must match the base AMI's root device (Ubuntu /dev/sda1, AL2023 /dev/xvda)
+  root_device_name = {
+    amazonlinux2023 = "/dev/xvda"
+    ubuntu2404      = "/dev/sda1"
+  }
+}
+
 source "amazon-ebs" "elastic-ci-stack-ami" {
-  ami_description                           = "Buildkite Elastic Stack (Amazon Linux 2023 w/ docker)"
+  ami_description                           = "Buildkite Elastic Stack (${local.os_distro_name[var.os_distro]} w/ docker)"
   ami_groups                                = var.ami_public ? ["all"] : []
   ami_users                                 = var.ami_public ? [] : var.ami_users
-  ami_name                                  = "buildkite-stack-linux-${var.arch}-${replace(timestamp(), ":", "-")}"
+  ami_name                                  = "buildkite-stack-linux-${var.os_distro}-${var.arch}-${replace(timestamp(), ":", "-")}"
   instance_type                             = var.instance_type
   region                                    = var.region
   source_ami                                = var.base_ami_id
-  ssh_username                              = "ec2-user"
+  ssh_username                              = local.ssh_username[var.os_distro]
   ssh_clear_authorized_keys                 = true
   temporary_security_group_source_public_ip = true
 
@@ -87,7 +98,7 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
 
   launch_block_device_mappings {
     volume_type           = "gp3"
-    device_name           = "/dev/xvda"
+    device_name           = local.root_device_name[var.os_distro]
     volume_size           = 10
     delete_on_termination = true
   }
@@ -97,8 +108,9 @@ source "amazon-ebs" "elastic-ci-stack-ami" {
   }
 
   tags = {
-    Name         = "elastic-ci-stack-linux-${var.arch}"
-    OSVersion    = "Amazon Linux 2023"
+    Name         = "elastic-ci-stack-linux-${var.os_distro}-${var.arch}"
+    OSVersion    = local.os_distro_name[var.os_distro]
+    Distro       = var.os_distro
     BuildNumber  = var.build_number
     AgentVersion = var.agent_version
     IsReleased   = var.is_released
@@ -134,19 +146,28 @@ build {
     source      = "../base/scripts/versions.sh"
   }
 
-  provisioner "shell" {
-    script = "scripts/configure-cloudwatch-agent.sh"
+  provisioner "file" {
+    destination = "/tmp/"
+    source      = "../shared/scripts/distro.sh"
   }
 
   provisioner "shell" {
-    script = "scripts/install-buildkite-agent.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/configure-cloudwatch-agent.sh"
   }
 
   provisioner "shell" {
-    script = "scripts/install-buildkite-utils.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/install-buildkite-agent.sh"
   }
 
   provisioner "shell" {
-    script = "../shared/scripts/cleanup.sh"
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "scripts/install-buildkite-utils.sh"
+  }
+
+  provisioner "shell" {
+    environment_vars = ["OS_DISTRO=${var.os_distro}"]
+    script           = "../shared/scripts/cleanup.sh"
   }
 }

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -454,14 +454,27 @@ fi
 echo Setting ownership of /etc/buildkite-agent/buildkite-agent.cfg to buildkite-agent...
 chown buildkite-agent: /etc/buildkite-agent/buildkite-agent.cfg
 
+# The default login user (and its home) differs by distro: ec2-user on Amazon
+# Linux, ubuntu on Ubuntu. Resolve it at boot rather than hardcoding.
+LOGIN_USER=ec2-user
+if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  if [[ "${ID:-}" == "ubuntu" ]]; then
+    LOGIN_USER=ubuntu
+  fi
+fi
+LOGIN_HOME="$(getent passwd "${LOGIN_USER}" | cut -d: -f6)"
+LOGIN_HOME="${LOGIN_HOME:-/home/${LOGIN_USER}}"
+
 if [[ -n "$BUILDKITE_AUTHORIZED_USERS_URL" ]]; then
   echo Writing authorized user fetching script...
   cat <<-EOF | tee /usr/local/bin/refresh_authorized_keys
 		#!/usr/bin/env bash
 		/usr/local/bin/bk-fetch.sh "$BUILDKITE_AUTHORIZED_USERS_URL" /tmp/authorized_keys
-		mv /tmp/authorized_keys /home/ec2-user/.ssh/authorized_keys
-		chmod 600 /home/ec2-user/.ssh/authorized_keys
-		chown ec2-user: /home/ec2-user/.ssh/authorized_keys
+		mv /tmp/authorized_keys ${LOGIN_HOME}/.ssh/authorized_keys
+		chmod 600 ${LOGIN_HOME}/.ssh/authorized_keys
+		chown ${LOGIN_USER}: ${LOGIN_HOME}/.ssh/authorized_keys
 	EOF
 
   echo Setting ownership of /usr/local/bin/refresh_authorized_keys to root...

--- a/packer/linux/stack/scripts/configure-cloudwatch-agent.sh
+++ b/packer/linux/stack/scripts/configure-cloudwatch-agent.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck disable=SC1091
+source "/tmp/distro.sh"
+
 echo "Configuring cloudwatch agent..."
 
 echo "Adding amazon-cloudwatch-agent config..."
 sudo cp /tmp/conf/cloudwatch-agent/amazon-cloudwatch-agent.json /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# The syslog/auth log locations differ by distro. On AL2023 these substitutions
+# are a no-op (the config already uses the RHEL paths). Each path appears only
+# as a file_path value, so a global replace is safe.
+sudo sed -i \
+  -e "s#/var/log/messages#${CW_SYSLOG_PATH}#g" \
+  -e "s#/var/log/secure#${CW_AUTHLOG_PATH}#g" \
+  /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 
 echo "Configuring amazon-cloudwatch-agent to start at boot"
 sudo systemctl enable amazon-cloudwatch-agent

--- a/packer/linux/stack/scripts/install-buildkite-agent.sh
+++ b/packer/linux/stack/scripts/install-buildkite-agent.sh
@@ -12,7 +12,10 @@ esac
 echo "Creating buildkite-agent user and group..."
 # Set the shell explicitly: useradd defaults to /bin/sh on Ubuntu but /bin/bash
 # on Amazon Linux, and the agent + goss checks expect bash on both.
-sudo useradd --base-dir /var/lib --uid 2000 --shell /bin/bash buildkite-agent
+# --create-home: Ubuntu's useradd does not create the home dir by default
+# (CREATE_HOME=no), unlike Amazon Linux (CREATE_HOME=yes). Without it the home
+# dir ends up root-owned and `git lfs install` cannot write ~/.gitconfig.
+sudo useradd --create-home --base-dir /var/lib --uid 2000 --shell /bin/bash buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
 sudo mkdir -p /var/lib/buildkite-agent/.aws

--- a/packer/linux/stack/scripts/install-buildkite-agent.sh
+++ b/packer/linux/stack/scripts/install-buildkite-agent.sh
@@ -10,7 +10,9 @@ aarch64) ARCH=arm64 ;;
 esac
 
 echo "Creating buildkite-agent user and group..."
-sudo useradd --base-dir /var/lib --uid 2000 buildkite-agent
+# Set the shell explicitly: useradd defaults to /bin/sh on Ubuntu but /bin/bash
+# on Amazon Linux, and the agent + goss checks expect bash on both.
+sudo useradd --base-dir /var/lib --uid 2000 --shell /bin/bash buildkite-agent
 sudo usermod -a -G docker buildkite-agent
 
 sudo mkdir -p /var/lib/buildkite-agent/.aws

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -86,6 +86,7 @@ Metadata:
         - ImageId
         - ImageIdParameter
         - InstanceOperatingSystem
+        - LinuxDistribution
         - InstanceTypes
         - CpuCredits
         - NestedVirtualizationEnabled
@@ -896,6 +897,14 @@ Parameters:
       - windows
     Default: "linux"
 
+  LinuxDistribution:
+    Type: String
+    Description: The Linux distribution to run on the instances. Only applies when InstanceOperatingSystem is linux.
+    AllowedValues:
+      - amazonlinux2023
+      - ubuntu2404
+    Default: "amazonlinux2023"
+
   ECRAccessPolicy:
     Type: String
     Description: >
@@ -1498,6 +1507,11 @@ Conditions:
     UseWindowsAgents:
       !Equals [ !Ref InstanceOperatingSystem, "windows" ]
 
+    UseUbuntu:
+      !And
+        - !Equals [ !Ref InstanceOperatingSystem, "linux" ]
+        - !Equals [ !Ref LinuxDistribution, "ubuntu2404" ]
+
     # Unfortunately, Cloudformation's !Or intrinsic function only accepts
     # between 2 and 10 arguments.  To get around this, we're grouping the
     # instance families in sub-conditionals.  At least this doesn't force us
@@ -1601,7 +1615,7 @@ Mappings:
     arm64: { ARN: 'arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler-arm64' }
 
   # Generated from Makefile via build/mappings.yml
-  AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId }
+  AWSRegion2AMI: { linuxamd64: !Ref ImageId, linuxarm64: !Ref ImageId, windows: !Ref ImageId, ubuntu2404amd64: !Ref ImageId, ubuntu2404arm64: !Ref ImageId }
 
 Resources:
   Vpc:
@@ -2259,15 +2273,27 @@ Resources:
                   - !Ref 'AWS::Region'
                   - 'windows'
                 - !If
-                  - UsingArmInstances
-                  - !FindInMap
-                    - AWSRegion2AMI
-                    - !Ref 'AWS::Region'
-                    - 'linuxarm64'
-                  - !FindInMap
-                    - AWSRegion2AMI
-                    - !Ref 'AWS::Region'
-                    - 'linuxamd64'
+                  - UseUbuntu
+                  - !If
+                    - UsingArmInstances
+                    - !FindInMap
+                      - AWSRegion2AMI
+                      - !Ref 'AWS::Region'
+                      - 'ubuntu2404arm64'
+                    - !FindInMap
+                      - AWSRegion2AMI
+                      - !Ref 'AWS::Region'
+                      - 'ubuntu2404amd64'
+                  - !If
+                    - UsingArmInstances
+                    - !FindInMap
+                      - AWSRegion2AMI
+                      - !Ref 'AWS::Region'
+                      - 'linuxarm64'
+                    - !FindInMap
+                      - AWSRegion2AMI
+                      - !Ref 'AWS::Region'
+                      - 'linuxamd64'
           BlockDeviceMappings:
             - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
               Ebs:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1512,6 +1512,12 @@ Conditions:
         - !Equals [ !Ref InstanceOperatingSystem, "linux" ]
         - !Equals [ !Ref LinuxDistribution, "ubuntu2404" ]
 
+    # Windows and Ubuntu AMIs root on /dev/sda1; Amazon Linux roots on /dev/xvda.
+    # The root block device mapping must name the AMI's actual root device or the
+    # RootVolumeSize override silently applies to a phantom device.
+    RootDeviceIsSda1:
+      !Or [ { Condition: UseWindowsAgents }, { Condition: UseUbuntu } ]
+
     # Unfortunately, Cloudformation's !Or intrinsic function only accepts
     # between 2 and 10 arguments.  To get around this, we're grouping the
     # instance families in sub-conditionals.  At least this doesn't force us
@@ -2295,7 +2301,7 @@ Resources:
                       - !Ref 'AWS::Region'
                       - 'linuxamd64'
           BlockDeviceMappings:
-            - DeviceName: !If [ UseDefaultRootVolumeName, !If [ UseWindowsAgents, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
+            - DeviceName: !If [ UseDefaultRootVolumeName, !If [ RootDeviceIsSda1, /dev/sda1, /dev/xvda ], !Ref RootVolumeName ]
               Ebs:
                 VolumeSize: !Ref RootVolumeSize
                 VolumeType: !Ref RootVolumeType

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -194,7 +194,7 @@ Metadata:
 
 Parameters:
   KeyName:
-    Description: Optional - SSH keypair used to access the Buildkite instances via ec2-user, setting this will enable SSH ingress.
+    Description: Optional - SSH keypair used to access the Buildkite instances via the default login user (ec2-user on Amazon Linux, ubuntu on Ubuntu), setting this will enable SSH ingress.
     Type: String
     Default: ""
 
@@ -622,7 +622,7 @@ Parameters:
     Default: ""
 
   AuthorizedUsersUrl:
-    Description: Optional - HTTPS or S3 URL to periodically download SSH authorized_keys from, setting this will enable SSH ingress. authorized_keys are applied to ec2-user.
+    Description: Optional - HTTPS or S3 URL to periodically download SSH authorized_keys from, setting this will enable SSH ingress. authorized_keys are applied to the default login user (ec2-user on Amazon Linux, ubuntu on Ubuntu).
     Type: String
     Default: ""
 


### PR DESCRIPTION
## Description

Adds Ubuntu 24.04 LTS as a selectable Linux base OS, chosen at deploy time via a new `LinuxDistribution` CloudFormation parameter. It defaults to `amazonlinux2023`, so existing stacks are unaffected; setting it to `ubuntu2404` builds and launches agents on Ubuntu. Both distributions are published for amd64 and arm64.

The implementation keeps a single `packer/linux/` tree parameterized by a new `os_distro` Packer variable. A sourced `distro.sh` helper abstracts the package manager (`pkg_update`/`pkg_install`/`pkg_install_local`/`pkg_clean`) and per-distro facts (login user, CloudWatch log paths, SSM packaging), so the shared install and binary-download logic stays distro-agnostic. The Makefile and CI pipeline gain parallel `ubuntu2404` build targets, and the region mappings plus the template gain `ubuntu2404amd64`/`ubuntu2404arm64` AMI keys.

Distro-specific handling on Ubuntu: `amazon-ssm-agent` installs via snap, `amazon-cloudwatch-agent` and `session-manager-plugin` install from `.deb` packages (with download-integrity hardening), and `aws-cfn-bootstrap` (cfn-signal) installs from Amazon's tarball with its Python dependencies sourced from apt. Amazon Linux 2023 behavior is unchanged. The launch template also now roots Ubuntu (and Windows) AMIs on `/dev/sda1` so the `RootVolumeSize` override applies to the real root volume.

Validated with live AMI builds (goss) and a runtime-validation pipeline that exercises real agent jobs on both distributions across amd64 and arm64.

## Checklist

- [x] Tests pass locally
- [x] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

**Public API change:** this adds a new `LinuxDistribution` stack parameter to select the Linux base OS (`amazonlinux2023` default, or `ubuntu2404`). Existing stacks default to `amazonlinux2023` and are unaffected.

- Add Ubuntu 24.04 LTS as a selectable Linux base OS via the `LinuxDistribution` CloudFormation parameter (`amazonlinux2023` default, `ubuntu2404` opt-in), published for amd64 and arm64.

- [x] My changes affect the public API (variable renames, new stack parameters, etc)
  - [x] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
