### PR TITLE
Revert "Bump agent to v3.138.0"

### DIFF
--- a/packer/linux/stack/scripts/install-buildkite-agent.sh
+++ b/packer/linux/stack/scripts/install-buildkite-agent.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AGENT_VERSION="3.138.0"
+AGENT_VERSION="3.137.2"
 
 case $(uname -m) in
 x86_64) ARCH=amd64 ;;
@@ -29,9 +29,9 @@ sudo mkdir -p /var/lib/buildkite-agent/.aws
 sudo cp /tmp/conf/aws/config /var/lib/buildkite-agent/.aws/config
 sudo chown -R buildkite-agent:buildkite-agent /var/lib/buildkite-agent/.aws
 
-echo "Downloading buildkite-agent v${AGENT_VERSION} oldstable..."
-sudo curl -LfsS -o /usr/bin/buildkite-agent-stable \
-  "https://download.buildkite.com/agent/oldstable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"
+echo "Downloading buildkite-agent v${AGENT_VERSION} stable..."
+sudo curl -Lsf -o /usr/bin/buildkite-agent-stable \
+  "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-linux-${ARCH}"
 sudo chmod 755 /usr/bin/buildkite-agent-stable
 buildkite-agent-stable --version
 

--- a/packer/windows/stack/scripts/install-buildkite-agent.ps1
+++ b/packer/windows/stack/scripts/install-buildkite-agent.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference = "Stop"
 
 
-$AGENT_VERSION = "3.138.0"
+$AGENT_VERSION = "3.137.2"
 
 Write-Output "Creating bin dir..."
 if (-not (Test-Path C:\buildkite-agent\bin)) { New-Item -ItemType Directory -Path C:\buildkite-agent\bin -Force }
@@ -11,8 +11,8 @@ Write-Output 'Updating PATH'
 $env:PATH = "C:\buildkite-agent\bin;" + $env:PATH
 [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
 
-Write-Output "Downloading buildkite-agent v${AGENT_VERSION} oldstable..."
-Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-stable.exe -Uri "https://download.buildkite.com/agent/oldstable/${AGENT_VERSION}/buildkite-agent-windows-amd64.exe"
+Write-Output "Downloading buildkite-agent v${AGENT_VERSION} stable..."
+Invoke-WebRequest -OutFile C:\buildkite-agent\bin\buildkite-agent-stable.exe -Uri "https://download.buildkite.com/agent/stable/${AGENT_VERSION}/buildkite-agent-windows-amd64.exe"
 buildkite-agent-stable.exe --version
 If ($lastexitcode -ne 0) { Exit $lastexitcode }
 


### PR DESCRIPTION
Reverts buildkite/elastic-ci-stack-for-aws#1876

We've installed v3.138.0 as `stable`, even though it's `oldstable`, so would be misleading. 
Reverting, so it doesn't confuse folks while upgrading.