### PR TITLE
Feat: SUP-7653 Implement Git Mirror Seed

### DIFF
--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -321,26 +321,74 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
     echo Not mounting git-mirrors to instance storage as instance storage is disabled.
   fi
 
-  if [[ -n "${BUILDKITE_AGENT_GIT_MIRRORS_SEED_BUCKET:-}" ]]; then
-    GIT_MIRRORS_SEED_URI="s3://${BUILDKITE_AGENT_GIT_MIRRORS_SEED_BUCKET}/git-mirrors-seed.tar"
-    echo "Seeding git-mirrors from ${GIT_MIRRORS_SEED_URI}..."
+  if [[ -n "${BUILDKITE_GIT_MIRROR_SEED_BUCKET:-}" ]]; then
+    GIT_MIRROR_SEED_PREFIX="git-mirror-seeds"
+    echo "Seeding git-mirrors from s3://${BUILDKITE_GIT_MIRROR_SEED_BUCKET}/${GIT_MIRROR_SEED_PREFIX}/..."
 
-    # A missing or unreadable seed must not fail the boot, it is only an optimisation. The
-    # agent will fall back to cloning mirrors from scratch as usual.
-    if aws s3 cp "$GIT_MIRRORS_SEED_URI" /tmp/git-mirrors-seed.tar; then
-      if tar -xf /tmp/git-mirrors-seed.tar -C "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
-        echo "Extracted git-mirrors seed to $BUILDKITE_AGENT_GIT_MIRRORS_PATH"
-      else
-        # A partially extracted mirror would break git fetches, so start clean instead
-        echo "WARNING: Failed to extract git-mirrors seed, clearing git-mirrors and continuing..."
-        rm -rf "${BUILDKITE_AGENT_GIT_MIRRORS_PATH:?}"/*
-      fi
-      rm -f /tmp/git-mirrors-seed.tar
+    # Seeding is best-effort, it is only an optimisation. If listing or extraction fails, the
+    # agent falls back to cloning mirrors from scratch as usual, and the boot must not fail.
+    seed_keys=()
+    if seed_listing="$(
+      aws s3api list-objects-v2 \
+        --bucket "$BUILDKITE_GIT_MIRROR_SEED_BUCKET" \
+        --prefix "${GIT_MIRROR_SEED_PREFIX}/" \
+        --output json \
+        | jq -r '.Contents[]?.Key // empty'
+    )"; then
+      while IFS= read -r seed_key; do
+        if [[ "$seed_key" == *.tar || "$seed_key" == *.tar.gz || "$seed_key" == *.zip ]]; then
+          seed_keys+=("$seed_key")
+        fi
+      done <<<"$seed_listing"
     else
-      echo "WARNING: Failed to fetch git-mirrors seed from ${GIT_MIRRORS_SEED_URI}, continuing with empty git-mirrors..."
+      echo "WARNING: Failed to list git mirror seeds in s3://${BUILDKITE_GIT_MIRROR_SEED_BUCKET}/${GIT_MIRROR_SEED_PREFIX}/, continuing with empty git-mirrors..."
     fi
+
+    if [[ ${#seed_keys[@]} -eq 0 ]]; then
+      echo "No git mirror seeds found."
+    fi
+
+    for seed_key in "${seed_keys[@]}"; do
+      seed_archive="${seed_key##*/}"
+      seed_uri="s3://${BUILDKITE_GIT_MIRROR_SEED_BUCKET}/${seed_key}"
+      extracted=false
+
+      echo "Extracting git mirror seed ${seed_archive}..."
+      case "$seed_archive" in
+      *.tar.gz)
+        seed_mirror_dir="${seed_archive%.tar.gz}"
+        if aws s3 cp "$seed_uri" - | tar -xzf - -C "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+          extracted=true
+        fi
+        ;;
+      *.tar)
+        seed_mirror_dir="${seed_archive%.tar}"
+        if aws s3 cp "$seed_uri" - | tar -xf - -C "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+          extracted=true
+        fi
+        ;;
+      *.zip)
+        # zip cannot be streamed: its central directory is at the end of the file
+        seed_mirror_dir="${seed_archive%.zip}"
+        seed_tmp="$(mktemp /tmp/git-mirror-seed-XXXXXX.zip)"
+        if aws s3 cp "$seed_uri" "$seed_tmp" && unzip -oq "$seed_tmp" -d "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+          extracted=true
+        fi
+        rm -f "$seed_tmp"
+        ;;
+      esac
+
+      if [[ "$extracted" == "true" ]]; then
+        echo "Seeded git mirror ${seed_mirror_dir}"
+      else
+        # A partially extracted mirror would break git fetches for that repository, so remove
+        # it while leaving mirrors seeded from other archives intact.
+        echo "WARNING: Failed to extract ${seed_archive}, removing partial mirror ${seed_mirror_dir} and continuing..."
+        rm -rf "${BUILDKITE_AGENT_GIT_MIRRORS_PATH:?}/${seed_mirror_dir}"
+      fi
+    done
   else
