### PR TITLE
Write Docker user namespace mappings atomically

### DIFF
--- a/goss.ubuntu2404.yaml
+++ b/goss.ubuntu2404.yaml
@@ -163,6 +163,9 @@ command:
   systemctl is-enabled docker-binfmt.service:
     exit-status: 0
 
+  systemctl is-active docker-binfmt.service:
+    exit-status: 0
+
   systemctl is-enabled docker-gc.timer:
     exit-status: 0
 

--- a/goss.yaml
+++ b/goss.yaml
@@ -157,6 +157,9 @@ command:
   systemctl is-enabled docker-binfmt.service:
     exit-status: 0
 
+  systemctl is-active docker-binfmt.service:
+    exit-status: 0
+
   systemctl is-enabled docker-gc.timer:
     exit-status: 0
 

--- a/packer/linux/base/conf/docker/systemd/docker-binfmt.service
+++ b/packer/linux/base/conf/docker/systemd/docker-binfmt.service
@@ -7,11 +7,9 @@ After=docker.service
 Type=oneshot
 RemainAfterExit=yes
 Restart=on-failure
-ExecStartPre=-/usr/bin/docker pull \
-    tonistiigi/binfmt:7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
-ExecStart=/usr/bin/docker run --privileged --userns=host \
-    tonistiigi/binfmt:7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55 \
-    --install all
+EnvironmentFile=/etc/docker-binfmt.env
+ExecStartPre=-/usr/bin/docker pull ${DOCKER_BINFMT_IMAGE}
+ExecStart=/usr/bin/docker run --privileged --userns=host ${DOCKER_BINFMT_IMAGE} --install all
 
 [Install]
 WantedBy=multi-user.target

--- a/packer/linux/base/conf/docker/systemd/docker-binfmt.service
+++ b/packer/linux/base/conf/docker/systemd/docker-binfmt.service
@@ -6,6 +6,7 @@ After=docker.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+Restart=on-failure
 ExecStartPre=-/usr/bin/docker pull \
     tonistiigi/binfmt:7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55
 ExecStart=/usr/bin/docker run --privileged --userns=host \

