### PR TITLE
Return to released goss binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,6 @@ GO_VERSION ?= 1.26.1
 
 FIXPERMS_FILES = go.mod go.sum $(shell find internal/fixperms)
 
-# goss is pinned to a commit (see versions.sh) until the upstream fix is
-# released. Read the pin from versions.sh.
-GOSS_VERSIONS_FILE = packer/linux/base/scripts/versions.sh
-GOSS_COMMIT = $(shell . $(GOSS_VERSIONS_FILE) && echo $$GOSS_COMMIT)
-GOSS_VERSION = $(shell . $(GOSS_VERSIONS_FILE) && echo $$GOSS_VERSION)
-
 AWS_REGION ?= us-east-1
 
 ARM64_INSTANCE_TYPE ?= m7g.xlarge
@@ -140,7 +134,7 @@ build/linux-amd64-ami.txt: packer-linux-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build linux packer image
-packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 $(if $(strip $(BASE_AMI_ID)),,packer-base-linux-amd64.output)
+packer-linux-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 $(if $(strip $(BASE_AMI_ID)),,packer-base-linux-amd64.output)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
 		-e AWS_PROFILE \
@@ -177,7 +171,7 @@ print-agent-versions:
 	@echo Windows: $(CURRENT_AGENT_VERSION_WINDOWS)
 
 # Build linuxarm64 packer image
-packer-linux-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 $(if $(strip $(BASE_AMI_ID)),,packer-base-linux-arm64.output)
+packer-linux-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 $(if $(strip $(BASE_AMI_ID)),,packer-base-linux-arm64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
@@ -211,7 +205,7 @@ build/ubuntu2404-amd64-ami.txt: packer-ubuntu2404-amd64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build ubuntu2404 amd64 packer image (reuses packer/linux/stack via os_distro)
-packer-ubuntu2404-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 build/goss-linux-amd64 $(if $(strip $(BASE_AMI_ID)),,packer-base-ubuntu2404-amd64.output)
+packer-ubuntu2404-amd64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-amd64 $(if $(strip $(BASE_AMI_ID)),,packer-base-ubuntu2404-amd64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
@@ -242,7 +236,7 @@ build/ubuntu2404-arm64-ami.txt: packer-ubuntu2404-arm64.output env-AWS_REGION
 	grep -Eo "$(AWS_REGION): (ami-.+)" $< | cut -d' ' -f2 | xargs echo -n > $@
 
 # Build ubuntu2404 arm64 packer image (reuses packer/linux/stack via os_distro)
-packer-ubuntu2404-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 build/goss-linux-arm64 $(if $(strip $(BASE_AMI_ID)),,packer-base-ubuntu2404-arm64.output)
+packer-ubuntu2404-arm64.output: $(PACKER_LINUX_STACK_FILES) build/fix-perms-linux-arm64 $(if $(strip $(BASE_AMI_ID)),,packer-base-ubuntu2404-arm64.output)
 	@echo Agent Version: $(CURRENT_AGENT_VERSION_LINUX)
 	docker run \
 		-e AWS_DEFAULT_REGION  \
@@ -472,38 +466,6 @@ build/fix-perms-linux-arm64: $(FIXPERMS_FILES)
 		--rm \
 		golang:$(GO_VERSION) \
 			go build -v -buildvcs=false -o "build/fix-perms-linux-arm64" ./internal/fixperms
-
-# Build goss in the golang container so no Go toolchain ends up in the AMI.
-# Same flags as goss's release-build.sh. Rebuilds when the pin changes.
-build/goss-linux-amd64: $(GOSS_VERSIONS_FILE)
-	mkdir -p build
-	docker run \
-		-e CGO_ENABLED=0 \
-		-e GOOS=linux \
-		-e GOARCH=amd64 \
-		-v "$(PWD)/build:/out" \
-		--rm \
-		golang:$(GO_VERSION) \
-			bash -c 'set -euo pipefail; \
-				git clone --quiet https://github.com/goss-org/goss /goss; \
-				git -C /goss checkout --quiet $(GOSS_COMMIT); \
-				cd /goss; \
-				go build -trimpath -ldflags "-X github.com/goss-org/goss/util.Version=$(GOSS_VERSION) -s -w" -o /out/goss-linux-amd64 ./cmd/goss'
-
-build/goss-linux-arm64: $(GOSS_VERSIONS_FILE)
-	mkdir -p build
-	docker run \
-		-e CGO_ENABLED=0 \
-		-e GOOS=linux \
-		-e GOARCH=arm64 \
-		-v "$(PWD)/build:/out" \
-		--rm \
-		golang:$(GO_VERSION) \
-			bash -c 'set -euo pipefail; \
-				git clone --quiet https://github.com/goss-org/goss /goss; \
-				git -C /goss checkout --quiet $(GOSS_COMMIT); \
-				cd /goss; \
-				go build -trimpath -ldflags "-X github.com/goss-org/goss/util.Version=$(GOSS_VERSION) -s -w" -o /out/goss-linux-arm64 ./cmd/goss'
 
 # -----------------------------------------
 # Cloudformation helpers

--- a/packer/linux/base/scripts/install-utils.sh
+++ b/packer/linux/base/scripts/install-utils.sh
@@ -9,9 +9,18 @@ source "/tmp/versions.sh"
 source "/tmp/distro.sh"
 
 case $(uname -m) in
-x86_64) ARCH=amd64 ;;
-aarch64) ARCH=arm64 ;;
-*) ARCH=unknown ;;
+x86_64)
+  ARCH=amd64
+  GOSS_ARCH=x86_64
+  ;;
+aarch64)
+  ARCH=arm64
+  GOSS_ARCH=arm64
+  ;;
+*)
+  ARCH=unknown
+  GOSS_ARCH=unknown
+  ;;
 esac
 
 echo Updating core packages