-    echo No git-mirrors seed bucket configured.
+    echo No git mirror seed bucket configured.
   fi
 
   echo Setting ownership of git-mirrors directory to buildkite-agent...

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -368,9 +368,11 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
         fi
         ;;
       *.zip)
-        # zip cannot be streamed: its central directory is at the end of the file
+        # Stage zip file in the mirrors path rather than /tmp, because /tmp is a memory-backed
+        # tmpfs by default (MountTmpfsAtTmp), which large archives would exhaust,
+        # while the mirrors path is on a volume sized for mirror data.
         seed_mirror_dir="${seed_archive%.zip}"
-        seed_tmp="$(mktemp /tmp/git-mirror-seed-XXXXXX.zip)"
+        seed_tmp="$(mktemp "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/.git-mirror-seed-XXXXXX.zip")"
         if aws s3 cp "$seed_uri" "$seed_tmp" && unzip -oq "$seed_tmp" -d "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
           extracted=true
         fi

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -373,8 +373,8 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
       # delete other mirrors. Staging lives on the mirrors volume rather than /tmp, because
       # /tmp is a memory-backed tmpfs by default (MountTmpfsAtTmp) which large archives would
       # exhaust, and so the final move is a rename on the same filesystem.
-      if ! seed_staging="$(mktemp -d "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/.git-mirror-seed-XXXXXX")" ||
-        ! mkdir "${seed_staging}/extract"; then
+      if ! seed_staging="$(mktemp -d "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/.git-mirror-seed-XXXXXX")" \
+        || ! mkdir "${seed_staging}/extract"; then
         echo "WARNING: Failed to create staging directory for ${seed_archive}, skipping seed..."
         continue
       fi
@@ -394,8 +394,8 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
         ;;
       *.zip)
         # zip cannot be streamed: its central directory is at the end of the file.
-        if aws s3 cp "$seed_uri" "${seed_staging}/download.zip" &&
-          unzip -oq "${seed_staging}/download.zip" -d "${seed_staging}/extract"; then
+        if aws s3 cp "$seed_uri" "${seed_staging}/download.zip" \
+          && unzip -oq "${seed_staging}/download.zip" -d "${seed_staging}/extract"; then
           extracted=true
         fi
         ;;
@@ -403,9 +403,9 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
 
       if [[ "$extracted" != "true" ]]; then
         echo "WARNING: Failed to extract ${seed_archive}, continuing without it..."
-      elif [[ "$(find "${seed_staging}/extract" -mindepth 1 -maxdepth 1 | wc -l)" -ne 1 ]] ||
-        [[ ! -f "${seed_staging}/extract/${seed_mirror_dir}/HEAD" ]] ||
-        [[ ! -d "${seed_staging}/extract/${seed_mirror_dir}/objects" ]]; then
+      elif [[ "$(find "${seed_staging}/extract" -mindepth 1 -maxdepth 1 | wc -l)" -ne 1 ]] \
+        || [[ ! -f "${seed_staging}/extract/${seed_mirror_dir}/HEAD" ]] \
+        || [[ ! -d "${seed_staging}/extract/${seed_mirror_dir}/objects" ]]; then
         echo "WARNING: ${seed_archive} does not contain a single bare git mirror named ${seed_mirror_dir}, continuing without it..."
       elif ! mv "${seed_staging}/extract/${seed_mirror_dir}" "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/${seed_mirror_dir}"; then
         echo "WARNING: Failed to move mirror ${seed_mirror_dir} into place, continuing without it..."

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -351,43 +351,69 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
     for seed_key in "${seed_keys[@]}"; do
       seed_archive="${seed_key##*/}"
       seed_uri="s3://${BUILDKITE_GIT_MIRROR_SEED_BUCKET}/${seed_key}"