--- a/packer/linux/base/scripts/install-docker.sh
+++ b/packer/linux/base/scripts/install-docker.sh
@@ -32,6 +32,12 @@ sudo cp /tmp/conf/docker/scripts/* /usr/local/bin
 sudo cp /tmp/conf/docker/systemd/docker-* /etc/systemd/system
 sudo chmod 755 /usr/local/bin/docker-*
 
+echo "Writing docker-binfmt environment..."
+sudo tee /etc/docker-binfmt.env >/dev/null <<EOF
+DOCKER_BINFMT_IMAGE=${DOCKER_BINFMT_IMAGE}
+EOF
+sudo chmod 644 /etc/docker-binfmt.env
+
 echo "Installing docker buildx..."
 DOCKER_CLI_DIR=/usr/libexec/docker/cli-plugins
 sudo mkdir -p "${DOCKER_CLI_DIR}"

--- a/packer/linux/base/scripts/versions.sh
+++ b/packer/linux/base/scripts/versions.sh
@@ -22,6 +22,7 @@ export GOSS_VERSION
 # Container Tools
 export DOCKER_COMPOSE_V2_VERSION="5.1.4"
 export DOCKER_BUILDX_VERSION="0.34.1"
+export DOCKER_BINFMT_IMAGE="tonistiigi/binfmt:qemu-v7.0.0-28@sha256:66e11bea77a5ea9d6f0fe79b57cd2b189b5d15b93a2bdb925be22949232e4e55"
 
 # Buildkite Tools
 export S3_SECRETS_HELPER_VERSION="2.8.0"

--- a/packer/linux/stack/conf/bin/bk-configure-docker.sh
+++ b/packer/linux/stack/conf/bin/bk-configure-docker.sh
@@ -27,22 +27,28 @@ exec > >(tee -a /var/log/elastic-stack.log | logger -t user-data -s 2>/dev/conso
 
 echo "Starting ${BASH_SOURCE[0]}..."
 
+# Replace mappings atomically so Docker never reads a truncated file during boot.
+write_userns_mapping_file() {
+  local destination="$1"
+  local first_id="$2"
+  local temporary_file
+
+  temporary_file=$(mktemp "${destination}.XXXXXX")
+  cp --attributes-only --preserve=all "$destination" "$temporary_file"
+  printf 'buildkite-agent:%s:1\nbuildkite-agent:100000:65536\n' "$first_id" >"$temporary_file"
+  mv "$temporary_file" "$destination"
+}
+
 if [[ "${DOCKER_USERNS_REMAP:-false}" == "true" ]]; then
   echo Configuring user namespace remapping...
 
-  cat <<<"$(jq '."userns-remap"="buildkite-agent"' /etc/docker/daemon.json)" >/etc/docker/daemon.json
-
   echo Writing subuid...
-  cat <<EOF | tee /etc/subuid
-buildkite-agent:$(id -u buildkite-agent):1
-buildkite-agent:100000:65536
-EOF
+  write_userns_mapping_file /etc/subuid "$(id -u buildkite-agent)"
 
   echo Writing subgid...
-  cat <<EOF | tee /etc/subgid
-buildkite-agent:$(getent group docker | awk -F: '{print $3}'):1
-buildkite-agent:100000:65536
-EOF
+  write_userns_mapping_file /etc/subgid "$(getent group docker | awk -F: '{print $3}')"
+
+  cat <<<"$(jq '."userns-remap"="buildkite-agent"' /etc/docker/daemon.json)" >/etc/docker/daemon.json
 else
   echo User namespace remapping not configured.
 fi

--- a/packer/linux/stack/conf/bin/bk-configure-docker.sh
+++ b/packer/linux/stack/conf/bin/bk-configure-docker.sh
@@ -121,3 +121,8 @@ systemctl enable docker-gc.timer docker-low-disk-gc.timer
 
 echo Restarting docker daemon...
 systemctl restart docker
+
+# docker-binfmt can dependency-fail if Docker's initial boot start races with this configuration.
+# Starting it here is a no-op when it is already active and retries it after Docker recovers.
+echo Starting docker-binfmt...
+systemctl start docker-binfmt.service

--- a/renovate.json
+++ b/renovate.json
@@ -117,6 +117,18 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "^packer/linux/base/scripts/versions\\.sh$"
+      ],
+      "matchStrings": [
+        "export DOCKER_BINFMT_IMAGE=\"tonistiigi/binfmt:(?<currentValue>qemu-v[^@]+)@(?<currentDigest>sha256:[a-f0-9]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "tonistiigi/binfmt",
+      "versioningTemplate": "regex:^qemu-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
         "^packer/linux/base/scripts/versions\\.sh$",
         "^packer/windows/base/scripts/versions\\.ps1$"
       ],
@@ -204,6 +216,7 @@
         "goss",
         "docker/compose",
         "docker/buildx",
+        "tonistiigi/binfmt",
         "buildkite/lifecycled",
         "buildkite/elastic-ci-stack-s3-secrets-hooks",
         "buildkite/buildkite-agent-scaler"
@@ -215,6 +228,12 @@
         "dependencies",
         "tools"
       ]
+    },
+    {
+      "matchPackageNames": [
+        "tonistiigi/binfmt"
+      ],
+      "commitMessageExtra": "to {{newVersion}}"
     },
     {
       "description": "Global stable releases configuration",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->

Fixes a boot race where Docker could read `/etc/subuid` or `/etc/subgid` while they were being rewritten. Docker would recover, but `docker-binfmt.service` could get stuck failed, leaving cross architecture containers unable to run.

This change:

 - Replaces the user namespace mapping files atomically.
 - Starts docker-binfmt after Docker has been reconfigured.
 - Retries failures from the binfmt oneshot itself.
 - Tracks the pinned binfmt image and digest with Renovate.
 - Verifies that docker-binfmt.service is active in both Linux image tests.


## Checklist

- [ ] Tests pass locally
- [x] Added tests for new features/fixes
- [x] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
