### PR TITLE
Use canonical Ubuntu ports mirror for AMI builds

### DIFF
--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -51,14 +51,14 @@ ubuntu2404)
     local sources="/etc/apt/sources.list.d/ubuntu.sources"
     local regional_mirror
 
-    # Prefer the fast EC2 regional mirror, but let apt transparently fall back
-    # to Canonical's mirror pool when the regional mirror is unavailable.
+    # Prefer Canonical's mirror pool, but let apt transparently fall back to the
+    # EC2 regional mirror if it is unavailable.
     regional_mirror="$(sed -n -E \
       's|^URIs:[[:space:]]+(https?://[a-z0-9-]+\.ec2\.ports\.ubuntu\.com/ubuntu-ports/?).*|\1|p' \
       "${sources}")"
     if [ -n "${regional_mirror}" ]; then
       printf '%s\tpriority:1\n%s\tpriority:2\n' \
-        "${regional_mirror}" "http://ports.ubuntu.com/ubuntu-ports/" \
+        "http://ports.ubuntu.com/ubuntu-ports/" "${regional_mirror}" \
         | sudo tee "${mirror_list}" >/dev/null
       sudo sed -i -E \
         "s|https?://[a-z0-9-]+\\.ec2\\.ports\\.ubuntu\\.com/ubuntu-ports/?|mirror+file:${mirror_list}|g" \

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -45,6 +45,11 @@ ubuntu2404)
   }
 
   pkg_update() {
+    # The EC2 regional ports mirrors can remain unavailable for hours. Use the
+    # canonical Ubuntu ports mirror so retries do not keep hitting the outage.
+    sudo sed -i -E \
+      's|https?://[a-z0-9-]+\.ec2\.ports\.ubuntu\.com/ubuntu-ports/?|http://ports.ubuntu.com/ubuntu-ports/|g' \
+      /etc/apt/sources.list.d/ubuntu.sources
     sudo apt-get update -yq
     sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -yq
   }

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -23,6 +23,7 @@ ubuntu2404)
   LOGIN_USER="ubuntu"
   CW_SYSLOG_PATH="/var/log/syslog"
   CW_AUTHLOG_PATH="/var/log/auth.log"
+  APT_HTTP_TIMEOUT=10
 
   # apt can 404 on a package version when ports.ubuntu.com rotates a security
   # update between `apt-get update` and the fetch: the index lists a version the
@@ -31,12 +32,13 @@ ubuntu2404)
   _apt_install() {
     local attempt
     for attempt in 1 2 3; do
-      if sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq "$@"; then
+      if sudo DEBIAN_FRONTEND=noninteractive apt-get \
+        -o Acquire::http::Timeout="${APT_HTTP_TIMEOUT}" install -yq "$@"; then
         return 0
       fi
       if [ "${attempt}" -lt 3 ]; then
         echo "apt-get install failed (attempt ${attempt}/3); refreshing index and retrying..." >&2
-        sudo apt-get update -yq || true
+        sudo apt-get -o Acquire::http::Timeout="${APT_HTTP_TIMEOUT}" update -yq || true
         sleep $((attempt * 5))
       fi
     done
@@ -62,8 +64,9 @@ ubuntu2404)
         "s|https?://[a-z0-9-]+\\.ec2\\.ports\\.ubuntu\\.com/ubuntu-ports/?|mirror+file:${mirror_list}|g" \
         "${sources}"
     fi
-    sudo apt-get update -yq
-    sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -yq
+    sudo apt-get -o Acquire::http::Timeout="${APT_HTTP_TIMEOUT}" update -yq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get \
+      -o Acquire::http::Timeout="${APT_HTTP_TIMEOUT}" dist-upgrade -yq
   }
   pkg_install() { _apt_install "$@"; }
   # apt resolves dependencies for a local .deb path when prefixed with ./

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -45,11 +45,23 @@ ubuntu2404)
   }
 
   pkg_update() {
-    # The EC2 regional ports mirrors can remain unavailable for hours. Use the
-    # canonical Ubuntu ports mirror so retries do not keep hitting the outage.
-    sudo sed -i -E \
-      's|https?://[a-z0-9-]+\.ec2\.ports\.ubuntu\.com/ubuntu-ports/?|http://ports.ubuntu.com/ubuntu-ports/|g' \
-      /etc/apt/sources.list.d/ubuntu.sources
+    local mirror_list="/etc/apt/ubuntu-ports-mirrors.list"
+    local sources="/etc/apt/sources.list.d/ubuntu.sources"
+    local regional_mirror
+
+    # Prefer the fast EC2 regional mirror, but let apt transparently fall back
+    # to Canonical's mirror pool when the regional mirror is unavailable.
+    regional_mirror="$(sed -n -E \
+      's|^URIs:[[:space:]]+(https?://[a-z0-9-]+\.ec2\.ports\.ubuntu\.com/ubuntu-ports/?).*|\1|p' \
+      "${sources}")"
+    if [ -n "${regional_mirror}" ]; then
+      printf '%s\tpriority:1\n%s\tpriority:2\n' \
+        "${regional_mirror}" "http://ports.ubuntu.com/ubuntu-ports/" |
+        sudo tee "${mirror_list}" >/dev/null
+      sudo sed -i -E \
+        "s|https?://[a-z0-9-]+\\.ec2\\.ports\\.ubuntu\\.com/ubuntu-ports/?|mirror+file:${mirror_list}|g" \
+        "${sources}"
+    fi
     sudo apt-get update -yq
     sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -yq
   }

--- a/packer/linux/shared/scripts/distro.sh
+++ b/packer/linux/shared/scripts/distro.sh
@@ -56,8 +56,8 @@ ubuntu2404)
       "${sources}")"
     if [ -n "${regional_mirror}" ]; then
       printf '%s\tpriority:1\n%s\tpriority:2\n' \
-        "${regional_mirror}" "http://ports.ubuntu.com/ubuntu-ports/" |
-        sudo tee "${mirror_list}" >/dev/null
+        "${regional_mirror}" "http://ports.ubuntu.com/ubuntu-ports/" \
+        | sudo tee "${mirror_list}" >/dev/null
       sudo sed -i -E \
         "s|https?://[a-z0-9-]+\\.ec2\\.ports\\.ubuntu\\.com/ubuntu-ports/?|mirror+file:${mirror_list}|g" \
         "${sources}"


### PR DESCRIPTION
## Description

Ubuntu ARM64 AMI builds use the EC2 regional ports mirror. That mirror has been returning 503s, and some requests remain open without completing, so retries alone don't help.

Use Canonical's `ports.ubuntu.com` pool as the primary mirror and keep the regional mirror as a fallback through APT's `mirror+file:` transport. A command-local 10-second HTTP inactivity timeout prevents an unresponsive mirror from blocking the fallback without changing APT configuration in the resulting AMI.

## Checklist

- [x] Tests pass locally
- [ ] Added tests for new features/fixes
- [ ] Updated documentation (if applicable)
- [x] Linting checks pass

## Release Notes

<!--
If your changes affect the public API, please highlight them at the top of the release notes.
-->

- [ ] My changes affect the public API (variable renames, new stack parameters, etc)
  - [ ] I have added a note at the top of the release notes highlighting the API changes
- [ ] Any changes to external libraries (agent, scaler function, etc) have been flagged in release notes