@@ -128,8 +137,16 @@ curl -sSL https://github.com/git-lfs/git-lfs/releases/download/v"${GIT_LFS_VERSI
 sudo git-lfs-"${GIT_LFS_VERSION}"/install.sh
 popd
 
-# goss is built from source and installed in the stack image (see
-# install-buildkite-utils.sh), because we pin it to an unreleased commit.
+# See https://github.com/goss-org/goss/releases for release versions
+GOSS_RELEASE_VERSION="${GOSS_VERSION#v}"
+echo "Installing goss $GOSS_VERSION for system validation..."
+curl -Lsf \
+  "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss_${GOSS_RELEASE_VERSION}_linux_${GOSS_ARCH}.tar.gz" \
+  | sudo tar xz -C /usr/local/bin goss
+sudo chmod 755 /usr/local/bin/goss
+sudo curl -Lsf -o /usr/local/bin/dgoss \
+  "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/dgoss"
+sudo chmod 755 /usr/local/bin/dgoss
 
 echo "Adding authorized keys systemd units..."
 sudo cp /tmp/conf/ssh/systemd/* /etc/systemd/system

--- a/packer/linux/base/scripts/versions.sh
+++ b/packer/linux/base/scripts/versions.sh
@@ -8,16 +8,7 @@ export SESSION_MANAGER_PLUGIN_VERSION="1.2.835.0"
 
 # Development Tools
 export GIT_LFS_VERSION="3.7.1"
-
-# goss is built from source (build/goss-* in the Makefile), pinned to a commit
-# because the dependency-bump fix (https://github.com/goss-org/goss/pull/1064)
-# for the Go CVEs is not in any release yet (latest is v0.4.9). Revert to a
-# release download once a version above v0.4.9 ships with the fix.
-# GOSS_VERSION derives its short hash from GOSS_COMMIT, so a Renovate digest
-# bump updates both. Bump the base version (v0.4.9) when goss next tags a release.
-export GOSS_COMMIT="c4634acb0ff00fff08438b2396deb72e6b2b9d83"
-GOSS_VERSION="v0.4.9-dev-$(printf '%.7s' "$GOSS_COMMIT")"
-export GOSS_VERSION
+export GOSS_VERSION="v0.4.10"
 
 # Container Tools
 export DOCKER_COMPOSE_V2_VERSION="5.1.4"

--- a/packer/linux/stack/scripts/install-buildkite-utils.sh
+++ b/packer/linux/stack/scripts/install-buildkite-utils.sh
@@ -19,15 +19,6 @@ echo "Installing fix-buildkite-agent-builds-permissions..."
 sudo chmod 755 "/tmp/build/fix-perms-linux-${ARCH}"
 sudo mv "/tmp/build/fix-perms-linux-${ARCH}" /usr/bin/fix-buildkite-agent-builds-permissions
 
-# goss is built by the build/goss-* Makefile targets and uploaded via the
-# build/ provisioner; dgoss is a shell script fetched from the same commit.
-echo "Installing goss ${GOSS_VERSION} (built from ${GOSS_COMMIT}) for system validation..."
-sudo chmod 755 "/tmp/build/goss-linux-${ARCH}"
-sudo mv "/tmp/build/goss-linux-${ARCH}" /usr/local/bin/goss
-sudo curl -Lsf -o /usr/local/bin/dgoss \
-  "https://raw.githubusercontent.com/goss-org/goss/${GOSS_COMMIT}/extras/dgoss/dgoss"
-sudo chmod 755 /usr/local/bin/dgoss
-
 echo "Downloading s3-secrets-helper ${S3_SECRETS_HELPER_VERSION}..."
 sudo curl -Lsf -o /usr/local/bin/s3secrets-helper \
   "https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/releases/download/v${S3_SECRETS_HELPER_VERSION}/s3secrets-helper-linux-${ARCH}"

--- a/renovate.json
+++ b/renovate.json
@@ -80,13 +80,11 @@
         "^packer/linux/base/scripts/versions\\.sh$"
       ],
       "matchStrings": [
-        "export GOSS_COMMIT=\"(?<currentDigest>[a-f0-9]+)\""
+        "export GOSS_VERSION=\"v(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
-      "currentValueTemplate": "master",
-      "datasourceTemplate": "git-refs",
-      "depNameTemplate": "goss",
-      "packageNameTemplate": "https://github.com/goss-org/goss",
-      "versioningTemplate": "git"
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "goss-org/goss",
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",
@@ -213,7 +211,7 @@
       "matchPackageNames": [
         "git-lfs/git-lfs",
         "git-for-windows/git",
-        "goss",
+        "goss-org/goss",
         "docker/compose",
         "docker/buildx",
         "tonistiigi/binfmt",


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the issue it fixes. -->

Effectively reverts #1821 where we pinned goss to a commit as release was lagging behind main branch that included desired fixes.

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