-      extracted=false
 
+      case "$seed_archive" in
+      *.tar.gz) seed_mirror_dir="${seed_archive%.tar.gz}" ;;
+      *.tar) seed_mirror_dir="${seed_archive%.tar}" ;;
+      *.zip) seed_mirror_dir="${seed_archive%.zip}" ;;
+      esac
+
+      if [[ -z "$seed_mirror_dir" || "$seed_mirror_dir" == "." || "$seed_mirror_dir" == ".." ]]; then
+        echo "WARNING: Skipping seed ${seed_key} as its name does not contain a mirror directory name..."
+        continue
+      fi
+
+      if [[ -e "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/${seed_mirror_dir}" ]]; then
+        echo "WARNING: Skipping seed ${seed_archive} as mirror ${seed_mirror_dir} already exists..."
+        continue
+      fi
+
+      # Extract each archive into its own staging directory and validate the contents before
+      # moving the mirror into the live mirrors path, so a bad archive can never overwrite or
+      # delete other mirrors. Staging lives on the mirrors volume rather than /tmp, because
+      # /tmp is a memory-backed tmpfs by default (MountTmpfsAtTmp) which large archives would
+      # exhaust, and so the final move is a rename on the same filesystem.
+      if ! seed_staging="$(mktemp -d "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/.git-mirror-seed-XXXXXX")" ||
+        ! mkdir "${seed_staging}/extract"; then
+        echo "WARNING: Failed to create staging directory for ${seed_archive}, skipping seed..."
+        continue
+      fi
+
+      extracted=false
       echo "Extracting git mirror seed ${seed_archive}..."
       case "$seed_archive" in
       *.tar.gz)
-        seed_mirror_dir="${seed_archive%.tar.gz}"
-        if aws s3 cp "$seed_uri" - | tar -xzf - -C "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+        if aws s3 cp "$seed_uri" - | tar -xzf - -C "${seed_staging}/extract"; then
           extracted=true
         fi
         ;;
       *.tar)
-        seed_mirror_dir="${seed_archive%.tar}"
-        if aws s3 cp "$seed_uri" - | tar -xf - -C "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+        if aws s3 cp "$seed_uri" - | tar -xf - -C "${seed_staging}/extract"; then
           extracted=true
         fi
         ;;
       *.zip)
-        # Stage zip file in the mirrors path rather than /tmp, because /tmp is a memory-backed
-        # tmpfs by default (MountTmpfsAtTmp), which large archives would exhaust,
-        # while the mirrors path is on a volume sized for mirror data.
-        seed_mirror_dir="${seed_archive%.zip}"
-        seed_tmp="$(mktemp "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/.git-mirror-seed-XXXXXX.zip")"
-        if aws s3 cp "$seed_uri" "$seed_tmp" && unzip -oq "$seed_tmp" -d "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+        # zip cannot be streamed: its central directory is at the end of the file.
+        if aws s3 cp "$seed_uri" "${seed_staging}/download.zip" &&
+          unzip -oq "${seed_staging}/download.zip" -d "${seed_staging}/extract"; then
           extracted=true
         fi
-        rm -f "$seed_tmp"
         ;;
       esac
 
-      if [[ "$extracted" == "true" ]]; then
-        echo "Seeded git mirror ${seed_mirror_dir}"
+      if [[ "$extracted" != "true" ]]; then
+        echo "WARNING: Failed to extract ${seed_archive}, continuing without it..."
+      elif [[ "$(find "${seed_staging}/extract" -mindepth 1 -maxdepth 1 | wc -l)" -ne 1 ]] ||
+        [[ ! -f "${seed_staging}/extract/${seed_mirror_dir}/HEAD" ]] ||
+        [[ ! -d "${seed_staging}/extract/${seed_mirror_dir}/objects" ]]; then
+        echo "WARNING: ${seed_archive} does not contain a single bare git mirror named ${seed_mirror_dir}, continuing without it..."
+      elif ! mv "${seed_staging}/extract/${seed_mirror_dir}" "${BUILDKITE_AGENT_GIT_MIRRORS_PATH}/${seed_mirror_dir}"; then
+        echo "WARNING: Failed to move mirror ${seed_mirror_dir} into place, continuing without it..."
       else
-        # A partially extracted mirror would break git fetches for that repository, so remove
-        # it while leaving mirrors seeded from other archives intact.
-        echo "WARNING: Failed to extract ${seed_archive}, removing partial mirror ${seed_mirror_dir} and continuing..."
-        rm -rf "${BUILDKITE_AGENT_GIT_MIRRORS_PATH:?}/${seed_mirror_dir}"
+        echo "Seeded git mirror ${seed_mirror_dir}"
       fi
+
+      rm -rf "$seed_staging" || true
     done
   else
     echo No git mirror seed bucket configured.

--- a/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
+++ b/packer/linux/stack/conf/bin/bk-install-elastic-stack.sh
@@ -321,8 +321,30 @@ if [[ "${BUILDKITE_AGENT_ENABLE_GIT_MIRRORS:-false}" == "true" ]]; then
     echo Not mounting git-mirrors to instance storage as instance storage is disabled.
   fi
 
+  if [[ -n "${BUILDKITE_AGENT_GIT_MIRRORS_SEED_BUCKET:-}" ]]; then
+    GIT_MIRRORS_SEED_URI="s3://${BUILDKITE_AGENT_GIT_MIRRORS_SEED_BUCKET}/git-mirrors-seed.tar"
+    echo "Seeding git-mirrors from ${GIT_MIRRORS_SEED_URI}..."
+
+    # A missing or unreadable seed must not fail the boot, it is only an optimisation. The
+    # agent will fall back to cloning mirrors from scratch as usual.
+    if aws s3 cp "$GIT_MIRRORS_SEED_URI" /tmp/git-mirrors-seed.tar; then
+      if tar -xf /tmp/git-mirrors-seed.tar -C "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"; then
+        echo "Extracted git-mirrors seed to $BUILDKITE_AGENT_GIT_MIRRORS_PATH"
+      else
+        # A partially extracted mirror would break git fetches, so start clean instead
+        echo "WARNING: Failed to extract git-mirrors seed, clearing git-mirrors and continuing..."
+        rm -rf "${BUILDKITE_AGENT_GIT_MIRRORS_PATH:?}"/*
+      fi
+      rm -f /tmp/git-mirrors-seed.tar
+    else
+      echo "WARNING: Failed to fetch git-mirrors seed from ${GIT_MIRRORS_SEED_URI}, continuing with empty git-mirrors..."
+    fi
+  else
+    echo No git-mirrors seed bucket configured.
+  fi
+
   echo Setting ownership of git-mirrors directory to buildkite-agent...
-  chown buildkite-agent: "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"
+  chown -R buildkite-agent: "$BUILDKITE_AGENT_GIT_MIRRORS_PATH"
 else
   echo git-mirrors disabled.
 fi

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -1371,6 +1371,7 @@ Conditions:
 
     HasGitMirrorSeedBucket:
       !And
+         - !Equals [ !Ref InstanceOperatingSystem, "linux" ]
          - !Equals [ !Ref BuildkiteAgentEnableGitMirrors, "true" ]
          - !Not [ !Equals [ !Ref GitMirrorSeedBucket, "" ] ]
 

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -54,7 +54,7 @@ Metadata:
         - BuildkiteAgentTimestampLines
         - BuildkiteAgentExperiments
         - BuildkiteAgentEnableGitMirrors
-        - GitMirrorsSeedBucket
+        - GitMirrorSeedBucket
         - BuildkiteAgentTracingBackend
         - BuildkiteAgentCancelGracePeriod
         - BuildkiteAgentSignalGracePeriod
@@ -1121,14 +1121,15 @@ Parameters:
       - "false"
     Default: "false"
 
-  GitMirrorsSeedBucket:
+  GitMirrorSeedBucket:
     Description: >
-      Optional - Name of an existing S3 bucket containing a git-mirrors seed tarball at key
-      git-mirrors-seed.tar. Only used when BuildkiteAgentEnableGitMirrors is true; the tarball
-      is extracted into the git-mirrors path at instance boot, before the agent starts.
-      If blank, or the tarball cannot be fetched, git mirrors start empty as usual.
-      Instances using a custom InstanceRoleARN must be granted access to this bucket separately.
-      Linux instances only.
+      Optional - Name of an existing S3 bucket containing git mirror seed archives under the
+      git-mirror-seeds/ prefix, one archive (.tar, .tar.gz, or .zip) per repository, named
+      after the agent's mirror directory for that repository. Only used when
+      BuildkiteAgentEnableGitMirrors is true; each archive is extracted into the git-mirrors
+      path at instance boot, before the agent starts. If blank, or archives cannot be fetched,
+      git mirrors start empty as usual. Instances using a custom InstanceRoleARN must be
+      granted access to this bucket separately. Linux instances only.
     Type: String
     Default: ""
 
@@ -1362,10 +1363,10 @@ Conditions:
     HasSecretsBucket:
       !Or [ !Condition CreateSecretsBucket, !Condition UseSpecifiedSecretsBucket ]
 
-    UseGitMirrorsSeedBucket:
+    HasGitMirrorSeedBucket:
       !And
          - !Equals [ !Ref BuildkiteAgentEnableGitMirrors, "true" ]
-         - !Not [ !Equals [ !Ref GitMirrorsSeedBucket, "" ] ]
+         - !Not [ !Equals [ !Ref GitMirrorSeedBucket, "" ] ]
 
     UseSpecifiedAvailabilityZones:
       !Not [ !Equals [ !Join [ "", !Ref AvailabilityZones ], "" ]  ]
@@ -2100,24 +2101,27 @@ Resources:
                 - !Sub "arn:aws:s3:::${ArtifactsBucket}"
             - !Ref "AWS::NoValue"
           - !If
-            - UseGitMirrorsSeedBucket
-            - Sid: GitMirrorsSeedBucketRead
+            - HasGitMirrorSeedBucket
+            - Sid: GitMirrorSeedBucketRead
               Effect: Allow
               Action:
                 - s3:GetObject
-                - s3:ListBucket
               Resource:
-                - !Sub "arn:aws:s3:::${GitMirrorsSeedBucket}/*"
-                - !Sub "arn:aws:s3:::${GitMirrorsSeedBucket}"
+                - !Sub "arn:aws:s3:::${GitMirrorSeedBucket}/git-mirror-seeds/*"
             - !Ref "AWS::NoValue"
           - !If
-            - UseGitMirrorsSeedBucket
-            - Sid: GitMirrorsSeedBucketWrite
+            - HasGitMirrorSeedBucket
+            - Sid: GitMirrorSeedBucketList
               Effect: Allow
               Action:
-                - s3:PutObject
+                - s3:ListBucket
               Resource:
-                - !Sub "arn:aws:s3:::${GitMirrorsSeedBucket}/git-mirrors-seed.tar"
+                - !Sub "arn:aws:s3:::${GitMirrorSeedBucket}"
+              Condition:
+                StringLike:
+                  s3:prefix:
+                    - git-mirror-seeds/
+                    - git-mirror-seeds/*
             - !Ref "AWS::NoValue"
           - Effect: Allow
             Action:
@@ -2522,7 +2526,7 @@ Resources:
                   BUILDKITE_AGENT_JOB_VERIFICATION_NO_SIGNATURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
                   BUILDKITE_QUEUE="${BuildkiteQueue}" \
                   BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
-                  BUILDKITE_AGENT_GIT_MIRRORS_SEED_BUCKET="${LocalGitMirrorsSeedBucket}" \
+                  BUILDKITE_GIT_MIRROR_SEED_BUCKET="${LocalGitMirrorSeedBucket}" \
                   BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
                   BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
@@ -2578,9 +2582,9 @@ Resources:
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                     - !Ref PipelineSigningKMSKeyId
-                  LocalGitMirrorsSeedBucket: !If
-                    - UseGitMirrorsSeedBucket
-                    - !Ref GitMirrorsSeedBucket
+                  LocalGitMirrorSeedBucket: !If
+                    - HasGitMirrorSeedBucket
+                    - !Ref GitMirrorSeedBucket
                     - ""
 
   AgentAutoScaleGroup:

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -54,6 +54,7 @@ Metadata:
         - BuildkiteAgentTimestampLines
         - BuildkiteAgentExperiments
         - BuildkiteAgentEnableGitMirrors
+        - GitMirrorsSeedBucket
         - BuildkiteAgentTracingBackend
         - BuildkiteAgentCancelGracePeriod
         - BuildkiteAgentSignalGracePeriod
@@ -1120,6 +1121,17 @@ Parameters:
       - "false"
     Default: "false"
 
+  GitMirrorsSeedBucket:
+    Description: >
+      Optional - Name of an existing S3 bucket containing a git-mirrors seed tarball at key
+      git-mirrors-seed.tar. Only used when BuildkiteAgentEnableGitMirrors is true; the tarball
+      is extracted into the git-mirrors path at instance boot, before the agent starts.
+      If blank, or the tarball cannot be fetched, git mirrors start empty as usual.
+      Instances using a custom InstanceRoleARN must be granted access to this bucket separately.
+      Linux instances only.
+    Type: String
+    Default: ""
+
   EnableDetailedMonitoring:
     Type: String
     Description: Enable detailed EC2 monitoring.
@@ -1349,6 +1361,11 @@ Conditions:
 
     HasSecretsBucket:
       !Or [ !Condition CreateSecretsBucket, !Condition UseSpecifiedSecretsBucket ]
+
+    UseGitMirrorsSeedBucket:
+      !And
+         - !Equals [ !Ref BuildkiteAgentEnableGitMirrors, "true" ]
+         - !Not [ !Equals [ !Ref GitMirrorsSeedBucket, "" ] ]
 
     UseSpecifiedAvailabilityZones:
       !Not [ !Equals [ !Join [ "", !Ref AvailabilityZones ], "" ]  ]
@@ -2082,6 +2099,26 @@ Resources:
                 - !Sub "arn:aws:s3:::${ArtifactsBucket}/*"
                 - !Sub "arn:aws:s3:::${ArtifactsBucket}"
             - !Ref "AWS::NoValue"
+          - !If
+            - UseGitMirrorsSeedBucket
+            - Sid: GitMirrorsSeedBucketRead
+              Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:ListBucket
+              Resource:
+                - !Sub "arn:aws:s3:::${GitMirrorsSeedBucket}/*"
+                - !Sub "arn:aws:s3:::${GitMirrorsSeedBucket}"
+            - !Ref "AWS::NoValue"
+          - !If
+            - UseGitMirrorsSeedBucket
+            - Sid: GitMirrorsSeedBucketWrite
+              Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource:
+                - !Sub "arn:aws:s3:::${GitMirrorsSeedBucket}/git-mirrors-seed.tar"
+            - !Ref "AWS::NoValue"
           - Effect: Allow
             Action:
               - autoscaling:DescribeAutoScalingInstances
@@ -2485,6 +2522,7 @@ Resources:
                   BUILDKITE_AGENT_JOB_VERIFICATION_NO_SIGNATURE_BEHAVIOR="${PipelineSigningVerificationFailureBehavior}" \
                   BUILDKITE_QUEUE="${BuildkiteQueue}" \
                   BUILDKITE_AGENT_ENABLE_GIT_MIRRORS="${BuildkiteAgentEnableGitMirrors}" \
+                  BUILDKITE_AGENT_GIT_MIRRORS_SEED_BUCKET="${LocalGitMirrorsSeedBucket}" \
                   BUILDKITE_ELASTIC_BOOTSTRAP_SCRIPT="${BootstrapScriptUrl}" \
                   BUILDKITE_ENV_FILE_URL=${AgentEnvFileUrl} \
                   BUILDKITE_ENABLE_INSTANCE_STORAGE="${EnableInstanceStorage}" \
@@ -2540,6 +2578,10 @@ Resources:
                     - CreatePipelineSigningKMSKey
                     - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/${PipelineSigningKMSKey}
                     - !Ref PipelineSigningKMSKeyId
+                  LocalGitMirrorsSeedBucket: !If
+                    - UseGitMirrorsSeedBucket
+                    - !Ref GitMirrorsSeedBucket
+                    - ""
 
   AgentAutoScaleGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/templates/aws-stack.yml
+++ b/templates/aws-stack.yml
@@ -773,7 +773,10 @@ Parameters:
     Default: "false"
 
   InstanceCreationTimeout:
-    Description: Optional - Timeout period for Auto Scaling Group Creation Policy.
+    Description: >
+      Optional - Timeout period for Auto Scaling Group Creation Policy. Defaults to PT5M on
+      Linux (PT15M when GitMirrorSeedBucket is set, to allow for downloading and extracting
+      seed archives at boot) and PT10M on Windows.
     Type: String
     Default: ""
 
@@ -1129,7 +1132,10 @@ Parameters:
       BuildkiteAgentEnableGitMirrors is true; each archive is extracted into the git-mirrors
       path at instance boot, before the agent starts. If blank, or archives cannot be fetched,
       git mirrors start empty as usual. Instances using a custom InstanceRoleARN must be
-      granted access to this bucket separately. Linux instances only.
+      granted access to this bucket separately. When set, the default InstanceCreationTimeout
+      is raised from PT5M to PT15M to allow for seed extraction at boot; set
+      InstanceCreationTimeout explicitly if extracting your archives takes longer.
+      Linux instances only.
     Type: String
     Default: ""
 
@@ -2726,7 +2732,7 @@ Resources:
           Value: !Ref AgentsPerInstance
     CreationPolicy:
       ResourceSignal:
-        Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, PT5M ], !Ref InstanceCreationTimeout ]
+        Timeout: !If [ UseDefaultInstanceCreationTimeout, !If [ UseWindowsAgents, PT10M, !If [ HasGitMirrorSeedBucket, PT15M, PT5M ] ], !Ref InstanceCreationTimeout ]
         Count: !Ref MinSize
     UpdatePolicy:
       AutoScalingReplacingUpdate:


### PR DESCRIPTION
## Description

When `BuildkiteAgentEnableGitMirrors=true` on ephemeral stack instances, the first job on every fresh instance performs a full `git clone --mirror` of each repository it builds. For large monorepos this cold start dominates job startup time. Investigation was done and found that tar archives of pre-built bare mirrors are the right seeding mechanism: they preserve the existing `.pack`/`.idx` files, so extraction is pure I/O (benchmarked at ~2 min for a Linux-kernel-sized repo, with near-instant first checkouts) — unlike git bundles, which require a CPU-bound `git index-pack` on clone that takes longer than cloning from the remote.

This PR lets customers pre-seed the git-mirrors directory from S3 at instance boot, before the agent starts. The agent's first job then fetches only the delta since the archive was created. No agent changes are required: the agent already handles pre-existing mirrors, automatically correcting stale remote URLs (`updateRemoteURL()`) and fetching missing refs (`updateGitMirror()`).

### Usage

Set two stack parameters:

- `BuildkiteAgentEnableGitMirrors=true`
- `GitMirrorSeedBucket=<bucket-name>` (new, default `""`) — an existing S3 bucket containing seed archives

Archives live under a fixed `git-mirror-seeds/` prefix, one per repository, in `.tar`, `.tar.gz`, or `.zip` format. Filenames must match the agent's mirror directory name for the repository (all non-alphanumeric characters replaced with `-`):

```
s3://<bucket>/git-mirror-seeds/
  git-github-com-org-repo-git.tar
  https---github-com-acme-inc-project-git.tar.gz
```

At boot, the bootstrap script lists the prefix and extracts every archive into the git-mirrors path (`.tar`/`.tar.gz` are streamed straight from S3; `.zip` is staged to a temp file since the format can't be streamed).

### Behavior notes for reviewers

- **Condition requires both parameters.** `HasGitMirrorSeedBucket` is only true when git mirrors are enabled *and* a bucket is named. Otherwise no IAM policy is created and no seeding is attempted.
- **IAM is read-only and prefix-scoped**: `s3:GetObject` on `git-mirror-seeds/*` plus `s3:ListBucket` conditioned on the same prefix. Customers who want stack instances to *build* seed archives grant `s3:PutObject` separately. Instances using a custom `InstanceRoleARN` must be granted read access separately.
- **Seeding is best-effort; the agent always starts.** An unreachable or empty bucket logs a warning and boots with empty mirrors (existing cold-start behavior). A corrupt archive fails extraction, removes only that archive's partial mirror directory, and continues with the remaining archives.
- **Stale archives are fine** — the agent fetches the delta and fixes the mirror's remote URL on first use; fresher archives just mean smaller deltas.
- **Linux only.** 

Fixes the cold-start bottleneck described in SUP-7653 (design) / SUP-6596 (research).

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [x] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes